### PR TITLE
Fuse operators that partially match in a concat operator

### DIFF
--- a/src/include/migraphx/algorithm.hpp
+++ b/src/include/migraphx/algorithm.hpp
@@ -23,9 +23,7 @@ void group_unique(Iterator start, Iterator last, Output out, Predicate pred)
 {
     while(start != last)
     {
-        auto it = std::find_if(start, last, [&](auto&& x) {
-            return not pred(*start, x);
-        });
+        auto it = std::find_if(start, last, [&](auto&& x) { return not pred(*start, x); });
         out(start, it);
         start = it;
     }

--- a/src/include/migraphx/algorithm.hpp
+++ b/src/include/migraphx/algorithm.hpp
@@ -12,7 +12,20 @@ void group_by(Iterator start, Iterator last, Output out, Predicate pred)
 {
     while(start != last)
     {
-        auto it = std::partition(start, last, [&](auto x) { return pred(x, *start); });
+        auto it = std::partition(start, last, [&](auto&& x) { return pred(x, *start); });
+        out(start, it);
+        start = it;
+    }
+}
+
+template <class Iterator, class Output, class Predicate>
+void group_unique(Iterator start, Iterator last, Output out, Predicate pred)
+{
+    while(start != last)
+    {
+        auto it = std::find_if(start, last, [&](auto&& x) {
+            return not pred(*start, x);
+        });
         out(start, it);
         start = it;
     }

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -177,8 +177,8 @@ struct find_concat_op
 {
     auto matcher() const
     {
-        return match::name("concat")(
-            match::any_of[match::inputs()](match::name("add", "multiply", "relu", "broadcast"), match::used_once()));
+        return match::name("concat")(match::any_of[match::inputs()](
+            match::name("add", "multiply", "relu", "broadcast"), match::used_once()));
     }
 
     template <class Iterator>

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -33,15 +33,6 @@ auto conv_const_weights()
                                       match::args(match::any(), match::is_constant().bind("w")));
 }
 
-MIGRAPHX_PRED_MATCHER(args_has_same_ops, instruction_ref ins)
-{
-    if(ins->inputs().empty())
-        return true;
-    return std::all_of(ins->inputs().begin(), ins->inputs().end(), [&](auto j) {
-        return j->get_operator() == ins->inputs().front()->get_operator();
-    });
-}
-
 struct find_mul_conv
 {
     auto matcher() const

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -195,7 +195,7 @@ struct find_concat_op
         return lens;
     }
 
-    void apply(program& p, match::matcher_result r) const
+    void apply(program& p, const match::matcher_result& r) const
     {
         auto ins  = r.result;
         auto axis = any_cast<op::concat>(ins->get_operator()).axis;

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -182,16 +182,16 @@ struct find_concat_op
             match::used_once());
     }
 
-    template<class Iterator>
+    template <class Iterator>
     static std::vector<std::size_t> get_output_lens(Iterator start, Iterator last, std::size_t axis)
     {
         assert(start != last);
         std::size_t dim = 0;
-        for(auto ins:range(start, last))
+        for(auto ins : range(start, last))
         {
             dim += ins->get_shape().lens().at(axis);
         }
-        auto lens = (*start)->get_shape().lens();
+        auto lens  = (*start)->get_shape().lens();
         lens[axis] = dim;
         return lens;
     }
@@ -210,7 +210,7 @@ struct find_concat_op
             auto&& name = x->name();
             if(not contains({"add", "multiply", "relu", "broadcast"}, name))
                 return {start, last};
-            auto op = x->get_operator();
+            auto op    = x->get_operator();
             auto iaxis = axis;
             // Adjust broadcast lens
             if(op.name() == "broadcast")
@@ -220,7 +220,7 @@ struct find_concat_op
                     return {start, last};
                 b.broadcast_lens = get_output_lens(start, last, iaxis);
                 op               = b;
