### PR TITLE
Fix slowness in eval

### DIFF
--- a/src/include/migraphx/instruction.hpp
+++ b/src/include/migraphx/instruction.hpp
@@ -74,7 +74,7 @@ struct instruction
 
     bool can_eval() const;
 
-    argument eval(bool check_eval=true) const;
+    argument eval(bool check_eval = true) const;
 
     void finalize(context& ctx);
 

--- a/src/include/migraphx/instruction.hpp
+++ b/src/include/migraphx/instruction.hpp
@@ -72,6 +72,8 @@ struct instruction
     static void
     replace(instruction_ref ins, operation o, const shape& r, std::vector<instruction_ref> args);
 
+    bool can_eval() const;
+
     argument eval() const;
 
     void finalize(context& ctx);

--- a/src/include/migraphx/instruction.hpp
+++ b/src/include/migraphx/instruction.hpp
@@ -74,7 +74,7 @@ struct instruction
 
     bool can_eval() const;
 
-    argument eval() const;
+    argument eval(bool check_eval=true) const;
 
     void finalize(context& ctx);
 

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -187,7 +187,7 @@ argument instruction::eval(bool check_eval) const
     }
     if(is_context_free(op))
     {
-        if (check_eval and not this->can_eval())
+        if(check_eval and not this->can_eval())
             return {};
         std::vector<argument> args;
         std::transform(this->inputs().begin(),

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -168,11 +168,10 @@ bool instruction::can_eval() const
     {
         return true;
     }
-    else if (is_context_free(op))
+    else if(is_context_free(op))
     {
-        return std::all_of(this->inputs().begin(), this->inputs().end(), [](auto arg) {
-            return arg->can_eval();
-        });
+        return std::all_of(
+            this->inputs().begin(), this->inputs().end(), [](auto arg) { return arg->can_eval(); });
     }
     else
     {
@@ -189,9 +188,10 @@ argument instruction::eval() const
     if(is_context_free(op) and this->can_eval())
     {
         std::vector<argument> args;
-        std::transform(this->inputs().begin(), this->inputs().end(), std::back_inserter(args), [](auto arg) {
-            return arg->eval();
-        });
+        std::transform(this->inputs().begin(),
+                       this->inputs().end(),
+                       std::back_inserter(args),
+                       [](auto arg) { return arg->eval(); });
         return op.compute(result, args);
     }
     return {};

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -179,19 +179,21 @@ bool instruction::can_eval() const
     }
 }
 
-argument instruction::eval() const
+argument instruction::eval(bool check_eval) const
 {
     if(op.name() == "@literal")
     {
         return this->get_literal().get_argument();
     }
-    if(is_context_free(op) and this->can_eval())
+    if(is_context_free(op))
     {
+        if (check_eval and not this->can_eval())
+            return {};
         std::vector<argument> args;
         std::transform(this->inputs().begin(),
                        this->inputs().end(),
                        std::back_inserter(args),
-                       [](auto arg) { return arg->eval(); });
+                       [](auto arg) { return arg->eval(false); });
         return op.compute(result, args);
     }
     return {};

--- a/src/propagate_constant.cpp
+++ b/src/propagate_constant.cpp
@@ -33,7 +33,7 @@ void propagate_constant::apply(program& p) const
                                                          ins->outputs().end());
             for(auto child : children)
             {
-                if (skip_propogate(child))
+                if(skip_propogate(child))
                 {
                     self(child);
                     continue;

--- a/src/propagate_constant.cpp
+++ b/src/propagate_constant.cpp
@@ -22,22 +22,33 @@ bool skip_propogate(instruction_ref ins)
 
 void propagate_constant::apply(program& p) const
 {
-    fix([&](auto self, auto ins) {
-        if(not skip_propogate(ins))
-        {
-            auto r = ins->eval();
-            if(not r.empty())
+    for(auto i:iterator_for(p))
+    {
+        if (i->name() != "@literal")
+            continue;
+        if (i->outputs().empty())
+            continue;
+        fix([&](auto self, auto ins) {
+            std::unordered_set<instruction_ref> children(ins->outputs().begin(), ins->outputs().end());
+            for(auto child : children)
             {
-                assert(r.get_shape() == ins->get_shape());
-                auto l = p.add_literal(r.get_shape(), r.data());
-                p.replace_instruction(ins, l);
-                return;
+                if(not skip_propogate(child))
+                {
+                    auto r = child->eval();
+                    if(not r.empty())
+                    {
+                        assert(r.get_shape() == child->get_shape());
+                        auto l = p.add_literal(r.get_shape(), r.data());
+                        self(p.replace_instruction(child, l));
+                    }
+                } 
+                else
+                {
+                    self(child);
+                }
             }
-        }
-        std::unordered_set<instruction_ref> children(ins->inputs().begin(), ins->inputs().end());
-        for(auto child : children)
-            self(child);
-    })(std::prev(p.end()));
+        })(i);
+    }
 }
 
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/propagate_constant.cpp
+++ b/src/propagate_constant.cpp
@@ -33,19 +33,17 @@ void propagate_constant::apply(program& p) const
                                                          ins->outputs().end());
             for(auto child : children)
             {
-                if(not skip_propogate(child))
-                {
-                    auto r = child->eval();
-                    if(not r.empty())
-                    {
-                        assert(r.get_shape() == child->get_shape());
-                        auto l = p.add_literal(r.get_shape(), r.data());
-                        self(p.replace_instruction(child, l));
-                    }
-                }
-                else
+                if (skip_propogate(child))
                 {
                     self(child);
+                    continue;
+                }
+                auto r = child->eval();
+                if(not r.empty())
+                {
+                    assert(r.get_shape() == child->get_shape());
+                    auto l = p.add_literal(r.get_shape(), r.data());
+                    self(p.replace_instruction(child, l));
                 }
             }
         })(i);

--- a/src/propagate_constant.cpp
+++ b/src/propagate_constant.cpp
@@ -22,14 +22,15 @@ bool skip_propogate(instruction_ref ins)
 
 void propagate_constant::apply(program& p) const
 {
-    for(auto i:iterator_for(p))
+    for(auto i : iterator_for(p))
     {
-        if (i->name() != "@literal")
+        if(i->name() != "@literal")
             continue;
-        if (i->outputs().empty())
+        if(i->outputs().empty())
             continue;
         fix([&](auto self, auto ins) {
-            std::unordered_set<instruction_ref> children(ins->outputs().begin(), ins->outputs().end());
+            std::unordered_set<instruction_ref> children(ins->outputs().begin(),
+                                                         ins->outputs().end());
             for(auto child : children)
             {
                 if(not skip_propogate(child))
@@ -41,7 +42,7 @@ void propagate_constant::apply(program& p) const
                         auto l = p.add_literal(r.get_shape(), r.data());
                         self(p.replace_instruction(child, l));
                     }
-                } 
+                }
                 else
                 {
                     self(child);


### PR DESCRIPTION
This only runs eval if it knows all arguments can run eval. This avoids partially calculating some arguments even when the calculation is not needed. This should help address #254.