### PR TITLE
Fix HIP-Clang GPU build issues

### DIFF
--- a/src/targets/gpu/device/acos.cpp
+++ b/src/targets/gpu/device/acos.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void acos(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::acos(to_hip_type(x)); });
+    nary(stream, result, arg)([](auto x) __device__ { return ::acos(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/add.cpp
+++ b/src/targets/gpu/device/add.cpp
@@ -8,7 +8,7 @@ namespace device {
 
 void add(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
-    nary(stream, result, arg1, arg2)([](auto x, auto y) { return x + y; });
+    nary(stream, result, arg1, arg2)([](auto x, auto y) __device__ { return x + y; });
 }
 
 void add(hipStream_t stream,
@@ -17,7 +17,8 @@ void add(hipStream_t stream,
          const argument& arg2,
          const argument& arg3)
 {
-    nary(stream, result, arg1, arg2, arg3)([](auto x, auto y, auto z) { return x + y + z; });
+    nary(stream, result, arg1, arg2, arg3)([](auto x, auto y, auto z)
+                                               __device__ { return x + y + z; });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/add_clip.cpp
+++ b/src/targets/gpu/device/add_clip.cpp
@@ -14,7 +14,7 @@ void add_clip(hipStream_t stream,
               const float min)
 {
     nary(stream, result, arg1, arg2)([max, min](auto x, auto y) __device__ {
-        return std::min<decltype(x + y)>(std::max<decltype(x)>(min, x + y), max);
+        return ::min<decltype(x + y)>(::max<decltype(x)>(min, x + y), max);
     });
 }
 
@@ -27,7 +27,7 @@ void add_clip(hipStream_t stream,
               const float min)
 {
     nary(stream, result, arg1, arg2, arg3)([max, min](auto x, auto y, auto z) __device__ {
-        return std::min<decltype(x + y + z)>(std::max<decltype(x)>(min, x + y + z), max);
+        return ::min<decltype(x + y + z)>(::max<decltype(x)>(min, x + y + z), max);
     });
 }
 

--- a/src/targets/gpu/device/add_clip.cpp
+++ b/src/targets/gpu/device/add_clip.cpp
@@ -13,7 +13,7 @@ void add_clip(hipStream_t stream,
               const float max,
               const float min)
 {
-    nary(stream, result, arg1, arg2)([max, min](auto x, auto y) {
+    nary(stream, result, arg1, arg2)([max, min](auto x, auto y) __device__ {
         return std::min<decltype(x + y)>(std::max<decltype(x)>(min, x + y), max);
     });
 }
@@ -26,7 +26,7 @@ void add_clip(hipStream_t stream,
               const float max,
               const float min)
 {
-    nary(stream, result, arg1, arg2, arg3)([max, min](auto x, auto y, auto z) {
+    nary(stream, result, arg1, arg2, arg3)([max, min](auto x, auto y, auto z) __device__ {
         return std::min<decltype(x + y + z)>(std::max<decltype(x)>(min, x + y + z), max);
     });
 }

--- a/src/targets/gpu/device/add_relu.cpp
+++ b/src/targets/gpu/device/add_relu.cpp
@@ -12,7 +12,7 @@ void add_relu(hipStream_t stream,
               const argument& arg2)
 {
     nary(stream, result, arg1, arg2)(
-        [](auto x, auto y) { return std::max<decltype(x + y)>(0, x + y); });
+        [](auto x, auto y) __device__ { return std::max<decltype(x + y)>(0, x + y); });
 }
 
 void add_relu(hipStream_t stream,
@@ -21,8 +21,9 @@ void add_relu(hipStream_t stream,
               const argument& arg2,
               const argument& arg3)
 {
-    nary(stream, result, arg1, arg2, arg3)(
-        [](auto x, auto y, auto z) { return std::max<decltype(x + y + z)>(0, x + y + z); });
+    nary(stream, result, arg1, arg2, arg3)([](auto x, auto y, auto z) __device__ {
+        return std::max<decltype(x + y + z)>(0, x + y + z);
+    });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/add_relu.cpp
+++ b/src/targets/gpu/device/add_relu.cpp
@@ -11,8 +11,8 @@ void add_relu(hipStream_t stream,
               const argument& arg1,
               const argument& arg2)
 {
-    nary(stream, result, arg1, arg2)(
-        [](auto x, auto y) __device__ { return ::max<decltype(x + y)>(0, x + y); });
+    nary(stream, result, arg1, arg2)([](auto x, auto y)
+                                         __device__ { return ::max<decltype(x + y)>(0, x + y); });
 }
 
 void add_relu(hipStream_t stream,
@@ -21,9 +21,8 @@ void add_relu(hipStream_t stream,
               const argument& arg2,
               const argument& arg3)
 {
-    nary(stream, result, arg1, arg2, arg3)([](auto x, auto y, auto z) __device__ {
-        return ::max<decltype(x + y + z)>(0, x + y + z);
-    });
+    nary(stream, result, arg1, arg2, arg3)(
+        [](auto x, auto y, auto z) __device__ { return ::max<decltype(x + y + z)>(0, x + y + z); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/add_relu.cpp
+++ b/src/targets/gpu/device/add_relu.cpp
@@ -12,7 +12,7 @@ void add_relu(hipStream_t stream,
               const argument& arg2)
 {
     nary(stream, result, arg1, arg2)(
-        [](auto x, auto y) __device__ { return std::max<decltype(x + y)>(0, x + y); });
+        [](auto x, auto y) __device__ { return ::max<decltype(x + y)>(0, x + y); });
 }
 
 void add_relu(hipStream_t stream,
@@ -22,7 +22,7 @@ void add_relu(hipStream_t stream,
               const argument& arg3)
 {
     nary(stream, result, arg1, arg2, arg3)([](auto x, auto y, auto z) __device__ {
-        return std::max<decltype(x + y + z)>(0, x + y + z);
+        return ::max<decltype(x + y + z)>(0, x + y + z);
     });
 }
 

--- a/src/targets/gpu/device/add_sigmoid.cpp
+++ b/src/targets/gpu/device/add_sigmoid.cpp
@@ -12,7 +12,7 @@ void add_sigmoid(hipStream_t stream,
                  const argument& arg2)
 {
     nary(stream, result, arg1, arg2)(
-        [](auto x, auto y) { return 1.f / (1.f + ::exp(to_hip_type(-(x + y)))); });
+        [](auto x, auto y) __device__ { return 1.f / (1.f + ::exp(to_hip_type(-(x + y)))); });
 }
 
 void add_sigmoid(hipStream_t stream,
@@ -21,8 +21,9 @@ void add_sigmoid(hipStream_t stream,
                  const argument& arg2,
                  const argument& arg3)
 {
-    nary(stream, result, arg1, arg2, arg3)(
-        [](auto x, auto y, auto z) { return 1.f / (1.f + ::exp(to_hip_type(-(x + y + z)))); });
+    nary(stream, result, arg1, arg2, arg3)([](auto x, auto y, auto z) __device__ {
+        return 1.f / (1.f + ::exp(to_hip_type(-(x + y + z))));
+    });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/add_tanh.cpp
+++ b/src/targets/gpu/device/add_tanh.cpp
@@ -11,7 +11,8 @@ void add_tanh(hipStream_t stream,
               const argument& arg1,
               const argument& arg2)
 {
-    nary(stream, result, arg1, arg2)([](auto x, auto y) { return ::tanh(to_hip_type(x + y)); });
+    nary(stream, result, arg1, arg2)([](auto x, auto y)
+                                         __device__ { return ::tanh(to_hip_type(x + y)); });
 }
 
 void add_tanh(hipStream_t stream,
@@ -21,7 +22,7 @@ void add_tanh(hipStream_t stream,
               const argument& arg3)
 {
     nary(stream, result, arg1, arg2, arg3)(
-        [](auto x, auto y, auto z) { return ::tanh(to_hip_type(x + y + z)); });
+        [](auto x, auto y, auto z) __device__ { return ::tanh(to_hip_type(x + y + z)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/asin.cpp
+++ b/src/targets/gpu/device/asin.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void asin(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::asin(to_hip_type(x)); });
+    nary(stream, result, arg)([](auto x) __device__ { return ::asin(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/atan.cpp
+++ b/src/targets/gpu/device/atan.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void atan(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::atan(to_hip_type(x)); });
+    nary(stream, result, arg)([](auto x) __device__ { return ::atan(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/ceil.cpp
+++ b/src/targets/gpu/device/ceil.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void ceil(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::ceil(to_hip_type(x)); });
+    nary(stream, result, arg)([](auto x) __device__ { return ::ceil(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/clip.cpp
+++ b/src/targets/gpu/device/clip.cpp
@@ -12,8 +12,9 @@ void clip(hipStream_t stream,
           const float max,
           const float min)
 {
-    nary(stream, result, arg1)(
-        [max, min](auto x) { return std::min<decltype(x)>(std::max<decltype(x)>(min, x), max); });
+    nary(stream, result, arg1)([max, min](auto x) __device__ {
+        return std::min<decltype(x)>(std::max<decltype(x)>(min, x), max);
+    });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/clip.cpp
+++ b/src/targets/gpu/device/clip.cpp
@@ -13,7 +13,7 @@ void clip(hipStream_t stream,
           const float min)
 {
     nary(stream, result, arg1)([max, min](auto x) __device__ {
-        return std::min<decltype(x)>(std::max<decltype(x)>(min, x), max);
+        return ::min<decltype(x)>(::max<decltype(x)>(min, x), max);
     });
 }
 

--- a/src/targets/gpu/device/contiguous.cpp
+++ b/src/targets/gpu/device/contiguous.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void contiguous(hipStream_t stream, argument result, argument arg)
 {
-    nary(stream, std::move(result), std::move(arg))([](auto x) { return x; });
+    nary(stream, std::move(result), std::move(arg))([](auto x) __device__ { return x; });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/convert.cpp
+++ b/src/targets/gpu/device/convert.cpp
@@ -12,8 +12,8 @@ void convert(hipStream_t stream, const argument& result, const argument& arg)
         arg.visit([&](auto input) {
             const auto* input_ptr = device_cast(input.data());
             auto* output_ptr      = device_cast(output.data());
-            gs_launch(stream,
-                      result.get_shape().elements())([=](auto i) { output_ptr[i] = input_ptr[i]; });
+            gs_launch(stream, result.get_shape().elements())(
+                [=](auto i) __device__ { output_ptr[i] = input_ptr[i]; });
         });
     });
 }

--- a/src/targets/gpu/device/cos.cpp
+++ b/src/targets/gpu/device/cos.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void cos(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::cos(to_hip_type(x)); });
+    nary(stream, result, arg)([](auto x) __device__ { return ::cos(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/cosh.cpp
+++ b/src/targets/gpu/device/cosh.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void cosh(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::cosh(to_hip_type(x)); });
+    nary(stream, result, arg)([](auto x) __device__ { return ::cosh(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/div.cpp
+++ b/src/targets/gpu/device/div.cpp
@@ -8,7 +8,7 @@ namespace device {
 
 void div(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
-    nary(stream, result, arg1, arg2)([](auto x, auto y) { return x / y; });
+    nary(stream, result, arg1, arg2)([](auto x, auto y) __device__ { return x / y; });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/erf.cpp
+++ b/src/targets/gpu/device/erf.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void erf(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::erf(to_hip_type(x)); });
+    nary(stream, result, arg)([](auto x) __device__ { return ::erf(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/exp.cpp
+++ b/src/targets/gpu/device/exp.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void exp(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::exp(to_hip_type(x)); });
+    nary(stream, result, arg)([](auto x) __device__ { return ::exp(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/floor.cpp
+++ b/src/targets/gpu/device/floor.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void floor(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::floor(to_hip_type(x)); });
+    nary(stream, result, arg)([](auto x) __device__ { return ::floor(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/gather.cpp
+++ b/src/targets/gpu/device/gather.cpp
@@ -25,7 +25,7 @@ argument gather(hipStream_t stream, argument result, argument arg1, argument arg
             arg2.visit([&](auto indices) {
                 const auto* indices_ptr = device_cast(indices.data());
                 auto* output_ptr        = device_cast(output.data());
-                gs_launch(stream, nelements, 256)([=](auto i) {
+                gs_launch(stream, nelements, 256)([=](auto i) __device__ {
                     auto idx        = out_comp.multi(i);
                     auto in_index   = indices_ptr[idx[axis_index]];
                     in_index        = (in_index < 0) ? in_index + axis_dim_size : in_index;

--- a/src/targets/gpu/device/include/migraphx/gpu/device/launch.hpp
+++ b/src/targets/gpu/device/include/migraphx/gpu/device/launch.hpp
@@ -78,8 +78,9 @@ inline auto gs_launch(hipStream_t stream, index_int n, index_int local = 1024)
     index_int nglobal = std::min<index_int>(256, groups) * local;
 
     return [=](auto f) {
-        launch(stream, nglobal, local)(
-            [=](auto idx) { idx.global_stride(n, [&](auto i) { gs_invoke(f, i, idx); }); });
+        launch(stream, nglobal, local)([=](auto idx) __device__ {
+            idx.global_stride(n, [&](auto i) { gs_invoke(f, i, idx); });
+        });
     };
 }
 

--- a/src/targets/gpu/device/include/migraphx/gpu/device/multi_index.hpp
+++ b/src/targets/gpu/device/include/migraphx/gpu/device/multi_index.hpp
@@ -95,7 +95,7 @@ inline auto mi_launch(hipStream_t stream, const hip_shape<N>& global, index_int 
     auto nglobal       = global.index(nglobal_multi);
 
     return [=](auto f) {
-        launch(stream, nglobal, nlocal)([=](auto idx) {
+        launch(stream, nglobal, nlocal)([=](auto idx) __device__ {
             auto midx = make_multi_index(global, idx.global, nglobal_multi);
             f(idx, midx.for_stride(global.lens));
         });

--- a/src/targets/gpu/device/include/migraphx/gpu/device/nary.hpp
+++ b/src/targets/gpu/device/include/migraphx/gpu/device/nary.hpp
@@ -62,12 +62,11 @@ auto nary_nonstandard_packed_impl(hipStream_t stream,
     auto arg_shape = make_array(args...).front().get_shape();
     auto perm      = find_permutation(arg_shape);
     auto s         = reorder_shape(arg_shape, perm);
-    hip_visit_all(s,
-                  result.reshape(reorder_shape(result.get_shape(), perm)),
-                  args.reshape(s)...)([&](auto standard_shape, auto output, auto... inputs) {
-        mi_gs_launch(stream,
-                     standard_shape)([=](auto idx) __device__ { output[idx] = f(inputs[idx]...); });
-    });
+    hip_visit_all(s, result.reshape(reorder_shape(result.get_shape(), perm)), args.reshape(s)...)(
+        [&](auto standard_shape, auto output, auto... inputs) {
+            mi_gs_launch(stream, standard_shape)(
+                [=](auto idx) __device__ { output[idx] = f(inputs[idx]...); });
+        });
 }
 
 template <class F, class... Arguments>

--- a/src/targets/gpu/device/include/migraphx/gpu/device/nary.hpp
+++ b/src/targets/gpu/device/include/migraphx/gpu/device/nary.hpp
@@ -36,7 +36,8 @@ auto nary_nonstandard_nonpacked_impl(hipStream_t stream, F f, argument result, A
     MIGRAPHX_TRACE_NARY_FUNCTION
     shape s{result.get_shape().type(), result.get_shape().lens()};
     hip_visit_all(s, result, args...)([&](auto standard_shape, auto output, auto... inputs) {
-        mi_gs_launch(stream, standard_shape)([=](auto idx) { output[idx] = f(inputs[idx]...); });
+        mi_gs_launch(stream,
+                     standard_shape)([=](auto idx) __device__ { output[idx] = f(inputs[idx]...); });
     });
 }
 
@@ -45,7 +46,7 @@ inline auto create_broadcast_index(index_int len, index_int stride)
     auto next_stride   = stride * len;
     auto e_next_stride = encode_divisor(next_stride);
     auto e_stride      = encode_divisor(stride);
-    return [=](auto i) {
+    return [=](auto i) __device__ {
         // ( i % next_stride) / stride
         return fast_div(i, e_stride) - len * fast_div(i, e_next_stride);
     };
@@ -64,7 +65,8 @@ auto nary_nonstandard_packed_impl(hipStream_t stream,
     hip_visit_all(s,
                   result.reshape(reorder_shape(result.get_shape(), perm)),
                   args.reshape(s)...)([&](auto standard_shape, auto output, auto... inputs) {
-        mi_gs_launch(stream, standard_shape)([=](auto idx) { output[idx] = f(inputs[idx]...); });
+        mi_gs_launch(stream,
+                     standard_shape)([=](auto idx) __device__ { output[idx] = f(inputs[idx]...); });
     });
 }
 
@@ -93,7 +95,6 @@ void nary_broadcast_vec_impl(
             using type                = typename decltype(output)::value_type;
             const index_int nelements = output.size() / vec_size;
             launch(stream, nglobal, nlocal)([=](auto idx) __device__ {
-
                 MIGRAPHX_DEVICE_SHARED type buffer[2048 / vec_size];
                 // Load bias into LDS
                 for(size_t i = idx.local; i < bdim_vec_len; i += nlocal)
@@ -185,7 +186,6 @@ void nary_double_broadcast_vec_impl(
             using type                = typename decltype(output)::value_type;
             const index_int nelements = output.size() / vec_size;
             launch(stream, nglobal, nlocal)([=](auto idx) __device__ {
-
                 MIGRAPHX_DEVICE_SHARED type buffer[2048 / vec_size];
                 // Load bias into LDS
                 for(size_t i = idx.local; i < bdim_vec_len; i += nlocal)
@@ -274,7 +274,7 @@ void nary_standard_vec_impl(hipStream_t stream, F f, argument result, Arguments.
         const index_int vec_size = 4;
         auto data                = pack_vec<4>(device_cast(inputs.data())...);
         auto* outp               = as_vec<4>(device_cast(output.data()));
-        gs_launch(stream, output_shape.elements() / vec_size)([=](auto i) {
+        gs_launch(stream, output_shape.elements() / vec_size)([=](auto i) __device__ {
             vec<type, 4> out = outp[i];
             data(
                 [&](auto... xs) {
@@ -295,7 +295,7 @@ void nary_standard_impl(hipStream_t stream, F f, argument result, Arguments... a
     MIGRAPHX_TRACE_NARY_FUNCTION
     index_int nelements = result.get_shape().elements();
     hip_pointer_visit_all(result, args...)([&](auto output, auto... inputs) {
-        gs_launch(stream, nelements)([=](auto i) { output[i] = f(inputs[i]...); });
+        gs_launch(stream, nelements)([=](auto i) __device__ { output[i] = f(inputs[i]...); });
     });
 }
 

--- a/src/targets/gpu/device/include/migraphx/gpu/device/reduce.hpp
+++ b/src/targets/gpu/device/include/migraphx/gpu/device/reduce.hpp
@@ -69,7 +69,7 @@ struct min
 struct lowest
 {
     template <class T>
-    MIGRAPHX_DEVICE_CONSTEXPR operator T() const
+    operator T() const
     {
         return device_cast(std::numeric_limits<host_type<T>>::lowest());
     }
@@ -78,7 +78,7 @@ struct lowest
 struct highest
 {
     template <class T>
-    MIGRAPHX_DEVICE_CONSTEXPR operator T() const
+    operator T() const
     {
         return device_cast(std::numeric_limits<host_type<T>>::max());
     }

--- a/src/targets/gpu/device/include/migraphx/gpu/device/reduce.hpp
+++ b/src/targets/gpu/device/include/migraphx/gpu/device/reduce.hpp
@@ -69,7 +69,7 @@ struct min
 struct lowest
 {
     template <class T>
-    operator T() const
+    MIGRAPHX_DEVICE_CONSTEXPR operator T() const
     {
         return device_cast(std::numeric_limits<host_type<T>>::lowest());
     }
@@ -78,7 +78,7 @@ struct lowest
 struct highest
 {
     template <class T>
-    operator T() const
+    MIGRAPHX_DEVICE_CONSTEXPR operator T() const
     {
         return device_cast(std::numeric_limits<host_type<T>>::max());
     }

--- a/src/targets/gpu/device/include/migraphx/gpu/device/types.hpp
+++ b/src/targets/gpu/device/include/migraphx/gpu/device/types.hpp
@@ -103,13 +103,13 @@ host_type<T>* host_cast(T* x)
 }
 
 template <class T>
-__device__ __host__ device_type<T> device_cast(const T& x)
+device_type<T> device_cast(const T& x)
 {
     return reinterpret_cast<const device_type<T>&>(x);
 }
 
 template <class T>
-__device__ __host__ device_type<T>* device_cast(T* x)
+device_type<T>* device_cast(T* x)
 {
     return reinterpret_cast<device_type<T>*>(x);
 }

--- a/src/targets/gpu/device/include/migraphx/gpu/device/types.hpp
+++ b/src/targets/gpu/device/include/migraphx/gpu/device/types.hpp
@@ -103,13 +103,13 @@ host_type<T>* host_cast(T* x)
 }
 
 template <class T>
-device_type<T> device_cast(const T& x)
+__device__ __host__ device_type<T> device_cast(const T& x)
 {
     return reinterpret_cast<const device_type<T>&>(x);
 }
 
 template <class T>
-device_type<T>* device_cast(T* x)
+__device__ __host__ device_type<T>* device_cast(T* x)
 {
     return reinterpret_cast<device_type<T>*>(x);
 }

--- a/src/targets/gpu/device/int8_gemm_pack.cpp
+++ b/src/targets/gpu/device/int8_gemm_pack.cpp
@@ -24,7 +24,7 @@ void int8_gemm_pack_a(hipStream_t stream, const argument& result, const argument
         auto* in_ptr          = device_cast(input.data());
         visit_tensor_size(out_lens.size(), [&](auto out_dim) {
             hip_tensor_descriptor<out_dim> desc(comp_shape);
-            gs_launch(stream, nelements, 256)([=](auto ii) {
+            gs_launch(stream, nelements, 256)([=](auto ii) __device__ {
                 const size_t nb    = 4;
                 auto idx           = desc.multi(ii);
                 std::size_t i_m    = idx[dim_1];
@@ -55,7 +55,7 @@ void int8_gemm_pack_b(hipStream_t stream, const argument& result, const argument
         auto* in_ptr          = device_cast(input.data());
         visit_tensor_size(out_lens.size(), [&](auto out_dim) {
             hip_tensor_descriptor<out_dim> desc(comp_shape);
-            gs_launch(stream, nelements, 256)([=](auto ii) {
+            gs_launch(stream, nelements, 256)([=](auto ii) __device__ {
                 const size_t nb    = 4;
                 auto idx           = desc.multi(ii);
                 std::size_t i_n    = idx[dim_1];

--- a/src/targets/gpu/device/log.cpp
+++ b/src/targets/gpu/device/log.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void log(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::log(to_hip_type(x)); });
+    nary(stream, result, arg)([](auto x) __device__ { return ::log(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/logsoftmax.cpp
+++ b/src/targets/gpu/device/logsoftmax.cpp
@@ -43,7 +43,7 @@ void logsoftmax(hipStream_t stream, const argument& result, const argument& arg,
 
             auto log_batch_sum = ::log(to_hip_type(batch_sum)) + batch_max;
 
-            idx.local_stride(batch_item_num, [&](auto j) {
+            idx.local_stride(batch_item_num, [&](auto j) __device__ {
                 data_idx[axis]   = j;
                 output[data_idx] = input[data_idx] - log_batch_sum;
             });

--- a/src/targets/gpu/device/max.cpp
+++ b/src/targets/gpu/device/max.cpp
@@ -10,7 +10,7 @@ namespace device {
 void max(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
     nary(stream, result, arg1, arg2)(
-        [](auto x, auto y) __device__ { return std::max(to_hip_type(x), to_hip_type(y)); });
+        [](auto x, auto y) __device__ { return ::max(to_hip_type(x), to_hip_type(y)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/max.cpp
+++ b/src/targets/gpu/device/max.cpp
@@ -10,7 +10,7 @@ namespace device {
 void max(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
     nary(stream, result, arg1, arg2)(
-        [](auto x, auto y) { return std::max(to_hip_type(x), to_hip_type(y)); });
+        [](auto x, auto y) __device__ { return std::max(to_hip_type(x), to_hip_type(y)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/min.cpp
+++ b/src/targets/gpu/device/min.cpp
@@ -10,7 +10,7 @@ namespace device {
 void min(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
     nary(stream, result, arg1, arg2)(
-        [](auto x, auto y) __device__ { return std::min(to_hip_type(x), to_hip_type(y)); });
+        [](auto x, auto y) __device__ { return ::min(to_hip_type(x), to_hip_type(y)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/min.cpp
+++ b/src/targets/gpu/device/min.cpp
@@ -10,7 +10,7 @@ namespace device {
 void min(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
     nary(stream, result, arg1, arg2)(
-        [](auto x, auto y) { return std::min(to_hip_type(x), to_hip_type(y)); });
+        [](auto x, auto y) __device__ { return std::min(to_hip_type(x), to_hip_type(y)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/mul.cpp
+++ b/src/targets/gpu/device/mul.cpp
@@ -8,7 +8,7 @@ namespace device {
 
 void mul(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
-    nary(stream, result, arg1, arg2)([](auto x, auto y) { return x * y; });
+    nary(stream, result, arg1, arg2)([](auto x, auto y) __device__ { return x * y; });
 }
 
 void mul(hipStream_t stream,
@@ -17,7 +17,8 @@ void mul(hipStream_t stream,
          const argument& arg2,
          const argument& arg3)
 {
-    nary(stream, result, arg1, arg2, arg3)([](auto x, auto y, auto z) { return x * y * z; });
+    nary(stream, result, arg1, arg2, arg3)([](auto x, auto y, auto z)
+                                               __device__ { return x * y * z; });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/mul_add.cpp
+++ b/src/targets/gpu/device/mul_add.cpp
@@ -12,7 +12,8 @@ void mul_add(hipStream_t stream,
              const argument& arg2,
              const argument& arg3)
 {
-    nary(stream, result, arg1, arg2, arg3)([](auto x, auto a, auto b) { return a * x + b; });
+    nary(stream, result, arg1, arg2, arg3)([](auto x, auto a, auto b)
+                                               __device__ { return a * x + b; });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/mul_add_relu.cpp
+++ b/src/targets/gpu/device/mul_add_relu.cpp
@@ -12,8 +12,9 @@ void mul_add_relu(hipStream_t stream,
                   const argument& arg2,
                   const argument& arg3)
 {
-    nary(stream, result, arg1, arg2, arg3)(
-        [](auto x, auto a, auto b) { return std::max<decltype(a * x + b)>(0, a * x + b); });
+    nary(stream, result, arg1, arg2, arg3)([](auto x, auto a, auto b) __device__ {
+        return std::max<decltype(a * x + b)>(0, a * x + b);
+    });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/mul_add_relu.cpp
+++ b/src/targets/gpu/device/mul_add_relu.cpp
@@ -13,7 +13,7 @@ void mul_add_relu(hipStream_t stream,
                   const argument& arg3)
 {
     nary(stream, result, arg1, arg2, arg3)([](auto x, auto a, auto b) __device__ {
-        return std::max<decltype(a * x + b)>(0, a * x + b);
+        return ::max<decltype(a * x + b)>(0, a * x + b);
     });
 }
 

--- a/src/targets/gpu/device/mul_add_relu.cpp
+++ b/src/targets/gpu/device/mul_add_relu.cpp
@@ -12,9 +12,8 @@ void mul_add_relu(hipStream_t stream,
                   const argument& arg2,
                   const argument& arg3)
 {
-    nary(stream, result, arg1, arg2, arg3)([](auto x, auto a, auto b) __device__ {
-        return ::max<decltype(a * x + b)>(0, a * x + b);
-    });
+    nary(stream, result, arg1, arg2, arg3)(
+        [](auto x, auto a, auto b) __device__ { return ::max<decltype(a * x + b)>(0, a * x + b); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/pad.cpp
+++ b/src/targets/gpu/device/pad.cpp
@@ -23,12 +23,12 @@ pad(hipStream_t stream, argument result, argument arg1, float value, std::vector
         {
             device_val = device_cast(std::numeric_limits<type>::lowest());
         }
-        gs_launch(stream,
-                  result.get_shape().elements())([=](auto i) { output.data()[i] = device_val; });
+        gs_launch(stream, result.get_shape().elements())(
+            [=](auto i) __device__ { output.data()[i] = device_val; });
 
         hip_index offsets;
         std::copy(pads.begin(), pads.begin() + offsets.size(), offsets.begin());
-        gs_launch(stream, nelements)([=](auto i) {
+        gs_launch(stream, nelements)([=](auto i) __device__ {
             auto idx = input.get_shape().multi(i);
             for(std::size_t j = 0; j < offsets.size(); j++)
             {

--- a/src/targets/gpu/device/pow.cpp
+++ b/src/targets/gpu/device/pow.cpp
@@ -9,7 +9,7 @@ namespace device {
 void pow(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
     nary(stream, result, arg1, arg2)(
-        [](auto b, auto e) { return ::pow(to_hip_type(b), to_hip_type(e)); });
+        [](auto b, auto e) __device__ { return ::pow(to_hip_type(b), to_hip_type(e)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/relu.cpp
+++ b/src/targets/gpu/device/relu.cpp
@@ -8,7 +8,7 @@ namespace device {
 
 void relu(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) __device__ { return std::max<decltype(x)>(0, x); });
+    nary(stream, result, arg)([](auto x) __device__ { return ::max<decltype(x)>(0, x); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/relu.cpp
+++ b/src/targets/gpu/device/relu.cpp
@@ -8,7 +8,7 @@ namespace device {
 
 void relu(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return std::max<decltype(x)>(0, x); });
+    nary(stream, result, arg)([](auto x) __device__ { return std::max<decltype(x)>(0, x); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/round.cpp
+++ b/src/targets/gpu/device/round.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void round(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::round(to_hip_type(x)); });
+    nary(stream, result, arg)([](auto x) __device__ { return ::round(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/sigmoid.cpp
+++ b/src/targets/gpu/device/sigmoid.cpp
@@ -9,7 +9,8 @@ namespace device {
 
 void sigmoid(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return 1.f / (1.f + ::exp(to_hip_type(-x))); });
+    nary(stream, result, arg)([](auto x)
+                                  __device__ { return 1.f / (1.f + ::exp(to_hip_type(-x))); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/sign.cpp
+++ b/src/targets/gpu/device/sign.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void sign(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return (x > 0 ? 1 : ((x < 0) ? -1 : 0)); });
+    nary(stream, result, arg)([](auto x) __device__ { return (x > 0 ? 1 : ((x < 0) ? -1 : 0)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/sin.cpp
+++ b/src/targets/gpu/device/sin.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void sin(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::sin(to_hip_type(x)); });
+    nary(stream, result, arg)([](auto x) __device__ { return ::sin(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/sinh.cpp
+++ b/src/targets/gpu/device/sinh.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void sinh(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::sinh(to_hip_type(x)); });
+    nary(stream, result, arg)([](auto x) __device__ { return ::sinh(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/softmax.cpp
+++ b/src/targets/gpu/device/softmax.cpp
@@ -42,7 +42,7 @@ void softmax(hipStream_t stream, const argument& result, const argument& arg, in
                     return ::exp(to_hip_type(val));
                 });
 
-            idx.local_stride(batch_item_num, [&](auto j) {
+            idx.local_stride(batch_item_num, [&](auto j) __device__ {
                 data_idx[axis]   = j;
                 auto val         = input[data_idx] - batch_max;
                 output[data_idx] = ::exp(to_hip_type(val)) / batch_sum;

--- a/src/targets/gpu/device/sqdiff.cpp
+++ b/src/targets/gpu/device/sqdiff.cpp
@@ -8,7 +8,7 @@ namespace device {
 
 void sqdiff(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
-    nary(stream, result, arg1, arg2)([](auto x, auto y) { return (x - y) * (x - y); });
+    nary(stream, result, arg1, arg2)([](auto x, auto y) __device__ { return (x - y) * (x - y); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/sqrt.cpp
+++ b/src/targets/gpu/device/sqrt.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void sqrt(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::sqrt(to_hip_type(x)); });
+    nary(stream, result, arg)([](auto x) __device__ { return ::sqrt(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/sub.cpp
+++ b/src/targets/gpu/device/sub.cpp
@@ -8,7 +8,7 @@ namespace device {
 
 void sub(hipStream_t stream, const argument& result, const argument& arg1, const argument& arg2)
 {
-    nary(stream, result, arg1, arg2)([](auto x, auto y) { return x - y; });
+    nary(stream, result, arg1, arg2)([](auto x, auto y) __device__ { return x - y; });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/tan.cpp
+++ b/src/targets/gpu/device/tan.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void tan(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::tan(to_hip_type(x)); });
+    nary(stream, result, arg)([](auto x) __device__ { return ::tan(to_hip_type(x)); });
 }
 
 } // namespace device

--- a/src/targets/gpu/device/tanh.cpp
+++ b/src/targets/gpu/device/tanh.cpp
@@ -9,7 +9,7 @@ namespace device {
 
 void tanh(hipStream_t stream, const argument& result, const argument& arg)
 {
-    nary(stream, result, arg)([](auto x) { return ::tanh(to_hip_type(x)); });
+    nary(stream, result, arg)([](auto x) __device__ { return ::tanh(to_hip_type(x)); });
 }
 
 } // namespace device


### PR DESCRIPTION
Add missing device attributes for GPU functions. GPU functions must be annotated with __device__ in HIP. Also, fix a few warning: nvcc does not allow '__device__' to appear after '()' in lambdas. Add __device__ for add_unary as well.

**Test Results on HIP-Clang:**
99% tests passed, 2 tests failed out of 191

Total Test time (real) =  30.74 sec

The following tests FAILED:
         37 - test_gpu_ops_test (OTHER_FAULT)
        191 - test_py_array (Failed)
Errors while running CTest
