### PR TITLE
Add const evaluation of instructions

### DIFF
--- a/cppcheck.rules
+++ b/cppcheck.rules
@@ -74,7 +74,7 @@
     </message>
 </rule>
 <rule>
-    <pattern>(fclose|free|hipFree|hipHostFree|hipFreeArray|hipMemFree|hipStreamDestroy|hipEventDestroy|hipArrayDestroy|hipCtxDestroy|hipDestroyTextureObject|hipDestroySurfaceObject) \(</pattern>
+    <pattern>\\W(fclose|free|hipFree|hipHostFree|hipFreeArray|hipMemFree|hipStreamDestroy|hipEventDestroy|hipArrayDestroy|hipCtxDestroy|hipDestroyTextureObject|hipDestroySurfaceObject) \(</pattern>
     <message>
         <id>useManagePointer</id>
         <severity>style</severity>

--- a/src/include/migraphx/instruction.hpp
+++ b/src/include/migraphx/instruction.hpp
@@ -71,6 +71,8 @@ struct instruction
     static void
     replace(instruction_ref ins, operation o, const shape& r, std::vector<instruction_ref> args);
 
+    argument eval() const;
+
     static instruction_ref get_output_alias(instruction_ref ins);
 
     private:

--- a/src/include/migraphx/operators.hpp
+++ b/src/include/migraphx/operators.hpp
@@ -16,7 +16,7 @@ namespace op {
 
 struct not_computable
 {
-    argument compute(context&, const shape&, const std::vector<argument>&) const
+    argument compute(const shape&, const std::vector<argument>&) const
     {
         MIGRAPHX_THROW("not computable");
     }
@@ -296,7 +296,7 @@ struct transpose
         }
         return {t, output_lens, output_strides};
     }
-    argument compute(context&, shape output_shape, std::vector<argument> args) const
+    argument compute(shape output_shape, std::vector<argument> args) const
     {
         return {std::move(output_shape), std::move(args.front().data)};
     }
@@ -437,7 +437,7 @@ struct slice
         }
         return shape{t, new_lens, old_strides};
     }
-    argument compute(context&, shape output_shape, std::vector<argument> args) const
+    argument compute(shape output_shape, std::vector<argument> args) const
     {
         auto input  = args[0];
         auto offset = compute_offset(input.get_shape()) * output_shape.type_size();
@@ -487,7 +487,7 @@ struct squeeze
         }
         return shape{type, new_lens};
     }
-    argument compute(context&, shape output_shape, std::vector<argument> args) const
+    argument compute(shape output_shape, std::vector<argument> args) const
     {
         return {std::move(output_shape), std::move(args.front().data)};
     }
@@ -526,7 +526,7 @@ struct unsqueeze
         }
         return shape{type, new_lens};
     }
-    argument compute(context&, shape output_shape, std::vector<argument> args) const
+    argument compute(shape output_shape, std::vector<argument> args) const
     {
         return {std::move(output_shape), std::move(args.front().data)};
     }
@@ -578,7 +578,7 @@ struct reshape
             MIGRAPHX_THROW("Wrong number of elements for reshape");
         return s;
     }
-    argument compute(context&, shape output_shape, std::vector<argument> args) const
+    argument compute(shape output_shape, std::vector<argument> args) const
     {
         return {std::move(output_shape), std::move(args.front().data)};
     }
@@ -624,7 +624,7 @@ struct identity
 {
     std::string name() const { return "identity"; }
     shape compute_shape(std::vector<shape> inputs) const { return inputs.at(0); }
-    argument compute(context&, shape output_shape, std::vector<argument> args) const
+    argument compute(shape output_shape, std::vector<argument> args) const
     {
         return {std::move(output_shape), std::move(args.at(0).data)};
     }
@@ -742,7 +742,7 @@ struct flatten
             std::accumulate(lens.begin() + axis, lens.end(), std::size_t{1}, std::multiplies<>{});
         return {inputs.at(0).type(), {x, y}};
     }
-    argument compute(context&, shape output_shape, std::vector<argument> args) const
+    argument compute(shape output_shape, std::vector<argument> args) const
     {
         return {std::move(output_shape), std::move(args.front().data)};
     }
@@ -794,7 +794,7 @@ struct broadcast
             return {t, broadcast_shape.lens(), std::move(bcast_strides)};
         }
     }