-                iaxis             = 0;
+                iaxis            = 0;
             }
 
             std::vector<instruction_ref> concats;

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -186,8 +186,9 @@ struct find_concat_op
 {
     auto matcher() const
     {
-        return match::name("concat")(match::any_of[match::inputs()](match::name("add", "multiply", "relu", "broadcast")),
-                                                   match::used_once());
+        return match::name("concat")(
+            match::any_of[match::inputs()](match::name("add", "multiply", "relu", "broadcast")),
+            match::used_once());
     }
 
     void apply(program& p, match::matcher_result r) const
@@ -199,10 +200,10 @@ struct find_concat_op
             if(std::distance(start, last) < 2)
                 return {start, last};
             auto x = *start;
-            if (x->inputs().size() > 2 or x->inputs().empty())
+            if(x->inputs().size() > 2 or x->inputs().empty())
                 return {start, last};
             auto&& name = x->name();
-            if (not contains({"add", "multiply", "relu", "broadcast"}, name))
+            if(not contains({"add", "multiply", "relu", "broadcast"}, name))
                 return {start, last};
             auto op = x->get_operator();
             // Adjust broadcast lens
@@ -217,7 +218,7 @@ struct find_concat_op
             }
 
             std::vector<instruction_ref> concats;
-            for(std::size_t i = 0;i< x->inputs().size();i++)
+            for(std::size_t i = 0; i < x->inputs().size(); i++)
             {
                 std::vector<instruction_ref> inputs;
                 std::transform(start, last, std::back_inserter(inputs), [&](auto j) {
@@ -237,10 +238,11 @@ struct find_concat_op
             args.insert(args.end(), x.begin(), x.end());
         };
         auto pred = [](auto i, auto j) {
-            return i->get_operator() == j->get_operator() and i->inputs().size() == i->inputs().size();
+            return i->get_operator() == j->get_operator() and
+                   i->inputs().size() == i->inputs().size();
         };
         group_unique(ins->inputs().begin(), ins->inputs().end(), update_args, pred);
-        if (args.size() == 1)
+        if(args.size() == 1)
             p.replace_instruction(ins, args.front());
         else
             p.replace_instruction(ins, op::concat{axis}, args);

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -178,8 +178,7 @@ struct find_concat_op
     auto matcher() const
     {
         return match::name("concat")(
-            match::any_of[match::inputs()](match::name("add", "multiply", "relu", "broadcast")),
-            match::used_once());
+            match::any_of[match::inputs()](match::name("add", "multiply", "relu", "broadcast"), match::used_once()));
     }
 
     template <class Iterator>
@@ -205,7 +204,7 @@ struct find_concat_op
             if(std::distance(start, last) < 2)
                 return {start, last};
             auto x = *start;
-            if(x->inputs().size() > 2 or x->inputs().empty())
+            if(x->inputs().size() > 2 or x->inputs().empty() or x->outputs().size() > 1)
                 return {start, last};
             auto&& name = x->name();
             if(not contains({"add", "multiply", "relu", "broadcast"}, name))
@@ -245,7 +244,8 @@ struct find_concat_op
         };
         auto pred = [](auto i, auto j) {
             return i->get_operator() == j->get_operator() and
-                   i->inputs().size() == i->inputs().size();
+                   i->inputs().size() == i->inputs().size() and
+                   i->outputs().size() == i->outputs().size();
         };
         group_unique(ins->inputs().begin(), ins->inputs().end(), update_args, pred);
         if(args.size() == 1)

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -447,7 +447,7 @@ TEST_CASE(simplify_concat_add_relu_partial)
         auto relu1  = p1.add_instruction(migraphx::op::relu{}, sum1);
         auto sum2   = p1.add_instruction(migraphx::op::add{}, y, two);
         auto relu2  = p1.add_instruction(migraphx::op::relu{}, sum2);
-        auto sum3 = p1.add_instruction(migraphx::op::add{}, x, y);
+        auto sum3   = p1.add_instruction(migraphx::op::add{}, x, y);
         auto concat = p1.add_instruction(migraphx::op::concat{0}, sum3, relu1, relu2);
         p1.add_instruction(pass_op{}, concat);
     }
@@ -461,10 +461,10 @@ TEST_CASE(simplify_concat_add_relu_partial)
         auto two     = p2.add_literal({s, {2}});
         auto concat1 = p2.add_instruction(migraphx::op::concat{0}, x, y);
         auto concat2 = p2.add_instruction(migraphx::op::concat{0}, one, two);
-        auto sum1     = p2.add_instruction(migraphx::op::add{}, concat1, concat2);
+        auto sum1    = p2.add_instruction(migraphx::op::add{}, concat1, concat2);
         auto relu    = p2.add_instruction(migraphx::op::relu{}, sum1);
