### PR TITLE
Workaround broken rocm packages on newer rocm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-
     rm -rf /var/lib/apt/lists/*
 
 # Wokaround broken rocm packages for rocm >= 3.1 
-RUN [ -d /opt/rocm-* ] && ln -sd $(realpath /opt/rocm-*) /opt/rocm
+RUN [ -d /opt/rocm ] || ln -sd $(realpath /opt/rocm-*) /opt/rocm
 
 RUN locale-gen en_US.UTF-8
 RUN update-locale LANG=en_US.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Wokaround broken rocm packages for rocm >= 3.1 
+RUN [ -d /opt/rocm-* ] && ln -sd $(realpath /opt/rocm-*) /opt/rocm
+
 RUN locale-gen en_US.UTF-8
 RUN update-locale LANG=en_US.UTF-8
 


### PR DESCRIPTION
Even though we install rocm packages, the symlink is missing, so this will add it in. This will allow the dockerfile to be built on newer rocm >= 3.1.