-    argument compute(context&, shape output_shape, std::vector<argument> args) const
+    argument compute(shape output_shape, std::vector<argument> args) const
     {
         return {std::move(output_shape), std::move(args.at(0).data)};
     }
@@ -836,7 +836,7 @@ struct multibroadcast
         }
         return {t, output_lens, bcast_strides};
     }
-    argument compute(context&, shape output_shape, std::vector<argument> args) const
+    argument compute(shape output_shape, std::vector<argument> args) const
     {
         return {std::move(output_shape), std::move(args.at(0).data)};
     }
@@ -858,7 +858,7 @@ struct scalar
         return {t, scalar_bcast.lens(), strides};
     }
 
-    argument compute(context&, shape output_shape, std::vector<argument> args) const
+    argument compute(shape output_shape, std::vector<argument> args) const
     {
         return {std::move(output_shape), std::move(args.at(0).data)};
     }
@@ -923,7 +923,7 @@ struct load
         check_shapes{inputs}.has(1);
         return s;
     }
-    argument compute(context&, const shape&, const std::vector<argument>& args) const
+    argument compute(const shape&, const std::vector<argument>& args) const
     {
         return {s, args[0].data() + offset};
     }
@@ -946,7 +946,7 @@ struct outline
         check_shapes{inputs, *this}.has(0);
         return s;
     }
-    argument compute(context&, const shape&, const std::vector<argument>&) const
+    argument compute(const shape&, const std::vector<argument>&) const
     {
         return {s, nullptr};
     }

--- a/src/include/migraphx/operators.hpp
+++ b/src/include/migraphx/operators.hpp
@@ -946,10 +946,7 @@ struct outline
         check_shapes{inputs, *this}.has(0);
         return s;
     }
-    argument compute(const shape&, const std::vector<argument>&) const
-    {
-        return {s, nullptr};
-    }
+    argument compute(const shape&, const std::vector<argument>&) const { return {s, nullptr}; }
 };
 
 } // namespace op

--- a/src/include/migraphx/operators.hpp
+++ b/src/include/migraphx/operators.hpp
@@ -370,6 +370,27 @@ struct concat
         new_lens[axis] = new_dim_axis;
         return {type, new_lens};
     }
+    argument compute(const shape& output_shape, std::vector<argument> args) const
+    {
+        argument result{output_shape};
+        std::vector<std::size_t> coffsets = compute_offsets(output_shape, args);
+        for(std::size_t l = 0; l < args.size(); l++)
+        {
+            auto argl             = args[l];
+            std::size_t nelements = argl.get_shape().elements();
+            visit_all(result, argl)([&](auto output, auto input) {
+                auto slice_shape =
+                    shape{output_shape.type(), input.get_shape().lens(), output_shape.strides()};
+                auto slice = make_view(slice_shape, output.data() + coffsets[l]);
+                // cppcheck-suppress useStlAlgorithm
+                for(std::size_t i = 0; i < nelements; i++)
+                {
+                    slice[i] = input[i];
+                }
+            });
+        }
+        return result;
+    }
     int output_alias(const std::vector<shape>&) const { return 0; }
 };
 

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -182,7 +182,8 @@ argument instruction::eval() const
         for(auto&& arg : this->inputs())
         {
             argument a = arg->eval();
-            if(a.empty()) return {};
+            if(a.empty())
+                return {};
             args.push_back(a);
         }
         return op.compute(result, args);

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -170,6 +170,26 @@ std::vector<shape> compute_shapes(const std::vector<instruction_ref>& args)
     return shapes;
 }
 
