### PR TITLE
Fix HIP-Clang GPU build issues

### DIFF
--- a/src/targets/gpu/device/acos.cpp
+++ b/src/targets/gpu/device/acos.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void acos(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::acos(to_hip_type(x)); });
+    nary(stream, result, arg)([] __device__ (auto x) { return ::acos(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/add.cpp
+++ b/src/targets/gpu/device/add.cpp
@@ -8,7 +8,7 @@ namespace device {
 
 void add(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
-    nary(stream, result, arg1, arg2)([](auto x, auto y) { return x + y; });
+    nary(stream, result, arg1, arg2)([] __device__ (auto x, auto y) { return x + y; });
 }
 
 void add(hipStream_t stream,
@@ -17,7 +17,7 @@ void add(hipStream_t stream,
          const argument& arg2,
          const argument& arg3)
 {
-    nary(stream, result, arg1, arg2, arg3)([](auto x, auto y, auto z) { return x + y + z; });
+    nary(stream, result, arg1, arg2, arg3)([] __device__ (auto x, auto y, auto z) { return x + y + z; });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/add_relu.cpp
+++ b/src/targets/gpu/device/add_relu.cpp
@@ -13,7 +13,7 @@ void mul_add_relu(hipStream_t stream,
                   const argument& arg3)
 {
     nary(stream, result, arg1, arg2, arg3)(
-        [](auto x, auto a, auto b) { return std::max<decltype(a * x + b)>(0, a * x + b); });
+        [] __device__ (auto x, auto a, auto b) { return std::max<decltype(a * x + b)>(0, a * x + b); });
 }
 
 void add_relu(hipStream_t stream,
@@ -22,7 +22,7 @@ void add_relu(hipStream_t stream,
               const argument& arg2)
 {
     nary(stream, result, arg1, arg2)(
-        [](auto x, auto y) { return std::max<decltype(x + y)>(0, x + y); });
+        [] __device__ (auto x, auto y) { return std::max<decltype(x + y)>(0, x + y); });
 }
 
 void add_relu(hipStream_t stream,
@@ -32,7 +32,7 @@ void add_relu(hipStream_t stream,
               const argument& arg3)
 {
     nary(stream, result, arg1, arg2, arg3)(
-        [](auto x, auto y, auto z) { return std::max<decltype(x + y + z)>(0, x + y + z); });
+        [] __device__ (auto x, auto y, auto z) { return std::max<decltype(x + y + z)>(0, x + y + z); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/asin.cpp
+++ b/src/targets/gpu/device/asin.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void asin(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::asin(to_hip_type(x)); });
+    nary(stream, result, arg)([] __device__ (auto x) { return ::asin(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/atan.cpp
+++ b/src/targets/gpu/device/atan.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void atan(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::atan(to_hip_type(x)); });
+    nary(stream, result, arg)([] __device__ (auto x) { return ::atan(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/clip.cpp
+++ b/src/targets/gpu/device/clip.cpp
@@ -13,7 +13,7 @@ void clip(hipStream_t stream,
           const float min)
 {
     nary(stream, result, arg1)(
-        [max, min](auto x) { return std::min<decltype(x)>(std::max<decltype(x)>(min, x), max); });
+        [max, min] __device__ (auto x) { return std::min<decltype(x)>(std::max<decltype(x)>(min, x), max); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/concat.cpp
+++ b/src/targets/gpu/device/concat.cpp
@@ -22,7 +22,7 @@ argument concat(hipStream_t stream,
         auto offset           = offsets[j];
         shape arg_shape{arg.get_shape().type(), arg.get_shape().lens()};
         hip_visit_all(args.back(), arg, arg_shape)([&](auto output, auto input, auto input_shape) {
-            gs_launch(stream, nelements)([=](auto i) {
+            gs_launch(stream, nelements)([=] __device__ (auto i) {
                 auto input_idx              = input_shape.multi(i);
                 auto idx                    = output.get_shape().index(input_idx);
                 output.data()[idx + offset] = input[input_idx];

--- a/src/targets/gpu/device/contiguous.cpp
+++ b/src/targets/gpu/device/contiguous.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void contiguous(hipStream_t stream, argument result, argument arg)
 {
-    nary_nonstandard(stream, std::move(result), std::move(arg))([](auto x) { return x; });
+    nary_nonstandard(stream, std::move(result), std::move(arg))([] __device__ (auto x) { return x; });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/convert.cpp
+++ b/src/targets/gpu/device/convert.cpp
@@ -13,7 +13,7 @@ void convert(hipStream_t stream, const argument& result, const argument& arg)
             const auto* input_ptr = device_cast(input.data());
             auto* output_ptr      = device_cast(output.data());
             gs_launch(stream,
-                      result.get_shape().elements())([=](auto i) { output_ptr[i] = input_ptr[i]; });
+                      result.get_shape().elements())([=] __device__ (auto i) { output_ptr[i] = input_ptr[i]; });
         });
     });
 }

--- a/src/targets/gpu/device/cos.cpp
+++ b/src/targets/gpu/device/cos.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void cos(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::cos(to_hip_type(x)); });
+    nary(stream, result, arg)([] __device__ (auto x) { return ::cos(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/cosh.cpp
+++ b/src/targets/gpu/device/cosh.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void cosh(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::cosh(to_hip_type(x)); });
+    nary(stream, result, arg)([] __device__ (auto x) { return ::cosh(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/div.cpp
+++ b/src/targets/gpu/device/div.cpp
@@ -8,7 +8,7 @@ namespace device {
 
 void div(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
-    nary(stream, result, arg1, arg2)([](auto x, auto y) { return x / y; });
+    nary(stream, result, arg1, arg2)([] __device__ (auto x, auto y) { return x / y; });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/erf.cpp
+++ b/src/targets/gpu/device/erf.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void erf(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::erf(to_hip_type(x)); });
+    nary(stream, result, arg)([] __device__ (auto x) { return ::erf(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/exp.cpp
+++ b/src/targets/gpu/device/exp.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void exp(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::exp(to_hip_type(x)); });
+    nary(stream, result, arg)([] __device__ (auto x) { return ::exp(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/gather.cpp
+++ b/src/targets/gpu/device/gather.cpp
@@ -25,7 +25,7 @@ argument gather(hipStream_t stream, argument result, argument arg1, argument arg
             arg2.visit([&](auto indices) {
                 const auto* indices_ptr = device_cast(indices.data());
                 auto* output_ptr        = device_cast(output.data());
-                gs_launch(stream, nelements, 256)([=](auto i) {
+                gs_launch(stream, nelements, 256)([=] __device__ (auto i) {
                     auto idx        = out_comp.multi(i);
                     idx[axis_index] = indices_ptr[idx[axis_index]];
                     output_ptr[i]   = input[idx];

--- a/src/targets/gpu/device/include/migraphx/gpu/device/launch.hpp
+++ b/src/targets/gpu/device/include/migraphx/gpu/device/launch.hpp
@@ -78,7 +78,7 @@ inline auto gs_launch(hipStream_t stream, std::size_t n, std::size_t local = 102
 
     return [=](auto f) {
         launch(stream, nglobal, local)(
-            [=](auto idx) { idx.global_stride(n, [&](auto i) { gs_invoke(f, i, idx); }); });
+            [=] __device__ (auto idx) { idx.global_stride(n, [&](auto i) { gs_invoke(f, i, idx); }); });
     };
 }
 

--- a/src/targets/gpu/device/include/migraphx/gpu/device/reduce.hpp
+++ b/src/targets/gpu/device/include/migraphx/gpu/device/reduce.hpp
@@ -59,7 +59,7 @@ struct min
 struct lowest
 {
     template <class T>
-    operator T() const
+    MIGRAPHX_DEVICE_CONSTEXPR operator T() const
     {
         return device_cast(std::numeric_limits<host_type<T>>::lowest());
     }
@@ -68,7 +68,7 @@ struct lowest
 struct highest
 {
     template <class T>
-    operator T() const
+    MIGRAPHX_DEVICE_CONSTEXPR operator T() const
     {
         return device_cast(std::numeric_limits<host_type<T>>::max());
     }
@@ -224,10 +224,10 @@ void reduce_multi_impl(hipStream_t stream,
 
         const std::size_t max_block_size = 256;
         const std::size_t block_size     = compute_block_size(relements, max_block_size);
-        gs_launch(stream, nelements * block_size, block_size)([=](auto i, auto idx) __device__ {
+        gs_launch(stream, nelements * block_size, block_size)([=] __device__ (auto i, auto idx) {
             const auto out_idx = i / block_size;
             auto base_idx      = output.get_shape().multi(out_idx);
-            auto r = block_reduce<max_block_size>(idx, op, init, relements, [&](auto j) __device__ {
+            auto r = block_reduce<max_block_size>(idx, op, init, relements, [&] __device__ (auto j) {
                 auto reduce_idx = reduce_shape.multi(j);
                 return read_input(input[reduce_idx + base_idx]);
             });
@@ -252,10 +252,10 @@ void reduce_standard_impl(hipStream_t stream,
 
         const std::size_t max_block_size = 256;
         const std::size_t block_size     = compute_block_size(relements, max_block_size);
-        gs_launch(stream, nelements * block_size, block_size)([=](auto i, auto idx) __device__ {
+        gs_launch(stream, nelements * block_size, block_size)([=] __device__ (auto i, auto idx) {
             const auto out_idx  = i / block_size;
             const auto base_idx = out_idx * relements;
-            auto r = block_reduce<max_block_size>(idx, op, init, relements, [&](auto j) __device__ {
+            auto r = block_reduce<max_block_size>(idx, op, init, relements, [&] __device__ (auto j) {
                 return read_input(input.data()[base_idx + j]);
             });
             if(idx.local == 0)

--- a/src/targets/gpu/device/include/migraphx/gpu/device/types.hpp
+++ b/src/targets/gpu/device/include/migraphx/gpu/device/types.hpp
@@ -101,13 +101,13 @@ host_type<T>* host_cast(T* x)
 }
 
 template <class T>
-device_type<T> device_cast(const T& x)
+__device__ __host__ device_type<T> device_cast(const T& x)
 {
     return reinterpret_cast<const device_type<T>&>(x);
 }
 
 template <class T>
-device_type<T>* device_cast(T* x)
+__device__ __host__ device_type<T>* device_cast(T* x)
 {
     return reinterpret_cast<device_type<T>*>(x);
 }

--- a/src/targets/gpu/device/int8_gemm_pack.cpp
+++ b/src/targets/gpu/device/int8_gemm_pack.cpp
@@ -25,7 +25,7 @@ void int8_gemm_pack_a(hipStream_t stream, const argument& result, const argument
         auto* in_ptr          = device_cast(input.data());
         visit_tensor_size(out_lens.size(), [&](auto out_dim) {
             hip_tensor_descriptor<out_dim> desc(comp_shape);
-            gs_launch(stream, nelements, 256)([=](auto ii) {
+            gs_launch(stream, nelements, 256)([=] __device__ (auto ii) {
                 const size_t nb    = 4;
                 auto idx           = desc.multi(ii);
                 std::size_t i_m    = idx[dim_1];
@@ -56,7 +56,7 @@ void int8_gemm_pack_b(hipStream_t stream, const argument& result, const argument
         auto* in_ptr          = device_cast(input.data());
         visit_tensor_size(out_lens.size(), [&](auto out_dim) {
             hip_tensor_descriptor<out_dim> desc(comp_shape);
-            gs_launch(stream, nelements, 256)([=](auto ii) {
+            gs_launch(stream, nelements, 256)([=] __device__ (auto ii) {
                 const size_t nb    = 4;
                 auto idx           = desc.multi(ii);
                 std::size_t i_n    = idx[dim_1];

--- a/src/targets/gpu/device/log.cpp
+++ b/src/targets/gpu/device/log.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void log(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::log(to_hip_type(x)); });
+    nary(stream, result, arg)([] __device__ (auto x) { return ::log(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/max.cpp
+++ b/src/targets/gpu/device/max.cpp
@@ -10,7 +10,7 @@ namespace device {
 void max(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
     nary(stream, result, arg1, arg2)(
-        [](auto x, auto y) { return std::max(to_hip_type(x), to_hip_type(y)); });
+        [] __device__ (auto x, auto y) { return std::max(to_hip_type(x), to_hip_type(y)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/min.cpp
+++ b/src/targets/gpu/device/min.cpp
@@ -10,7 +10,7 @@ namespace device {
 void min(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
     nary(stream, result, arg1, arg2)(
-        [](auto x, auto y) { return std::min(to_hip_type(x), to_hip_type(y)); });
+        [] __device__ (auto x, auto y) { return std::min(to_hip_type(x), to_hip_type(y)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/mul.cpp
+++ b/src/targets/gpu/device/mul.cpp
@@ -8,7 +8,7 @@ namespace device {
 
 void mul(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
-    nary(stream, result, arg1, arg2)([](auto x, auto y) { return x * y; });
+    nary(stream, result, arg1, arg2)([] __device__ (auto x, auto y) { return x * y; });
 }
 
 void mul(hipStream_t stream,
@@ -17,7 +17,7 @@ void mul(hipStream_t stream,
          const argument& arg2,
          const argument& arg3)
 {
-    nary(stream, result, arg1, arg2, arg3)([](auto x, auto y, auto z) { return x * y * z; });
+    nary(stream, result, arg1, arg2, arg3)([] __device__ (auto x, auto y, auto z) { return x * y * z; });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/mul_add.cpp
+++ b/src/targets/gpu/device/mul_add.cpp
@@ -12,7 +12,7 @@ void mul_add(hipStream_t stream,
              const argument& arg2,
              const argument& arg3)
 {
-    nary(stream, result, arg1, arg2, arg3)([](auto x, auto a, auto b) { return a * x + b; });
+    nary(stream, result, arg1, arg2, arg3)([] __device__ (auto x, auto a, auto b) { return a * x + b; });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/pad.cpp
+++ b/src/targets/gpu/device/pad.cpp
@@ -24,11 +24,11 @@ pad(hipStream_t stream, argument result, argument arg1, float value, std::vector
             device_val = device_cast(std::numeric_limits<type>::lowest());
         }
         gs_launch(stream,
-                  result.get_shape().elements())([=](auto i) { output.data()[i] = device_val; });
+                  result.get_shape().elements())([=] __device__ (auto i) { output.data()[i] = device_val; });
 
         hip_index offsets;
         std::copy(pads.begin(), pads.begin() + offsets.size(), offsets.begin());
-        gs_launch(stream, nelements)([=](auto i) {
+        gs_launch(stream, nelements)([=] __device__ (auto i) {
             auto idx = input.get_shape().multi(i);
             for(std::size_t j = 0; j < offsets.size(); j++)
             {

--- a/src/targets/gpu/device/pow.cpp
+++ b/src/targets/gpu/device/pow.cpp
@@ -9,7 +9,7 @@ namespace device {
 void pow(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
     nary(stream, result, arg1, arg2)(
-        [](auto b, auto e) { return ::pow(to_hip_type(b), to_hip_type(e)); });
+        [] __device__ (auto b, auto e) { return ::pow(to_hip_type(b), to_hip_type(e)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/relu.cpp
+++ b/src/targets/gpu/device/relu.cpp
@@ -8,7 +8,7 @@ namespace device {
 
 void relu(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return std::max<decltype(x)>(0, x); });
+    nary(stream, result, arg)([] __device__ (auto x) { return std::max<decltype(x)>(0, x); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/round.cpp
+++ b/src/targets/gpu/device/round.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void round(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::round(to_hip_type(x)); });
+    nary(stream, result, arg)([] __device__ (auto x) { return ::round(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/rsqrt.cpp
+++ b/src/targets/gpu/device/rsqrt.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void rsqrt(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) __device__ { return ::rsqrt(to_hip_type(x)); });
+    nary(stream, result, arg)([] __device__ (auto x) { return ::rsqrt(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/sigmoid.cpp
+++ b/src/targets/gpu/device/sigmoid.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void sigmoid(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return 1.f / (1.f + ::exp(to_hip_type(-x))); });
+    nary(stream, result, arg)([] __device__ (auto x) { return 1.f / (1.f + ::exp(to_hip_type(-x))); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/sign.cpp
+++ b/src/targets/gpu/device/sign.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void sign(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return (x > 0 ? 1 : ((x < 0) ? -1 : 0)); });
+    nary(stream, result, arg)([] __device__ (auto x) { return (x > 0 ? 1 : ((x < 0) ? -1 : 0)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/sin.cpp
+++ b/src/targets/gpu/device/sin.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void sin(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::sin(to_hip_type(x)); });
+    nary(stream, result, arg)([] __device__ (auto x) { return ::sin(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/sinh.cpp
+++ b/src/targets/gpu/device/sinh.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void sinh(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::sinh(to_hip_type(x)); });
+    nary(stream, result, arg)([] __device__ (auto x) { return ::sinh(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/softmax.cpp
+++ b/src/targets/gpu/device/softmax.cpp
@@ -26,19 +26,19 @@ void softmax(hipStream_t stream, const argument& result, const argument& arg, in
         const std::size_t block_size     = compute_block_size(batch_item_num, max_block_size);
         gs_launch(stream,
                   batch_shape.elements() * block_size,
-                  block_size)([=](auto i, auto idx) __device__ {
+                  block_size)([=] __device__ (auto i, auto idx) {
             auto data_idx = batch.multi(i / block_size);
             using type    = device_type<std::remove_cv_t<typename decltype(input)::value_type>>;
             type init     = lowest();
 
             auto batch_max = block_reduce<max_block_size>(
-                idx, max{}, init, batch_item_num, [&](auto j) __device__ {
+                idx, max{}, init, batch_item_num, [&] __device__ (auto j) {
                     data_idx[axis] = j;
                     return input[data_idx];
                 });
 
             auto batch_sum =
-                block_reduce<max_block_size>(idx, sum{}, 0, batch_item_num, [&](auto j) __device__ {
+                block_reduce<max_block_size>(idx, sum{}, 0, batch_item_num, [&] __device__ (auto j) {
                     data_idx[axis] = j;
                     auto val       = input[data_idx] - batch_max;
                     return ::exp(to_hip_type(val));

--- a/src/targets/gpu/device/sqdiff.cpp
+++ b/src/targets/gpu/device/sqdiff.cpp
@@ -8,7 +8,7 @@ namespace device {
 
 void sqdiff(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
-    nary(stream, result, arg1, arg2)([](auto x, auto y) { return (x - y) * (x - y); });
+    nary(stream, result, arg1, arg2)([] __device__ (auto x, auto y) { return (x - y) * (x - y); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/sqrt.cpp
+++ b/src/targets/gpu/device/sqrt.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void sqrt(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::sqrt(to_hip_type(x)); });
+    nary(stream, result, arg)([] __device__ (auto x) { return ::sqrt(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/sub.cpp
+++ b/src/targets/gpu/device/sub.cpp
@@ -8,7 +8,7 @@ namespace device {
 
 void sub(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
-    nary(stream, result, arg1, arg2)([](auto x, auto y) { return x - y; });
+    nary(stream, result, arg1, arg2)([] __device__ (auto x, auto y) { return x - y; });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/tan.cpp
+++ b/src/targets/gpu/device/tan.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void tan(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::tan(to_hip_type(x)); });
+    nary(stream, result, arg)([] __device__ (auto x) { return ::tan(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/tanh.cpp
+++ b/src/targets/gpu/device/tanh.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void tanh(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::tanh(to_hip_type(x)); });
+    nary(stream, result, arg)([] __device__ (auto x) { return ::tanh(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/include/migraphx/gpu/device/arg_op.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/device/arg_op.hpp
@@ -87,13 +87,13 @@ void arg_op(Op op, hipStream_t stream, const argument& result, const argument& a
         const std::size_t block_size = compute_block_size(batch_item_num, max_block_size);
         gs_launch(stream,
                   batch_shape.elements() * block_size,
-                  block_size)([=](auto i, auto idx) __device__ {
+                  block_size)([=] __device__ (auto i, auto idx) {
             auto batch_idx = batch_s.multi(i / block_size);
             auto data_idx  = batch_idx;
             auto init      = make_val_index<type>(op.init());
 
             auto op_output =
-                block_reduce<max_block_size>(idx, op, init, batch_item_num, [&](auto j) __device__ {
+                block_reduce<max_block_size>(idx, op, init, batch_item_num, [&] __device__ (auto j) {
                     data_idx[axis] = j;
                     return make_val_index(input[arg_s.index(data_idx)], j);
                 });


### PR DESCRIPTION
Add missing device attributes for GPU functions. GPU functions must be annotated with __device__ in HIP. Also, fix a few warning: nvcc does not allow '__device__' to appear after '()' in lambdas.

Here are the test results, I will file bugs for the failures:

99% tests passed, 2 tests failed out of 182

Total Test time (real) =  26.47 sec