-        auto sum2 = p2.add_instruction(migraphx::op::add{}, x, y);
-        auto concat = p2.add_instruction(migraphx::op::concat{0}, sum2, relu);
+        auto sum2    = p2.add_instruction(migraphx::op::add{}, x, y);
+        auto concat  = p2.add_instruction(migraphx::op::concat{0}, sum2, relu);
         p2.add_instruction(pass_op{}, concat);
     }
     EXPECT(p1.sort() == p2.sort());

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -470,6 +470,40 @@ TEST_CASE(simplify_concat_add_relu_partial)
     EXPECT(p1.sort() == p2.sort());
 }
 
+TEST_CASE(simplify_concat_add_relu_partial_broadcast)
+{
+    auto s = migraphx::shape{migraphx::shape::int32_type, {2, 1, 4, 5}};
+    migraphx::program p1;
+    {
+        auto b      = migraphx::op::broadcast{1, {2, 1, 4, 5}};
+        auto x      = p1.add_parameter("x", s);
+        auto y      = p1.add_parameter("y", s);
+        auto one    = p1.add_literal(1);
+        auto oneb   = p1.add_instruction(b, one);
+        auto two    = p1.add_literal(2);
+        auto twob   = p1.add_instruction(b, two);
+        auto sum   = p1.add_instruction(migraphx::op::add{}, x, y);
+        auto concat = p1.add_instruction(migraphx::op::concat{1}, sum, oneb, twob);
+        p1.add_instruction(pass_op{}, concat);
+    }
+    run_pass(p1);
+
+    migraphx::program p2;
+    {
+        auto b      = migraphx::op::broadcast{1, {2, 2, 4, 5}};
+        auto x      = p2.add_parameter("x", s);
+        auto y      = p2.add_parameter("y", s);
+        auto one    = p2.add_literal(1);
+        auto two    = p2.add_literal(2);
+        auto concat1 = p2.add_instruction(migraphx::op::concat{0}, one, two);
+        auto concatb   = p2.add_instruction(b, concat1);
+        auto sum   = p2.add_instruction(migraphx::op::add{}, x, y);
+        auto concat2 = p2.add_instruction(migraphx::op::concat{1}, sum, concatb);
+        p2.add_instruction(pass_op{}, concat2);
+    }
+    EXPECT(p1.sort() == p2.sort());
+}
+
 TEST_CASE(simplify_concat_add_relu_broadcast_different_axis)
 {
     auto s = migraphx::shape{migraphx::shape::int32_type, {2, 1, 4, 5}};

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -482,7 +482,7 @@ TEST_CASE(simplify_concat_add_relu_partial_broadcast)
         auto oneb   = p1.add_instruction(b, one);
         auto two    = p1.add_literal(2);
         auto twob   = p1.add_instruction(b, two);
-        auto sum   = p1.add_instruction(migraphx::op::add{}, x, y);
+        auto sum    = p1.add_instruction(migraphx::op::add{}, x, y);
         auto concat = p1.add_instruction(migraphx::op::concat{1}, sum, oneb, twob);
         p1.add_instruction(pass_op{}, concat);
     }
@@ -490,14 +490,14 @@ TEST_CASE(simplify_concat_add_relu_partial_broadcast)
 
     migraphx::program p2;
     {
-        auto b      = migraphx::op::broadcast{1, {2, 2, 4, 5}};
-        auto x      = p2.add_parameter("x", s);
-        auto y      = p2.add_parameter("y", s);
-        auto one    = p2.add_literal(1);
-        auto two    = p2.add_literal(2);
+        auto b       = migraphx::op::broadcast{1, {2, 2, 4, 5}};
+        auto x       = p2.add_parameter("x", s);
+        auto y       = p2.add_parameter("y", s);
+        auto one     = p2.add_literal(1);
+        auto two     = p2.add_literal(2);
         auto concat1 = p2.add_instruction(migraphx::op::concat{0}, one, two);
-        auto concatb   = p2.add_instruction(b, concat1);
-        auto sum   = p2.add_instruction(migraphx::op::add{}, x, y);
+        auto concatb = p2.add_instruction(b, concat1);
+        auto sum     = p2.add_instruction(migraphx::op::add{}, x, y);
         auto concat2 = p2.add_instruction(migraphx::op::concat{1}, sum, concatb);
         p2.add_instruction(pass_op{}, concat2);
     }


### PR DESCRIPTION
This will fuse more operators. If a concat operator has `concat(sub{}, add{}, add{})`, then we can still fuse the two `add` operators.