+argument instruction::eval() const
+{
+    if(op.name() == "@literal")
+    {
+        return this->get_literal().get_argument();
+    }
+    if(is_context_free(op))
+    {
+        std::vector<argument> args;
+        for(auto&& arg : this->inputs())
+        {
+            argument a = arg->eval();
+            if(a.empty()) return {};
+            args.push_back(a);
+        }
+        return op.compute(result, args);
+    }
+    return {};
+}
+
 instruction_ref instruction::get_output_alias(instruction_ref ins)
 {
     auto i = ins->get_operator().output_alias(compute_shapes(ins->inputs()));

--- a/src/targets/cpu/lowering.cpp
+++ b/src/targets/cpu/lowering.cpp
@@ -299,24 +299,7 @@ struct cpu_concat
     shape compute_shape(const std::vector<shape>& inputs) const { return op.compute_shape(inputs); }
     argument compute(context&, const shape& output_shape, std::vector<argument> args) const
     {
-        argument result{output_shape};
-        std::vector<std::size_t> coffsets = op.compute_offsets(output_shape, args);
-        for(std::size_t l = 0; l < args.size(); l++)
-        {
-            auto argl             = args[l];
-            std::size_t nelements = argl.get_shape().elements();
-            visit_all(result, argl)([&](auto output, auto input) {
-                auto slice_shape =
-                    shape{output_shape.type(), input.get_shape().lens(), output_shape.strides()};
-                auto slice = make_view(slice_shape, output.data() + coffsets[l]);
-                // cppcheck-suppress useStlAlgorithm
-                for(std::size_t i = 0; i < nelements; i++)
-                {
-                    slice[i] = input[i];
-                }
-            });
-        }
-        return result;
+        return op.compute(output_shape, args);
     }
 };
 

--- a/src/targets/cpu/lowering.cpp
+++ b/src/targets/cpu/lowering.cpp
@@ -299,7 +299,7 @@ struct cpu_concat
     shape compute_shape(const std::vector<shape>& inputs) const { return op.compute_shape(inputs); }
     argument compute(context&, const shape& output_shape, std::vector<argument> args) const
     {
-        return op.compute(output_shape, args);
+        return op.compute(output_shape, std::move(args));
     }
 };
 

--- a/test/const_eval_test.cpp
+++ b/test/const_eval_test.cpp
@@ -94,26 +94,32 @@ TEST_CASE(op_test3)
 TEST_CASE(compute_op_c)
 {
     migraphx::operation op = sum_op{};
-    auto one = migraphx::literal{1}.get_argument();
-    auto two = migraphx::literal{2}.get_argument();
-    EXPECT(test::throws([&] { op.compute(migraphx::shape{migraphx::shape::float_type, {1}}, {one, two}); }));
+    auto one               = migraphx::literal{1}.get_argument();
+    auto two               = migraphx::literal{2}.get_argument();
+    EXPECT(test::throws([&] {
+        op.compute(migraphx::shape{migraphx::shape::float_type, {1}}, {one, two});
+    }));
 }
 
 TEST_CASE(compute_nop_c)
 {
     migraphx::operation op = non_computable_cf{};
-    auto one = migraphx::literal{1}.get_argument();
-    auto two = migraphx::literal{2}.get_argument();
-    EXPECT(test::throws([&] { op.compute(migraphx::shape{migraphx::shape::float_type, {1}}, {one, two}); }));
+    auto one               = migraphx::literal{1}.get_argument();
+    auto two               = migraphx::literal{2}.get_argument();
+    EXPECT(test::throws([&] {
+        op.compute(migraphx::shape{migraphx::shape::float_type, {1}}, {one, two});
+    }));
 }
 
 TEST_CASE(compute_nop_context)
 {
     migraphx::operation op = non_computable_cf{};
-    auto one = migraphx::literal{1}.get_argument();
-    auto two = migraphx::literal{2}.get_argument();
-    migraphx::context ctx = test_context{};
-    EXPECT(test::throws([&] { op.compute(ctx, migraphx::shape{migraphx::shape::float_type, {1}}, {one, two}); }));
+    auto one               = migraphx::literal{1}.get_argument();
+    auto two               = migraphx::literal{2}.get_argument();
+    migraphx::context ctx  = test_context{};
+    EXPECT(test::throws([&] {
+        op.compute(ctx, migraphx::shape{migraphx::shape::float_type, {1}}, {one, two});
+    }));
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/const_eval_test.cpp
+++ b/test/const_eval_test.cpp
@@ -1,0 +1,79 @@
+#include <migraphx/program.hpp>
+#include <migraphx/instruction.hpp>
+#include <sstream>
+#include "test.hpp"
+#include <basic_ops.hpp>
+
+struct sum_cf_op
+{
+    std::string name() const { return "sum_cf"; }
+    migraphx::argument
+    compute(const migraphx::shape&, std::vector<migraphx::argument> args) const
+    {
+        migraphx::argument result;
+        if(args.size() != 2)
+            MIGRAPHX_THROW("Wrong args");
+        if(args[0].get_shape() != args[1].get_shape())
+            MIGRAPHX_THROW("Wrong args");
+        if(args[0].get_shape().lens().size() != 1)
+            MIGRAPHX_THROW("Wrong args");
+        if(args[0].get_shape().lens().front() != 1)
+            MIGRAPHX_THROW("Wrong args");
+
+        args[0].visit_at([&](auto x) {
+            args[1].visit_at([&](auto y) { result = migraphx::literal{x + y}.get_argument(); });
+        });
+        return result;
+    }
+
+    migraphx::shape compute_shape(std::vector<migraphx::shape> inputs) const
+    {
+        if(inputs.size() != 2)
+            MIGRAPHX_THROW("Wrong inputs");
+        return inputs.front();
+    }
+};
+
+TEST_CASE(literal_test)
+{
+    migraphx::program p;
+    auto lit = p.add_literal(1);
+    CHECK(lit->eval() == migraphx::literal{1});
+}
+
+TEST_CASE(param_test)
+{
+    migraphx::program p;
+    auto lit = p.add_parameter("param", migraphx::shape{migraphx::shape::float_type, {1}});
+    CHECK(lit->eval().empty());
+}
+
+TEST_CASE(op_test1)
+{
+    migraphx::program p;
+    auto one = p.add_literal(1);
+    auto two = p.add_literal(2);
+    auto sum = p.add_instruction(sum_cf_op{}, one, two);
+    CHECK(sum->eval() == migraphx::literal{3});
+}
+
+TEST_CASE(op_test2)
+{
+    migraphx::program p;
+    auto x = p.add_parameter("param", migraphx::shape{migraphx::shape::float_type, {1}});;
+    auto two = p.add_literal(2);
+    auto sum = p.add_instruction(sum_cf_op{}, x, two);
+    CHECK(sum->eval().empty());
+}
+
+TEST_CASE(op_test3)
+{
+    migraphx::program p;
+    auto one = p.add_literal(1);
+    auto two = p.add_literal(2);
+    auto sum1 = p.add_instruction(sum_op{}, one, two);
+    auto sum2 = p.add_instruction(sum_cf_op{}, sum1, two);
+    CHECK(sum2->eval().empty());
+}
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/const_eval_test.cpp
+++ b/test/const_eval_test.cpp
@@ -60,7 +60,6 @@ TEST_CASE(op_test2)
 {
     migraphx::program p;
     auto x = p.add_parameter("param", migraphx::shape{migraphx::shape::float_type, {1}});
-    ;
     auto two = p.add_literal(2);
     auto sum = p.add_instruction(sum_cf_op{}, x, two);
     CHECK(sum->eval().empty());

--- a/test/const_eval_test.cpp
+++ b/test/const_eval_test.cpp
@@ -7,8 +7,7 @@
 struct sum_cf_op
 {
     std::string name() const { return "sum_cf"; }
-    migraphx::argument
-    compute(const migraphx::shape&, std::vector<migraphx::argument> args) const
+    migraphx::argument compute(const migraphx::shape&, std::vector<migraphx::argument> args) const
     {
         migraphx::argument result;
         if(args.size() != 2)
@@ -60,7 +59,8 @@ TEST_CASE(op_test1)
 TEST_CASE(op_test2)
 {
     migraphx::program p;
-    auto x = p.add_parameter("param", migraphx::shape{migraphx::shape::float_type, {1}});;
+    auto x = p.add_parameter("param", migraphx::shape{migraphx::shape::float_type, {1}});
+    ;
     auto two = p.add_literal(2);
     auto sum = p.add_instruction(sum_cf_op{}, x, two);
     CHECK(sum->eval().empty());
@@ -69,8 +69,8 @@ TEST_CASE(op_test2)
 TEST_CASE(op_test3)
 {
     migraphx::program p;
-    auto one = p.add_literal(1);
-    auto two = p.add_literal(2);
+    auto one  = p.add_literal(1);
+    auto two  = p.add_literal(2);
     auto sum1 = p.add_instruction(sum_op{}, one, two);
     auto sum2 = p.add_instruction(sum_cf_op{}, sum1, two);
     CHECK(sum2->eval().empty());

--- a/test/const_eval_test.cpp
+++ b/test/const_eval_test.cpp
@@ -59,7 +59,7 @@ TEST_CASE(op_test1)
 TEST_CASE(op_test2)
 {
     migraphx::program p;
-    auto x = p.add_parameter("param", migraphx::shape{migraphx::shape::float_type, {1}});
+    auto x   = p.add_parameter("param", migraphx::shape{migraphx::shape::float_type, {1}});
     auto two = p.add_literal(2);
     auto sum = p.add_instruction(sum_cf_op{}, x, two);
     CHECK(sum->eval().empty());

--- a/tools/include/operation.hpp
+++ b/tools/include/operation.hpp
@@ -103,11 +103,8 @@ auto compute_op(rank<2>,
 }
 
 template <class T>
-auto compute_op(rank<1>,
-                const T& x,
-                context&,
-                const shape& output_shape,
-                const std::vector<argument>& input)
+auto compute_op(
+    rank<1>, const T& x, context&, const shape& output_shape, const std::vector<argument>& input)
     -> decltype(x.compute(output_shape, input))
 {
     return x.compute(output_shape, input);
@@ -128,20 +125,14 @@ compute_op(const T& x, context& ctx, const shape& output_shape, const std::vecto
 }
 
 template <class T>
-auto compute_op(rank<2>,
-                const T& x,
-                const shape& output_shape,
-                const std::vector<argument>& input)
+auto compute_op(rank<2>, const T& x, const shape& output_shape, const std::vector<argument>& input)
     -> decltype(x.compute(output_shape, input))
 {
     return x.compute(output_shape, input);
 }
 
 template <class T>
-auto compute_op(rank<1>,
-                const T& x,
-                const shape& output_shape,
-                const std::vector<argument>& input)
+auto compute_op(rank<1>, const T& x, const shape& output_shape, const std::vector<argument>& input)
     -> decltype(x.compute(auto_any_cast(std::declval<context&>()), output_shape, input))
 {
     std::string name = x.name();
@@ -156,20 +147,25 @@ argument compute_op(rank<0>, const T& x, const shape&, const std::vector<argumen
 }
 
 template <class T>
-argument
-compute_op(const T& x, const shape& output_shape, const std::vector<argument>& input)
+argument compute_op(const T& x, const shape& output_shape, const std::vector<argument>& input)
 {
     return compute_op(rank<2>{}, x, output_shape, input);
 }
 
 template <class T>
-auto is_context_free_op(rank<1>, const T& x, const shape& output_shape, const std::vector<argument>& input) -> decltype(x.compute(output_shape, input), std::true_type{});
+auto is_context_free_op(rank<1>,
+                        const T& x,
+                        const shape& output_shape,
+                        const std::vector<argument>& input)
+    -> decltype(x.compute(output_shape, input), std::true_type{});
 
 template <class T>
-auto is_context_free_op(rank<0>, const T&, const shape&, const std::vector<argument>&) -> std::false_type;
+auto is_context_free_op(rank<0>, const T&, const shape&, const std::vector<argument>&)
+    -> std::false_type;
 
 template <class T>
-auto is_context_free_op(const T& x) -> decltype(is_context_free_op(rank<1>{}, x, std::declval<const shape&>(), std::declval<std::vector<argument>>()))
+auto is_context_free_op(const T& x) -> decltype(is_context_free_op(
+    rank<1>{}, x, std::declval<const shape&>(), std::declval<std::vector<argument>>()))
 {
     return {};
 }
@@ -233,12 +229,9 @@ int output_alias_op(const T& x, const std::vector<shape>& shapes)
     return !(x == y);
 }
 
-inline bool is_context_free(const operation& op)
-{
-    return op.is_context_free();
-}
+inline bool is_context_free(const operation& op) { return op.is_context_free(); }
 
-template<class T>
+template <class T>
 bool is_context_free(const T& x)
 {
     return is_context_free_op(x);

--- a/tools/include/operation.hpp
+++ b/tools/include/operation.hpp
@@ -53,6 +53,9 @@ struct operation
     friend std::ostream& operator<<(std::ostream& os, const operation& op);
 };
 
+/// Returns true if operation does not require a context to run compute
+bool is_context_free(const operation& x);
+
 #else
 
 namespace operation_stream {
@@ -89,7 +92,7 @@ auto operator==(const T& x, const U& y) -> decltype(x.name() == y.name())
 } // namespace operation_equal
 
 template <class T>
-auto compute_op(rank<1>,
+auto compute_op(rank<2>,
                 const T& x,
                 context& ctx,
                 const shape& output_shape,
@@ -97,6 +100,17 @@ auto compute_op(rank<1>,
     -> decltype(x.compute(auto_any_cast(ctx), output_shape, input))
 {
     return x.compute(auto_any_cast(ctx), output_shape, input);
+}
+
+template <class T>
+auto compute_op(rank<1>,
+                const T& x,
+                context&,
+                const shape& output_shape,
+                const std::vector<argument>& input)
+    -> decltype(x.compute(output_shape, input))
+{
+    return x.compute(output_shape, input);
 }
 
 template <class T>
@@ -110,7 +124,54 @@ template <class T>
 argument
 compute_op(const T& x, context& ctx, const shape& output_shape, const std::vector<argument>& input)
 {
-    return compute_op(rank<1>{}, x, ctx, output_shape, input);
+    return compute_op(rank<2>{}, x, ctx, output_shape, input);
+}
+
+template <class T>
+auto compute_op(rank<2>,
+                const T& x,
+                const shape& output_shape,
+                const std::vector<argument>& input)
+    -> decltype(x.compute(output_shape, input))
+{
+    return x.compute(output_shape, input);
+}
+
+template <class T>
+auto compute_op(rank<1>,
+                const T& x,
+                const shape& output_shape,
+                const std::vector<argument>& input)
+    -> decltype(x.compute(auto_any_cast(std::declval<context&>()), output_shape, input))
+{
+    std::string name = x.name();
+    MIGRAPHX_THROW("Not computable without a context: " + name);
+}
+
+template <class T>
+argument compute_op(rank<0>, const T& x, const shape&, const std::vector<argument>&)
+{
+    std::string name = x.name();
+    MIGRAPHX_THROW("Not computable: " + name);
+}
+
+template <class T>
+argument
+compute_op(const T& x, const shape& output_shape, const std::vector<argument>& input)
+{
+    return compute_op(rank<2>{}, x, output_shape, input);
+}
+
+template <class T>
+auto is_context_free_op(rank<1>, const T& x, const shape& output_shape, const std::vector<argument>& input) -> decltype(x.compute(output_shape, input), std::true_type{});
+
+template <class T>
+auto is_context_free_op(rank<0>, const T&, const shape&, const std::vector<argument>&) -> std::false_type;
+
+template <class T>
+auto is_context_free_op(const T& x) -> decltype(is_context_free_op(rank<1>{}, x, std::declval<const shape&>(), std::declval<std::vector<argument>>()))
+{
+    return {};
 }
 
 template <class T>
@@ -136,6 +197,7 @@ int output_alias_op(const T& x, const std::vector<shape>& shapes)
  interface(
      'operation',
      virtual('name', returns = 'std::string', const = True),
+     virtual('is_context_free', returns = 'bool', const = True, default = 'is_context_free_op'),
      virtual('output_alias',
              returns = 'int',
              input   = 'const std::vector<shape>&',
@@ -145,6 +207,12 @@ int output_alias_op(const T& x, const std::vector<shape>& shapes)
      virtual('compute',
              returns = 'argument',
              ctx     = 'context&',
+             output  = 'const shape&',
+             input   = 'const std::vector<argument>&',
+             const   = True,
+             default = 'compute_op'),
+     virtual('compute',
+             returns = 'argument',
              output  = 'const shape&',
              input   = 'const std::vector<argument>&',
              const   = True,
@@ -163,6 +231,17 @@ int output_alias_op(const T& x, const std::vector<shape>& shapes)
     inline bool operator!=(const operation& x, const operation& y)
 {
     return !(x == y);
+}
+
+inline bool is_context_free(const operation& op)
+{
+    return op.is_context_free();
+}
+
+template<class T>
+bool is_context_free(const T& x)
+{
+    return is_context_free_op(x);
 }
 
 #endif


### PR DESCRIPTION
Added an `eval` method to the `instruction` class that will try to evaluate the value if its inputs are literals. Operators support adding a `compute` method without a `context` so it can be evaluated as such.