### PR TITLE
Improve layernorm performance

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(migraphx
     simplify_algebra.cpp
     simplify_reshapes.cpp
     value.cpp
+    verify_args.cpp
     json.cpp
     opt/memory_coloring.cpp
     opt/memory_coloring_impl.cpp

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -135,7 +135,6 @@ struct program_params
         fill_param_map(m, p, use_gpu);
         return m;
     }
-
 };
 
 struct compiler

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -115,11 +115,35 @@ struct loader
     }
 };
 
+struct program_params
+{
+    std::vector<std::string> fill0{};
+    std::vector<std::string> fill1{};
+    void parse(argument_parser& ap)
+    {
+        ap(fill0, {"--fill0"}, ap.help("Fill parameter with 0s"), ap.append());
+        ap(fill1, {"--fill1"}, ap.help("Fill parameter with 1s"), ap.append());
+    }
+
+    auto generate(const program& p, bool use_gpu)
+    {
+        program::parameter_map m;
+        for(auto&& s : fill0)
+            m[s] = fill_argument(p.get_parameter_shape(s), 0);
+        for(auto&& s : fill1)
+            m[s] = fill_argument(p.get_parameter_shape(s), 1);
+        fill_param_map(m, p, use_gpu);
+        return m;
+    }
+
+};
+
 struct compiler
 {
     static const int q_fp16 = 1;
     static const int q_int8 = 2;
     loader l;
+    program_params parameters;
     bool gpu          = true;
     bool offload_copy = false;
     int quantize      = 0;
@@ -129,6 +153,7 @@ struct compiler
     void parse(argument_parser& ap)
     {
         l.parse(ap);
+        parameters.parse(ap);
         ap(gpu, {"--gpu"}, ap.help("Compile on the gpu"), ap.set_value(true));
         ap(gpu, {"--cpu"}, ap.help("Compile on the cpu"), ap.set_value(false));
         ap(offload_copy,
@@ -137,20 +162,11 @@ struct compiler
            ap.set_value(true));
         ap(quantize, {"--fp16"}, ap.help("Quantize for fp16"), ap.set_value(q_fp16));
         ap(quantize, {"--int8"}, ap.help("Quantize for int8"), ap.set_value(q_int8));
-        ap(fill0, {"--fill0"}, ap.help("Fill parameter with 0s"), ap.append());
-        ap(fill1, {"--fill1"}, ap.help("Fill parameter with 1s"), ap.append());
     }
 
     auto params(const program& p, bool use_gpu = true)
     {
-        bool gpu_flag = use_gpu && gpu && !offload_copy;
-        program::parameter_map m;
-        for(auto&& s : fill0)
-            m[s] = fill_argument(p.get_parameter_shape(s), 0);
-        for(auto&& s : fill1)
-            m[s] = fill_argument(p.get_parameter_shape(s), 1);
-        fill_param_map(m, p, gpu_flag);
-        return m;
+        return parameters.generate(p, use_gpu && gpu && !offload_copy);
     }
 
     program compile()
@@ -228,6 +244,7 @@ struct params : command<params>
 struct verify : command<verify>
 {
     loader l;
+    program_params parameters;
     double tolerance     = 80;
     bool per_instruction = false;
     bool reduce          = false;
@@ -235,6 +252,7 @@ struct verify : command<verify>
     void parse(argument_parser& ap)
     {
         l.parse(ap);
+        parameters.parse(ap);
         ap(offload_copy,
            {"--enable-offload-copy"},
            ap.help("Enable implicit offload copying"),
@@ -255,17 +273,19 @@ struct verify : command<verify>
         compile_options options;
         options.offload_copy = offload_copy;
 
+        auto m = parameters.generate(p, false);
+
         if(per_instruction)
         {
             verify_instructions(p, options, tolerance);
         }
         else if(reduce)
         {
-            verify_reduced_program(p, options, tolerance);
+            verify_reduced_program(p, options, m, tolerance);
         }
         else
         {
-            verify_program(l.file, p, options, tolerance);
+            verify_program(l.file, p, options, m, tolerance);
         }
     }
 };

--- a/src/driver/perf.cpp
+++ b/src/driver/perf.cpp
@@ -11,13 +11,19 @@ namespace migraphx {
 namespace driver {
 inline namespace MIGRAPHX_INLINE_NS {
 
+template <class T>
+auto get_hash(const T& x)
+{
+    return std::hash<T>{}(x);
+}
+
 program::parameter_map fill_param_map(program::parameter_map& m, const program& p, bool gpu)
 {
     for(auto&& x : p.get_parameter_shapes())
     {
         argument& arg = m[x.first];
         if(arg.empty())
-            arg = generate_argument(x.second);
+            arg = generate_argument(x.second, get_hash(x.first));
 #ifdef HAVE_GPU
         if(gpu)
             arg = gpu::to_gpu(arg);
@@ -35,12 +41,12 @@ program::parameter_map create_param_map(const program& p, bool gpu)
     {
 #ifdef HAVE_GPU
         if(gpu)
-            m[x.first] = gpu::to_gpu(generate_argument(x.second));
+            m[x.first] = gpu::to_gpu(generate_argument(x.second, get_hash(x.first)));
         else
 #else
         (void)gpu;
 #endif
-            m[x.first] = generate_argument(x.second);
+            m[x.first] = generate_argument(x.second, get_hash(x.first));
     }
     return m;
 }

--- a/src/driver/verify.cpp
+++ b/src/driver/verify.cpp
@@ -16,7 +16,7 @@ namespace migraphx {
 namespace driver {
 inline namespace MIGRAPHX_INLINE_NS {
 
-std::vector<argument> run_cpu(program p, program::parameter_map inputs)
+std::vector<argument> run_cpu(program p, const program::parameter_map& inputs)
 {
     p.compile(cpu::target{});
     auto out = p.eval(inputs);
@@ -25,7 +25,7 @@ std::vector<argument> run_cpu(program p, program::parameter_map inputs)
 }
 
 std::vector<argument>
-run_gpu(program p, const compile_options& options, program::parameter_map inputs)
+run_gpu(program p, const compile_options& options, const program::parameter_map& inputs)
 {
 #ifdef HAVE_GPU
     p.compile(gpu::target{}, options);
@@ -47,6 +47,7 @@ run_gpu(program p, const compile_options& options, program::parameter_map inputs
 #else
     (void)p;
     (void)options;
+    (void)inputs;
     MIGRAPHX_THROW("Gpu unsupported!");
 #endif
 }
@@ -54,7 +55,7 @@ run_gpu(program p, const compile_options& options, program::parameter_map inputs
 void verify_program(const std::string& name,
                     const program& p,
                     compile_options options,
-                    program::parameter_map inputs,
+                    const program::parameter_map& inputs,
                     double tolerance)
 {
     auto x = run_cpu(p, inputs);
@@ -108,7 +109,7 @@ void verify_instructions(const program& prog, compile_options options, double to
 }
 
 void verify_reduced(
-    program p, int n, compile_options options, program::parameter_map inputs, double tolerance)
+    program p, int n, compile_options options, const program::parameter_map& inputs, double tolerance)
 {
     auto last = std::prev(p.end(), n + 1);
     p.remove_instructions(last, p.end());
@@ -119,7 +120,7 @@ void verify_reduced(
 
 void verify_reduced_program(const program& p,
                             compile_options options,
-                            program::parameter_map inputs,
+                            const program::parameter_map& inputs,
                             double tolerance)
 {
     auto n = std::distance(p.begin(), p.end());

--- a/src/driver/verify.cpp
+++ b/src/driver/verify.cpp
@@ -24,7 +24,8 @@ std::vector<argument> run_cpu(program p, program::parameter_map inputs)
     return out;
 }
 
-std::vector<argument> run_gpu(program p, const compile_options& options, program::parameter_map inputs)
+std::vector<argument>
+run_gpu(program p, const compile_options& options, program::parameter_map inputs)
 {
 #ifdef HAVE_GPU
     p.compile(gpu::target{}, options);
@@ -53,7 +54,7 @@ std::vector<argument> run_gpu(program p, const compile_options& options, program
 void verify_program(const std::string& name,
                     const program& p,
                     compile_options options,
-                    program::parameter_map inputs, 
+                    program::parameter_map inputs,
                     double tolerance)
 {
     auto x = run_cpu(p, inputs);
@@ -106,7 +107,8 @@ void verify_instructions(const program& prog, compile_options options, double to
     }
 }
 
-void verify_reduced(program p, int n, compile_options options, program::parameter_map inputs, double tolerance)
+void verify_reduced(
+    program p, int n, compile_options options, program::parameter_map inputs, double tolerance)
 {
     auto last = std::prev(p.end(), n + 1);
     p.remove_instructions(last, p.end());
@@ -115,7 +117,10 @@ void verify_reduced(program p, int n, compile_options options, program::paramete
     verify_program(std::to_string(n), p, options, inputs, tolerance);
 }
 
-void verify_reduced_program(const program& p, compile_options options, program::parameter_map inputs, double tolerance)
+void verify_reduced_program(const program& p,
+                            compile_options options,
+                            program::parameter_map inputs,
+                            double tolerance)
 {
     auto n = std::distance(p.begin(), p.end());
     for(std::size_t i = 0; i < n; i++)

--- a/src/driver/verify.cpp
+++ b/src/driver/verify.cpp
@@ -1,4 +1,5 @@
 #include "verify.hpp"
+#include "perf.hpp"
 
 #include <migraphx/cpu/target.hpp>
 #include <migraphx/generate.hpp>
@@ -15,26 +16,15 @@ namespace migraphx {
 namespace driver {
 inline namespace MIGRAPHX_INLINE_NS {
 
-template <class T>
-auto get_hash(const T& x)
-{
-    return std::hash<T>{}(x);
-}
-
-std::vector<argument> run_cpu(program p)
+std::vector<argument> run_cpu(program p, program::parameter_map inputs)
 {
     p.compile(cpu::target{});
-    program::parameter_map m;
-    for(auto&& x : p.get_parameter_shapes())
-    {
-        m[x.first] = generate_argument(x.second, get_hash(x.first));
-    }
-    auto out = p.eval(m);
+    auto out = p.eval(inputs);
     std::cout << p << std::endl;
     return out;
 }
 
-std::vector<argument> run_gpu(program p, const compile_options& options)
+std::vector<argument> run_gpu(program p, const compile_options& options, program::parameter_map inputs)
 {
 #ifdef HAVE_GPU
     p.compile(gpu::target{}, options);
@@ -42,7 +32,7 @@ std::vector<argument> run_gpu(program p, const compile_options& options)
     program::parameter_map m;
     for(auto&& x : p.get_parameter_shapes())
     {
-        auto arg   = generate_argument(x.second, get_hash(x.first));
+        auto arg   = inputs.count(x.first) == 0 ? generate_argument(x.second) : inputs.at(x.first);
         m[x.first] = options.offload_copy ? arg : gpu::to_gpu(arg);
     }
     auto gpu_out = p.eval(m);
@@ -63,10 +53,11 @@ std::vector<argument> run_gpu(program p, const compile_options& options)
 void verify_program(const std::string& name,
                     const program& p,
                     compile_options options,
+                    program::parameter_map inputs, 
                     double tolerance)
 {
-    auto x = run_cpu(p);
-    auto y = run_gpu(p, options);
+    auto x = run_cpu(p, inputs);
+    auto y = run_gpu(p, options, inputs);
 
     std::size_t output_num = x.size();
     for(std::size_t i = 0; i < output_num; ++i)
@@ -105,7 +96,7 @@ void verify_instructions(const program& prog, compile_options options, double to
         {
             std::cout << "Verify: " << ins.name() << std::endl;
             std::cout << p << std::endl;
-            verify_program(ins.name(), p, options, tolerance);
+            verify_program(ins.name(), p, options, create_param_map(p, false), tolerance);
         }
         catch(...)
         {
@@ -115,21 +106,21 @@ void verify_instructions(const program& prog, compile_options options, double to
     }
 }
 
-void verify_reduced(program p, int n, compile_options options, double tolerance)
+void verify_reduced(program p, int n, compile_options options, program::parameter_map inputs, double tolerance)
 {
     auto last = std::prev(p.end(), n + 1);
     p.remove_instructions(last, p.end());
     std::cout << "Verify: " << std::endl;
     std::cout << p << std::endl;
-    verify_program(std::to_string(n), p, options, tolerance);
+    verify_program(std::to_string(n), p, options, inputs, tolerance);
 }
 
-void verify_reduced_program(const program& p, compile_options options, double tolerance)
+void verify_reduced_program(const program& p, compile_options options, program::parameter_map inputs, double tolerance)
 {
     auto n = std::distance(p.begin(), p.end());
     for(std::size_t i = 0; i < n; i++)
     {
-        verify_reduced(p, i, options, tolerance);
+        verify_reduced(p, i, options, inputs, tolerance);
     }
 }
 

--- a/src/driver/verify.cpp
+++ b/src/driver/verify.cpp
@@ -108,8 +108,11 @@ void verify_instructions(const program& prog, compile_options options, double to
     }
 }
 
-void verify_reduced(
-    program p, int n, compile_options options, const program::parameter_map& inputs, double tolerance)
+void verify_reduced(program p,
+                    int n,
+                    compile_options options,
+                    const program::parameter_map& inputs,
+                    double tolerance)
 {
     auto last = std::prev(p.end(), n + 1);
     p.remove_instructions(last, p.end());

--- a/src/driver/verify.hpp
+++ b/src/driver/verify.hpp
@@ -11,16 +11,16 @@ std::vector<argument> run_cpu(program p);
 std::vector<argument> run_gpu(program p);
 void verify_program(const std::string& name,
                     const program& p,
-                    compile_options options = compile_options{},
+                    compile_options options       = compile_options{},
                     program::parameter_map inputs = {},
-                    double tolerance        = 100);
+                    double tolerance              = 100);
 void verify_instructions(const program& prog,
                          compile_options options = compile_options{},
                          double tolerance        = 80);
 void verify_reduced_program(const program& p,
-                            compile_options options = compile_options{},
+                            compile_options options       = compile_options{},
                             program::parameter_map inputs = {},
-                            double tolerance        = 80);
+                            double tolerance              = 80);
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace driver

--- a/src/driver/verify.hpp
+++ b/src/driver/verify.hpp
@@ -12,12 +12,14 @@ std::vector<argument> run_gpu(program p);
 void verify_program(const std::string& name,
                     const program& p,
                     compile_options options = compile_options{},
+                    program::parameter_map inputs = {},
                     double tolerance        = 100);
 void verify_instructions(const program& prog,
                          compile_options options = compile_options{},
                          double tolerance        = 80);
 void verify_reduced_program(const program& p,
                             compile_options options = compile_options{},
+                            program::parameter_map inputs = {},
                             double tolerance        = 80);
 
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/driver/verify.hpp
+++ b/src/driver/verify.hpp
@@ -11,16 +11,16 @@ std::vector<argument> run_cpu(program p);
 std::vector<argument> run_gpu(program p);
 void verify_program(const std::string& name,
                     const program& p,
-                    compile_options options       = compile_options{},
+                    compile_options options              = compile_options{},
                     const program::parameter_map& inputs = {},
-                    double tolerance              = 100);
+                    double tolerance                     = 100);
 void verify_instructions(const program& prog,
                          compile_options options = compile_options{},
                          double tolerance        = 80);
 void verify_reduced_program(const program& p,
-                            compile_options options       = compile_options{},
+                            compile_options options              = compile_options{},
                             const program::parameter_map& inputs = {},
-                            double tolerance              = 80);
+                            double tolerance                     = 80);
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace driver

--- a/src/driver/verify.hpp
+++ b/src/driver/verify.hpp
@@ -12,14 +12,14 @@ std::vector<argument> run_gpu(program p);
 void verify_program(const std::string& name,
                     const program& p,
                     compile_options options       = compile_options{},
-                    program::parameter_map inputs = {},
+                    const program::parameter_map& inputs = {},
                     double tolerance              = 100);
 void verify_instructions(const program& prog,
                          compile_options options = compile_options{},
                          double tolerance        = 80);
 void verify_reduced_program(const program& p,
                             compile_options options       = compile_options{},
-                            program::parameter_map inputs = {},
+                            const program::parameter_map& inputs = {},
                             double tolerance              = 80);
 
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/include/migraphx/verify_args.hpp
+++ b/src/include/migraphx/verify_args.hpp
@@ -8,81 +8,10 @@
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
-inline bool verify_args(const std::string& name,
+bool verify_args(const std::string& name,
                         const argument& cpu_arg,
                         const argument& gpu_arg,
-                        double tolerance = 80)
-{
-    bool passed = true;
-    visit_all(cpu_arg, gpu_arg)([&](auto cpu, auto gpu) {
-        double error;
-        passed = verify_range(cpu, gpu, tolerance, &error);
-        if(not passed)
-        {
-            // TODO: Check for nans
-            std::cout << "FAILED: " << name << std::endl;
-            std::cout << "error: " << error << std::endl;
-            if(cpu.size() < 32)
-                std::cout << "cpu:" << cpu << std::endl;
-            if(gpu.size() < 32)
-                std::cout << "gpu:" << gpu << std::endl;
-            if(range_zero(cpu))
-                std::cout << "Cpu data is all zeros" << std::endl;
-            if(range_zero(gpu))
-                std::cout << "Gpu data is all zeros" << std::endl;
-
-            auto mxdiff = max_diff(cpu, gpu);
-            std::cout << "Max diff: " << mxdiff << std::endl;
-
-            auto idx = mismatch_idx(cpu, gpu, float_equal);
-            if(idx < range_distance(cpu))
-            {
-                std::cout << "Mismatch at " << idx << ": " << cpu[idx] << " != " << gpu[idx]
-                          << std::endl;
-            }
-
-            auto cpu_nan_idx = find_idx(cpu, not_finite);
-            if(cpu_nan_idx >= 0)
-                std::cout << "Non finite number found in cpu at " << cpu_nan_idx << ": "
-                          << cpu[cpu_nan_idx] << std::endl;
-
-            auto gpu_nan_idx = find_idx(gpu, not_finite);
-            if(gpu_nan_idx >= 0)
-                std::cout << "Non finite number found in gpu at " << gpu_nan_idx << ": "
-                          << gpu[gpu_nan_idx] << std::endl;
-            std::cout << std::endl;
-        }
-        else
-        {
-            if(range_zero(cpu))
-                std::cout << "Cpu data is all zeros" << std::endl;
-            if(range_zero(gpu))
-                std::cout << "Gpu data is all zeros" << std::endl;
-
-            // auto mxdiff = max_diff(cpu, gpu);
-            // std::cout << "Max diff: " << mxdiff << std::endl;
-
-            // auto idx = mismatch_idx(cpu, gpu, float_equal);
-            // if(idx < range_distance(cpu))
-            // {
-            //     std::cout << "Mismatch at " << idx << ": " << cpu[idx] << " != " << gpu[idx]
-            //               << std::endl;
-            // }
-
-            auto cpu_nan_idx = find_idx(cpu, not_finite);
-            if(cpu_nan_idx >= 0)
-                std::cout << "Non finite number found in cpu at " << cpu_nan_idx << ": "
-                          << cpu[cpu_nan_idx] << std::endl;
-
-            auto gpu_nan_idx = find_idx(gpu, not_finite);
-            if(gpu_nan_idx >= 0)
-                std::cout << "Non finite number found in gpu at " << gpu_nan_idx << ": "
-                          << gpu[gpu_nan_idx] << std::endl;
-            // std::cout << std::endl;
-        }
-    });
-    return passed;
-}
+                        double tolerance = 80);
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/include/migraphx/verify_args.hpp
+++ b/src/include/migraphx/verify_args.hpp
@@ -9,9 +9,9 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
 bool verify_args(const std::string& name,
-                        const argument& cpu_arg,
-                        const argument& gpu_arg,
-                        double tolerance = 80);
+                 const argument& cpu_arg,
+                 const argument& gpu_arg,
+                 double tolerance = 80);
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/targets/gpu/device/layernorm.cpp
+++ b/src/targets/gpu/device/layernorm.cpp
@@ -42,13 +42,13 @@ void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
 
             auto m =
                 block_reduce<max_block_size>(idx, sum{}, 0, relements_v, [&](auto) { return x; }) /
-                relements;
+                value_type(relements);
 
             x = x - m;
 
             auto r = (block_reduce<max_block_size>(
                           idx, sum{}, 0, relements, [&](auto) { return x * x; }) /
-                      relements) +
+                      value_type(relements)) +
                      value_type(1e-12);
 
             value_type eps;

--- a/src/targets/gpu/device/layernorm.cpp
+++ b/src/targets/gpu/device/layernorm.cpp
@@ -8,147 +8,44 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 namespace device {
 
-#define BLOCK_SIZE 1024
+template <class T>
+struct vector_type {};
+
+template <class T, index_int N>
+struct vector_type<vec<T, N>> { using type = T; };
+
+template <class T>
+using vector_type_t = typename vector_type<T>::type;
 
 // m = x - mean(x)
 // m / sqrt(mean(m ^ 2) + 1e-12)
-void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
+
+template<index_int N>
+void layernorm_vec_impl(hipStream_t stream, const argument& result, const argument& arg1, index_int nelements, index_int relements)
 {
-    auto relements = arg1.get_shape().lens().back();
-    assert(relements <= 1024);
-    auto nelements    = result.get_shape().elements() / relements;
-    auto input_shape  = arg1.get_shape();
-    auto output_shape = result.get_shape();
-    auto reduce_output_lens(output_shape.lens());
-    reduce_output_lens.back() = 1;
-
-    std::vector<index_int> reduce_lens = get_reduce_lens(input_shape.lens(), reduce_output_lens);
-    const index_int vec_size           = 4;
-    assert((nelements % vec_size) == 0);
-    assert((relements % vec_size) == 0);
-    auto nelements_v = nelements / vec_size;
-    auto relements_v = relements / vec_size;
-
-    // std::cout << "nelements: " << nelements << ", " << nelements_v << std::endl;
-    // std::cout << "relements: " << relements << ", " << relements_v << std::endl;
-
-#if BLOCK_SIZE == 1024
-    hip_visit_all(result, arg1)([&](auto output, auto input) {
+    hip_vec_visit_all<N>(result, arg1)([&](auto output, auto input) {
         using value_type = typename decltype(input)::value_type;
 
-        const std::size_t max_block_size = 1024;
-        const std::size_t block_size     = compute_block_size(relements, max_block_size);
-        const std::size_t block_size_div = encode_divisor(block_size);
-
-        gs_launch(stream, nelements * block_size, block_size)([=](auto i, auto idx) __device__ {
-            const auto out_idx   = fast_div(i, block_size_div);
-            const auto base_idx  = out_idx * relements;
-            const auto input_idx = base_idx + idx.local;
-            const bool in_range  = idx.local < relements;
-
-            auto mean = [&](auto z) {
-                return block_reduce<max_block_size>(
-                           idx, sum{}, value_type(0), relements, [=](auto) { return z; }) /
-                       relements;
-            };
-
-            // m = x - mean(x)
-            value_type x = in_range ? input.data()[input_idx] : 0;
-            value_type m = x - mean(x);
-
-            // mean(m ^ 2) + 1e-12
-            value_type r = mean(m * m) + 1e-12;
-
-            // m * rsqrt(mean(m ^ 2) + 1e-12)
-            if(in_range)
-                output.data()[input_idx] = m * ::rsqrt(r);
-        });
-
-    });
-#elif BLOCK_SIZE == 256
-    hip_visit_all(result, arg1)([&](auto output, auto input) {
-        using value_type = typename decltype(input)::value_type;
-
-        const std::size_t max_block_size = 256;
-        const std::size_t block_size     = compute_block_size(relements, max_block_size);
-        const std::size_t block_size_div = encode_divisor(block_size);
-
-        gs_launch(stream, nelements * block_size, block_size)([=](auto i, auto idx) __device__ {
-            const auto out_idx  = fast_div(i, block_size_div);
-            const auto base_idx = out_idx * relements;
-            value_type x_data[4];
-            auto with_x = [&](auto f) {
-                int offset = 0;
-                return [=, &x_data](auto j) mutable { return f(x_data[offset++], j); };
-            };
-
-            idx.local_stride(relements,
-                             with_x([&](auto& x, auto j) { x = input.data()[base_idx + j]; }));
-
-            auto m = block_reduce<max_block_size>(
-                         idx, sum{}, 0, relements, with_x([](auto& x, auto) { return x; })) /
-                     relements;
-
-            idx.local_stride(relements, with_x([&](auto& x, auto) { x = x - m; }));
-
-            auto r = block_reduce<max_block_size>(
-                         idx, sum{}, 0, relements, with_x([&](auto& x, auto) { return x * x; })) /
-                     relements;
-
-            const auto eps = ::rsqrt(r + 1e-12);
-            idx.local_stride(
-                relements, with_x([&](auto& x, auto j) { output.data()[base_idx + j] = x * eps; }));
-
-        });
-    });
-#else
-
-    hip_vec_visit_all<vec_size>(result, arg1)([&](auto output, auto input) {
-        std::cout << "******************** hip_vec_visit_all ********************" << std::endl;
-        using value_type = typename decltype(input)::value_type;
-
+        const auto relements_v = relements / N;
         const std::size_t max_block_size = 256;
         const std::size_t block_size     = compute_block_size(relements_v, max_block_size);
         const std::size_t block_size_div = encode_divisor(block_size);
-        const auto ielements_v           = result.get_shape().elements() / vec_size;
-        assert(relements_v < block_size);
+        assert(relements_v <= block_size);
 
-        std::cout << "block_size: " << block_size << std::endl;
-        std::cout << "relements: " << relements << std::endl;
-        std::cout << "relements_v: " << relements_v << std::endl;
-        std::cout << "nelements: " << nelements << std::endl;
-        std::cout << "nelements_v: " << nelements_v << std::endl;
-
-        for(int global = 0; global < nelements_v; global++)
-        {
-            std::cout << "global: " << global << std::endl;
-            for(int local = 0; local < block_size; local++)
-            {
-                int i                = global * block_size + local;
-                const auto out_idx   = fast_div(i, block_size_div);
-                const auto base_idx  = out_idx * relements_v;
-                const auto input_idx = base_idx + local;
-                const bool in_range  = input_idx < ielements_v;
-                if(local >= relements_v)
-                    continue;
-                std::cout << "input_idx: " << input_idx << " {";
-                std::cout << "i=" << i << ", ";
-                std::cout << "base_idx=" << base_idx << ", ";
-                std::cout << "out_idx=" << out_idx << ", ";
-                std::cout << "}" << std::endl;
-            }
-        }
-
-        gs_launch(stream, nelements_v * block_size, block_size)([=](auto i, auto idx) __device__ {
+        gs_launch(stream, nelements * block_size, block_size)([=](auto i, auto idx) __device__ {
             const auto out_idx   = fast_div(i, block_size_div);
             const auto base_idx  = out_idx * relements_v;
             const auto input_idx = base_idx + idx.local;
             const bool in_range  = idx.local < relements_v;
 
-            auto mean = [&](auto z) -> value_type {
-                return block_reduce<max_block_size>(
-                           idx, sum{}, value_type(0), relements_v, [=](auto) { return z; }) /
-                       value_type(relements);
+            auto mean = [&](auto z) {
+                auto psum = block_reduce<max_block_size>(
+                           idx, sum{}, value_type(0), relements_v, [=](auto) { return z; });
+                vector_type_t<value_type> sum = 0;
+                for(index_int k = 0; k < vec_size; k++)
+                    sum += psum[k];
+                return sum / relements;
+
             };
 
             // m = x - mean(x)
@@ -166,9 +63,60 @@ void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
             if(in_range)
                 output.data()[input_idx] = m * d;
         });
-
     });
-#endif
+}
+
+void layernorm_impl(hipStream_t stream, const argument& result, const argument& arg1, index_int nelements, index_int relements)
+{
+    hip_visit_all(result, arg1)([&](auto output, auto input) {
+        using value_type = typename decltype(input)::value_type;
+
+        const std::size_t max_block_size = 256;
+        const std::size_t block_size     = compute_block_size(relements, max_block_size);
+        const std::size_t block_size_div = encode_divisor(block_size);
+        assert(relements <= block_size);
+
+        gs_launch(stream, nelements * block_size, block_size)([=](auto i, auto idx) __device__ {
+            const auto out_idx   = fast_div(i, block_size_div);
+            const auto base_idx  = out_idx * relements;
+            const auto input_idx = base_idx + idx.local;
+            const bool in_range  = idx.local < relements;
+
+            auto mean = [&](auto z) {
+                return block_reduce<max_block_size>(
+                           idx, sum{}, value_type(0), relements, [=](auto) { return in_range ? z : 0; }) /
+                       relements;
+            };
+
+            // m = x - mean(x)
+            value_type x = in_range ? input.data()[input_idx] : 0;
+            value_type m = x - mean(x);
+
+            // mean(m ^ 2) + 1e-12
+            value_type r = mean(m * m) + 1e-12;
+
+            // m * rsqrt(mean(m ^ 2) + 1e-12)
+            if(in_range)
+                output.data()[input_idx] = m * ::rsqrt(r);
+        });
+    });
+}
+
+void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
+{
+    auto relements = arg1.get_shape().lens().back();
+    auto nelements    = result.get_shape().elements() / relements;
+    auto input_shape  = arg1.get_shape();
+    auto output_shape = result.get_shape();
+    auto reduce_output_lens(output_shape.lens());
+    reduce_output_lens.back() = 1;
+
+    if ((relements % 4) == 0)
+        layernorm_vec_impl<4>(stream, result, arg1, nelements, relements);
+    else if (relements < 256)
+        layernorm_impl(stream, result, arg1, nelements, relements);
+    else
+        MIGRAPHX_THROW("No kernel for layernorm");
 }
 
 } // namespace device

--- a/src/targets/gpu/device/layernorm.cpp
+++ b/src/targets/gpu/device/layernorm.cpp
@@ -65,7 +65,7 @@ void layernorm_vec_impl(hipStream_t stream,
             value_type r = mean(m * m) + value_type(1e-12);
 
             // rsqrt(mean(m ^ 2) + 1e-12)
-            value_type d;
+            value_type d = 0;
             for(index_int k = 0; k < N; k++)
                 d[k] = ::rsqrt(r[k]);
             // m * rsqrt(mean(m ^ 2) + 1e-12)
@@ -122,7 +122,6 @@ void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
 {
     auto relements    = arg1.get_shape().lens().back();
     auto nelements    = result.get_shape().elements() / relements;
-    auto input_shape  = arg1.get_shape();
     auto output_shape = result.get_shape();
     auto reduce_output_lens(output_shape.lens());
     reduce_output_lens.back() = 1;

--- a/src/targets/gpu/device/layernorm.cpp
+++ b/src/targets/gpu/device/layernorm.cpp
@@ -15,8 +15,6 @@ namespace device {
 void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
 {
     auto relements = arg1.get_shape().lens().back();
-    if (relements > 1024)
-        MIGRAPHX_THROW("relements: " + std::to_string(relements));
     assert(relements <= 1024);
     auto nelements    = result.get_shape().elements() / relements;
     auto input_shape  = arg1.get_shape();

--- a/src/targets/gpu/device/layernorm.cpp
+++ b/src/targets/gpu/device/layernorm.cpp
@@ -51,7 +51,7 @@ void layernorm_vec_impl(hipStream_t stream,
                 auto psum = block_reduce<max_block_size>(
                     idx, sum{}, value_type(0), relements_v, [=](auto) { return z; });
                 vector_type_t<value_type> sum = 0;
-                for(index_int k = 0; k < vec_size; k++)
+                for(index_int k = 0; k < N; k++)
                     sum += psum[k];
                 return sum / relements;
 
@@ -66,7 +66,7 @@ void layernorm_vec_impl(hipStream_t stream,
 
             // rsqrt(mean(m ^ 2) + 1e-12)
             value_type d;
-            for(index_int k = 0; k < vec_size; k++)
+            for(index_int k = 0; k < N; k++)
                 d[k] = ::rsqrt(r[k]);
             // m * rsqrt(mean(m ^ 2) + 1e-12)
             if(in_range)

--- a/src/targets/gpu/device/layernorm.cpp
+++ b/src/targets/gpu/device/layernorm.cpp
@@ -41,13 +41,15 @@ void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
         const std::size_t block_size_div = encode_divisor(block_size);
 
         gs_launch(stream, nelements * block_size, block_size)([=](auto i, auto idx) __device__ {
-            const auto out_idx  = fast_div(i, block_size_div);
-            const auto base_idx = out_idx * relements;
-            const auto input_idx = base_idx+idx.local;
-            const bool in_range = idx.local < relements;
+            const auto out_idx   = fast_div(i, block_size_div);
+            const auto base_idx  = out_idx * relements;
+            const auto input_idx = base_idx + idx.local;
+            const bool in_range  = idx.local < relements;
 
             auto mean = [&](auto z) {
-                return block_reduce<max_block_size>(idx, sum{}, value_type(0), relements, [=](auto) { return z; }) / relements;
+                return block_reduce<max_block_size>(
+                           idx, sum{}, value_type(0), relements, [=](auto) { return z; }) /
+                       relements;
             };
 
             // m = x - mean(x)
@@ -55,10 +57,10 @@ void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
             value_type m = x - mean(x);
 
             // mean(m ^ 2) + 1e-12
-            value_type r = mean(m*m) + 1e-12;
+            value_type r = mean(m * m) + 1e-12;
 
             // m * rsqrt(mean(m ^ 2) + 1e-12)
-            if (in_range)
+            if(in_range)
                 output.data()[input_idx] = m * ::rsqrt(r);
         });
 
@@ -108,7 +110,7 @@ void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
         const std::size_t max_block_size = 256;
         const std::size_t block_size     = compute_block_size(relements_v, max_block_size);
         const std::size_t block_size_div = encode_divisor(block_size);
-        const auto ielements_v = result.get_shape().elements() / vec_size;
+        const auto ielements_v           = result.get_shape().elements() / vec_size;
         assert(relements_v < block_size);
 
         std::cout << "block_size: " << block_size << std::endl;
@@ -117,15 +119,17 @@ void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
         std::cout << "nelements: " << nelements << std::endl;
         std::cout << "nelements_v: " << nelements_v << std::endl;
 
-        for(int global=0;global<nelements_v;global++) {
+        for(int global = 0; global < nelements_v; global++)
+        {
             std::cout << "global: " << global << std::endl;
-            for(int local=0;local<block_size;local++) {
-                int i = global*block_size+local;
-                const auto out_idx  = fast_div(i, block_size_div);
-                const auto base_idx = out_idx * relements_v;
-                const auto input_idx = base_idx+local;
-                const bool in_range = input_idx < ielements_v;
-                if (local >= relements_v)
+            for(int local = 0; local < block_size; local++)
+            {
+                int i                = global * block_size + local;
+                const auto out_idx   = fast_div(i, block_size_div);
+                const auto base_idx  = out_idx * relements_v;
+                const auto input_idx = base_idx + local;
+                const bool in_range  = input_idx < ielements_v;
+                if(local >= relements_v)
                     continue;
                 std::cout << "input_idx: " << input_idx << " {";
                 std::cout << "i=" << i << ", ";
@@ -136,13 +140,15 @@ void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
         }
 
         gs_launch(stream, nelements_v * block_size, block_size)([=](auto i, auto idx) __device__ {
-            const auto out_idx  = fast_div(i, block_size_div);
-            const auto base_idx = out_idx * relements_v;
-            const auto input_idx = base_idx+idx.local;
-            const bool in_range = idx.local < relements_v;
+            const auto out_idx   = fast_div(i, block_size_div);
+            const auto base_idx  = out_idx * relements_v;
+            const auto input_idx = base_idx + idx.local;
+            const bool in_range  = idx.local < relements_v;
 
             auto mean = [&](auto z) -> value_type {
-                return block_reduce<max_block_size>(idx, sum{}, value_type(0), relements_v, [=](auto) { return z; }) / value_type(relements);
+                return block_reduce<max_block_size>(
+                           idx, sum{}, value_type(0), relements_v, [=](auto) { return z; }) /
+                       value_type(relements);
             };
 
             // m = x - mean(x)
@@ -150,14 +156,14 @@ void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
             value_type m = x - mean(x);
 
             // mean(m ^ 2) + 1e-12
-            value_type r = mean(m*m) + value_type(1e-12);
+            value_type r = mean(m * m) + value_type(1e-12);
 
             // rsqrt(mean(m ^ 2) + 1e-12)
             value_type d;
             for(index_int k = 0; k < vec_size; k++)
                 d[k] = ::rsqrt(r[k]);
             // m * rsqrt(mean(m ^ 2) + 1e-12)
-            if (in_range)
+            if(in_range)
                 output.data()[input_idx] = m * d;
         });
 

--- a/src/targets/gpu/device/layernorm.cpp
+++ b/src/targets/gpu/device/layernorm.cpp
@@ -25,27 +25,35 @@ void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
     hip_visit_all(result, arg1)([&](auto output, auto input) {
         using value_type = typename decltype(input)::value_type;
 
-        const std::size_t max_block_size = 1024;
+        const std::size_t max_block_size = 256;
         const std::size_t block_size     = compute_block_size(relements, max_block_size);
         const std::size_t block_size_div = encode_divisor(block_size);
 
         gs_launch(stream, nelements * block_size, block_size)([=](auto i, auto idx) __device__ {
             const auto out_idx  = fast_div(i, block_size_div);
             const auto base_idx = out_idx * relements;
-            value_type x        = input.data()[base_idx];
+            value_type x_data[4];
+            auto with_x = [&](auto f) {
+                int offset = 0;
+                return [=, &x_data](auto j) mutable { return f(x_data[offset++], j); };
+            };
 
-            auto m =
-                block_reduce<max_block_size>(idx, sum{}, 0, relements, [&](auto) { return x; }) /
-                relements;
+            idx.local_stride(relements,
+                             with_x([&](auto& x, auto j) { x = input.data()[base_idx + j]; }));
 
-            x = x - m;
-
-            auto r = block_reduce<max_block_size>(
-                         idx, sum{}, 0, relements, [&](auto) { return x * x; }) /
+            auto m = block_reduce<max_block_size>(
+                         idx, sum{}, 0, relements, with_x([](auto& x, auto) { return x; })) /
                      relements;
 
-            const auto eps          = ::rsqrt(r + 1e-12);
-            output.data()[base_idx] = x * eps;
+            idx.local_stride(relements, with_x([&](auto& x, auto) { x = x - m; }));
+
+            auto r = block_reduce<max_block_size>(
+                         idx, sum{}, 0, relements, with_x([&](auto& x, auto) { return x * x; })) /
+                     relements;
+
+            const auto eps = ::rsqrt(r + 1e-12);
+            idx.local_stride(
+                relements, with_x([&](auto& x, auto j) { output.data()[base_idx + j] = x * eps; }));
 
         });
 

--- a/src/targets/gpu/device/layernorm.cpp
+++ b/src/targets/gpu/device/layernorm.cpp
@@ -8,11 +8,15 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 namespace device {
 
+#define BLOCK_SIZE 1024
+
 // m = x - mean(x)
 // m / sqrt(mean(m ^ 2) + 1e-12)
 void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
 {
     auto relements = arg1.get_shape().lens().back();
+    if (relements > 1024)
+        MIGRAPHX_THROW("relements: " + std::to_string(relements));
     assert(relements <= 1024);
     auto nelements    = result.get_shape().elements() / relements;
     auto input_shape  = arg1.get_shape();
@@ -27,37 +31,140 @@ void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
     auto nelements_v = nelements / vec_size;
     auto relements_v = relements / vec_size;
 
+    // std::cout << "nelements: " << nelements << ", " << nelements_v << std::endl;
+    // std::cout << "relements: " << relements << ", " << relements_v << std::endl;
+
+#if BLOCK_SIZE == 1024
+    hip_visit_all(result, arg1)([&](auto output, auto input) {
+        using value_type = typename decltype(input)::value_type;
+
+        const std::size_t max_block_size = 1024;
+        const std::size_t block_size     = compute_block_size(relements, max_block_size);
+        const std::size_t block_size_div = encode_divisor(block_size);
+
+        gs_launch(stream, nelements * block_size, block_size)([=](auto i, auto idx) __device__ {
+            const auto out_idx  = fast_div(i, block_size_div);
+            const auto base_idx = out_idx * relements;
+            const auto input_idx = base_idx+idx.local;
+            const bool in_range = idx.local < relements;
+
+            auto mean = [&](auto z) {
+                return block_reduce<max_block_size>(idx, sum{}, value_type(0), relements, [=](auto) { return z; }) / relements;
+            };
+
+            // m = x - mean(x)
+            value_type x = in_range ? input.data()[input_idx] : 0;
+            value_type m = x - mean(x);
+
+            // mean(m ^ 2) + 1e-12
+            value_type r = mean(m*m) + 1e-12;
+
+            // m * rsqrt(mean(m ^ 2) + 1e-12)
+            if (in_range)
+                output.data()[input_idx] = m * ::rsqrt(r);
+        });
+
+    });
+#elif BLOCK_SIZE == 256
+    hip_visit_all(result, arg1)([&](auto output, auto input) {
+        using value_type = typename decltype(input)::value_type;
+
+        const std::size_t max_block_size = 256;
+        const std::size_t block_size     = compute_block_size(relements, max_block_size);
+        const std::size_t block_size_div = encode_divisor(block_size);
+
+        gs_launch(stream, nelements * block_size, block_size)([=](auto i, auto idx) __device__ {
+            const auto out_idx  = fast_div(i, block_size_div);
+            const auto base_idx = out_idx * relements;
+            value_type x_data[4];
+            auto with_x = [&](auto f) {
+                int offset = 0;
+                return [=, &x_data](auto j) mutable { return f(x_data[offset++], j); };
+            };
+
+            idx.local_stride(relements,
+                             with_x([&](auto& x, auto j) { x = input.data()[base_idx + j]; }));
+
+            auto m = block_reduce<max_block_size>(
+                         idx, sum{}, 0, relements, with_x([](auto& x, auto) { return x; })) /
+                     relements;
+
+            idx.local_stride(relements, with_x([&](auto& x, auto) { x = x - m; }));
+
+            auto r = block_reduce<max_block_size>(
+                         idx, sum{}, 0, relements, with_x([&](auto& x, auto) { return x * x; })) /
+                     relements;
+
+            const auto eps = ::rsqrt(r + 1e-12);
+            idx.local_stride(
+                relements, with_x([&](auto& x, auto j) { output.data()[base_idx + j] = x * eps; }));
+
+        });
+    });
+#else
+
     hip_vec_visit_all<vec_size>(result, arg1)([&](auto output, auto input) {
+        std::cout << "******************** hip_vec_visit_all ********************" << std::endl;
         using value_type = typename decltype(input)::value_type;
 
         const std::size_t max_block_size = 256;
         const std::size_t block_size     = compute_block_size(relements_v, max_block_size);
         const std::size_t block_size_div = encode_divisor(block_size);
+        const auto ielements_v = result.get_shape().elements() / vec_size;
+        assert(relements_v < block_size);
+
+        std::cout << "block_size: " << block_size << std::endl;
+        std::cout << "relements: " << relements << std::endl;
+        std::cout << "relements_v: " << relements_v << std::endl;
+        std::cout << "nelements: " << nelements << std::endl;
+        std::cout << "nelements_v: " << nelements_v << std::endl;
+
+        for(int global=0;global<nelements_v;global++) {
+            std::cout << "global: " << global << std::endl;
+            for(int local=0;local<block_size;local++) {
+                int i = global*block_size+local;
+                const auto out_idx  = fast_div(i, block_size_div);
+                const auto base_idx = out_idx * relements_v;
+                const auto input_idx = base_idx+local;
+                const bool in_range = input_idx < ielements_v;
+                if (local >= relements_v)
+                    continue;
+                std::cout << "input_idx: " << input_idx << " {";
+                std::cout << "i=" << i << ", ";
+                std::cout << "base_idx=" << base_idx << ", ";
+                std::cout << "out_idx=" << out_idx << ", ";
+                std::cout << "}" << std::endl;
+            }
+        }
 
         gs_launch(stream, nelements_v * block_size, block_size)([=](auto i, auto idx) __device__ {
             const auto out_idx  = fast_div(i, block_size_div);
             const auto base_idx = out_idx * relements_v;
+            const auto input_idx = base_idx+idx.local;
+            const bool in_range = idx.local < relements_v;
 
-            value_type x = input.data()[base_idx];
+            auto mean = [&](auto z) -> value_type {
+                return block_reduce<max_block_size>(idx, sum{}, value_type(0), relements_v, [=](auto) { return z; }) / value_type(relements);
+            };
 
-            auto m =
-                block_reduce<max_block_size>(idx, sum{}, 0, relements_v, [&](auto) { return x; }) /
-                value_type(relements);
+            // m = x - mean(x)
+            value_type x = in_range ? input.data()[input_idx] : 0;
+            value_type m = x - mean(x);
 
-            x = x - m;
+            // mean(m ^ 2) + 1e-12
+            value_type r = mean(m*m) + value_type(1e-12);
 
-            auto r = (block_reduce<max_block_size>(
-                          idx, sum{}, 0, relements, [&](auto) { return x * x; }) /
-                      value_type(relements)) +
-                     value_type(1e-12);
-
-            value_type eps;
+            // rsqrt(mean(m ^ 2) + 1e-12)
+            value_type d;
             for(index_int k = 0; k < vec_size; k++)
-                eps[k] = ::rsqrt(r[k]);
-            output.data()[base_idx] = x * eps;
+                d[k] = ::rsqrt(r[k]);
+            // m * rsqrt(mean(m ^ 2) + 1e-12)
+            if (in_range)
+                output.data()[input_idx] = m * d;
         });
 
     });
+#endif
 }
 
 } // namespace device

--- a/src/targets/gpu/device/layernorm.cpp
+++ b/src/targets/gpu/device/layernorm.cpp
@@ -21,7 +21,7 @@ void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
     reduce_output_lens.back() = 1;
 
     std::vector<index_int> reduce_lens = get_reduce_lens(input_shape.lens(), reduce_output_lens);
-    const index_int vec_size     = 4;
+    const index_int vec_size           = 4;
     assert((nelements % vec_size) == 0);
     assert((relements % vec_size) == 0);
     auto nelements_v = nelements / vec_size;
@@ -40,18 +40,19 @@ void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
 
             value_type x = input.data()[base_idx];
 
-            auto m = block_reduce<max_block_size>(
-                         idx, sum{}, 0, relements_v, [&](auto) { return x; }) /
-                     relements;
+            auto m =
+                block_reduce<max_block_size>(idx, sum{}, 0, relements_v, [&](auto) { return x; }) /
+                relements;
 
             x = x - m;
 
             auto r = (block_reduce<max_block_size>(
-                                     idx, sum{}, 0, relements, [&](auto) { return x*x; }) /
-                                 relements) + value_type(1e-12);
+                          idx, sum{}, 0, relements, [&](auto) { return x * x; }) /
+                      relements) +
+                     value_type(1e-12);
 
             value_type eps;
-            for(index_int k=0;k<vec_size;k++)
+            for(index_int k = 0; k < vec_size; k++)
                 eps[k] = ::rsqrt(r[k]);
             output.data()[base_idx] = x * eps;
         });

--- a/src/targets/gpu/device/layernorm.cpp
+++ b/src/targets/gpu/device/layernorm.cpp
@@ -32,19 +32,19 @@ void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
         gs_launch(stream, nelements * block_size, block_size)([=](auto i, auto idx) __device__ {
             const auto out_idx  = fast_div(i, block_size_div);
             const auto base_idx = out_idx * relements;
-            value_type x = input.data()[base_idx];
+            value_type x        = input.data()[base_idx];
 
-            auto m = block_reduce<max_block_size>(
-                         idx, sum{}, 0, relements, [&](auto) { return x; }) /
-                     relements;
+            auto m =
+                block_reduce<max_block_size>(idx, sum{}, 0, relements, [&](auto) { return x; }) /
+                relements;
 
             x = x - m;
 
             auto r = block_reduce<max_block_size>(
-                         idx, sum{}, 0, relements, [&](auto) { return x*x; }) /
+                         idx, sum{}, 0, relements, [&](auto) { return x * x; }) /
                      relements;
 
-            const auto eps = ::rsqrt(r + 1e-12);
+            const auto eps          = ::rsqrt(r + 1e-12);
             output.data()[base_idx] = x * eps;
 
         });

--- a/src/targets/gpu/device/layernorm.cpp
+++ b/src/targets/gpu/device/layernorm.cpp
@@ -25,35 +25,27 @@ void layernorm(hipStream_t stream, const argument& result, const argument& arg1)
     hip_visit_all(result, arg1)([&](auto output, auto input) {
         using value_type = typename decltype(input)::value_type;
 
-        const std::size_t max_block_size = 256;
+        const std::size_t max_block_size = 1024;
         const std::size_t block_size     = compute_block_size(relements, max_block_size);
         const std::size_t block_size_div = encode_divisor(block_size);
 
         gs_launch(stream, nelements * block_size, block_size)([=](auto i, auto idx) __device__ {
             const auto out_idx  = fast_div(i, block_size_div);
             const auto base_idx = out_idx * relements;
-            value_type x_data[4];
-            auto with_x = [&](auto f) {
-                int offset = 0;
-                return [=, &x_data](auto j) mutable { return f(x_data[offset++], j); };
-            };
-
-            idx.local_stride(relements,
-                             with_x([&](auto& x, auto j) { x = input.data()[base_idx + j]; }));
+            value_type x = input.data()[base_idx];
 
             auto m = block_reduce<max_block_size>(
-                         idx, sum{}, 0, relements, with_x([](auto& x, auto) { return x; })) /
+                         idx, sum{}, 0, relements, [&](auto) { return x; }) /
                      relements;
 
-            idx.local_stride(relements, with_x([&](auto& x, auto) { x = x - m; }));
+            x = x - m;
 
             auto r = block_reduce<max_block_size>(
-                         idx, sum{}, 0, relements, with_x([&](auto& x, auto) { return x * x; })) /
+                         idx, sum{}, 0, relements, [&](auto) { return x*x; }) /
                      relements;
 
             const auto eps = ::rsqrt(r + 1e-12);
-            idx.local_stride(
-                relements, with_x([&](auto& x, auto j) { output.data()[base_idx + j] = x * eps; }));
+            output.data()[base_idx] = x * eps;
 
         });
 

--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -234,8 +234,7 @@ MIGRAPHX_REGISTER_OP(hip_add_tanh)
 struct hip_layernorm : unary_device<hip_layernorm, &device::layernorm>
 {
     // Empty finalize to skip dimension reduction
-    void finalize(context&, const shape&, const std::vector<shape>&)
-    {}
+    void finalize(context&, const shape&, const std::vector<shape>&) {}
 };
 MIGRAPHX_REGISTER_OP(hip_layernorm)
 

--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -233,6 +233,9 @@ MIGRAPHX_REGISTER_OP(hip_add_tanh)
 
 struct hip_layernorm : unary_device<hip_layernorm, &device::layernorm>
 {
+    // Empty finalize to skip dimension reduction
+    void finalize(context&, const shape&, const std::vector<shape>&)
+    {}
 };
 MIGRAPHX_REGISTER_OP(hip_layernorm)
 

--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -327,7 +327,7 @@ struct find_layernorm
         auto args  = ins->inputs();
 
         // We dont fuse for non-standard layouts
-        if (not x_ins.get_shape().standard())
+        if(not x_ins.get_shape().standard())
             return;
 
         // We dont fuse layernorm for sizes larger than 1024

--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -334,15 +334,15 @@ struct find_layernorm
 
         auto relements = x_ins->get_shape().lens().back();
 
-        if(relements % 4 == 0) 
+        if(relements % 4 == 0)
         {
-          if(relements > 1024)
-            return;
+            if(relements > 1024)
+                return;
         }
         else
         {
             if(relements > 256)
-            return;
+                return;
         }
 
         p.replace_instruction(ins, hip_layernorm{}, x_ins, args.back());

--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -334,7 +334,7 @@ struct find_layernorm
 
         auto relements = x_ins->get_shape().lens().back();
 
-        if(relements > 1024 or (relements % 4 !=0 and relements > 256))
+        if(relements > 1024 or (relements % 4 != 0 and relements > 256))
             return;
 
         p.replace_instruction(ins, hip_layernorm{}, x_ins, args.back());

--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -326,6 +326,14 @@ struct find_layernorm
         auto x_ins = r.instructions["x"];
         auto args  = ins->inputs();
 
+        // We dont fuse for non-standard layouts
+        if (not x_ins.get_shape().standard())
+            return;
+
+        // We dont fuse layernorm for sizes larger than 1024
+        if(x_ins.get_shape().lens().back() > 1024)
+            return;
+
         p.replace_instruction(ins, hip_layernorm{}, x_ins, args.back());
     }
 };

--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -322,16 +322,17 @@ struct find_layernorm
 
     void apply(program& p, match::matcher_result r) const
     {
+        return;
         auto ins   = r.result;
         auto x_ins = r.instructions["x"];
         auto args  = ins->inputs();
 
         // We dont fuse for non-standard layouts
-        if(not x_ins.get_shape().standard())
+        if(not x_ins->get_shape().standard())
             return;
 
         // We dont fuse layernorm for sizes larger than 1024
-        if(x_ins.get_shape().lens().back() > 1024)
+        if(x_ins->get_shape().lens().back() > 1024)
             return;
 
         p.replace_instruction(ins, hip_layernorm{}, x_ins, args.back());

--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -334,16 +334,8 @@ struct find_layernorm
 
         auto relements = x_ins->get_shape().lens().back();
 
-        if(relements % 4 == 0)
-        {
-            if(relements > 1024)
-                return;
-        }
-        else
-        {
-            if(relements > 256)
-                return;
-        }
+        if(relements > 1024 or (relements % 4 !=0 and relements > 256))
+            return;
 
         p.replace_instruction(ins, hip_layernorm{}, x_ins, args.back());
     }

--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -332,9 +332,18 @@ struct find_layernorm
         if(not x_ins->get_shape().standard())
             return;
 
-        // We dont fuse layernorm for sizes larger than 1024
-        if(x_ins->get_shape().lens().back() > 1024)
+        auto relements = x_ins->get_shape().lens().back();
+
+        if(relements % 4 == 0) 
+        {
+          if(relements > 1024)
             return;
+        }
+        else
+        {
+            if(relements > 256)
+            return;
+        }
 
         p.replace_instruction(ins, hip_layernorm{}, x_ins, args.back());
     }

--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -322,7 +322,6 @@ struct find_layernorm
 
     void apply(program& p, match::matcher_result r) const
     {
-        return;
         auto ins   = r.result;
         auto x_ins = r.instructions["x"];
         auto args  = ins->inputs();

--- a/src/verify_args.cpp
+++ b/src/verify_args.cpp
@@ -1,0 +1,84 @@
+
+#include <migraphx/verify_args.hpp>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+
+bool verify_args(const std::string& name,
+                        const argument& cpu_arg,
+                        const argument& gpu_arg,
+                        double tolerance)
+{
+    bool passed = true;
+    visit_all(cpu_arg, gpu_arg)([&](auto cpu, auto gpu) {
+        double error;
+        passed = verify_range(cpu, gpu, tolerance, &error);
+        if(not passed)
+        {
+            // TODO: Check for nans
+            std::cout << "FAILED: " << name << std::endl;
+            std::cout << "error: " << error << std::endl;
+            if(cpu.size() < 32)
+                std::cout << "cpu:" << cpu << std::endl;
+            if(gpu.size() < 32)
+                std::cout << "gpu:" << gpu << std::endl;
+            if(range_zero(cpu))
+                std::cout << "Cpu data is all zeros" << std::endl;
+            if(range_zero(gpu))
+                std::cout << "Gpu data is all zeros" << std::endl;
+
+            auto mxdiff = max_diff(cpu, gpu);
+            std::cout << "Max diff: " << mxdiff << std::endl;
+
+            auto idx = mismatch_idx(cpu, gpu, float_equal);
+            if(idx < range_distance(cpu))
+            {
+                std::cout << "Mismatch at " << idx << ": " << cpu[idx] << " != " << gpu[idx]
+                          << std::endl;
+            }
+
+            auto cpu_nan_idx = find_idx(cpu, not_finite);
+            if(cpu_nan_idx >= 0)
+                std::cout << "Non finite number found in cpu at " << cpu_nan_idx << ": "
+                          << cpu[cpu_nan_idx] << std::endl;
+
+            auto gpu_nan_idx = find_idx(gpu, not_finite);
+            if(gpu_nan_idx >= 0)
+                std::cout << "Non finite number found in gpu at " << gpu_nan_idx << ": "
+                          << gpu[gpu_nan_idx] << std::endl;
+            std::cout << std::endl;
+        }
+        else
+        {
+            if(range_zero(cpu))
+                std::cout << "Cpu data is all zeros" << std::endl;
+            if(range_zero(gpu))
+                std::cout << "Gpu data is all zeros" << std::endl;
+
+            // auto mxdiff = max_diff(cpu, gpu);
+            // std::cout << "Max diff: " << mxdiff << std::endl;
+
+            // auto idx = mismatch_idx(cpu, gpu, float_equal);
+            // if(idx < range_distance(cpu))
+            // {
+            //     std::cout << "Mismatch at " << idx << ": " << cpu[idx] << " != " << gpu[idx]
+            //               << std::endl;
+            // }
+
+            auto cpu_nan_idx = find_idx(cpu, not_finite);
+            if(cpu_nan_idx >= 0)
+                std::cout << "Non finite number found in cpu at " << cpu_nan_idx << ": "
+                          << cpu[cpu_nan_idx] << std::endl;
+
+            auto gpu_nan_idx = find_idx(gpu, not_finite);
+            if(gpu_nan_idx >= 0)
+                std::cout << "Non finite number found in gpu at " << gpu_nan_idx << ": "
+                          << gpu[gpu_nan_idx] << std::endl;
+            // std::cout << std::endl;
+        }
+    });
+    return passed;
+}
+
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx

--- a/src/verify_args.cpp
+++ b/src/verify_args.cpp
@@ -5,9 +5,9 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
 bool verify_args(const std::string& name,
-                        const argument& cpu_arg,
-                        const argument& gpu_arg,
-                        double tolerance)
+                 const argument& cpu_arg,
+                 const argument& gpu_arg,
+                 double tolerance)
 {
     bool passed = true;
     visit_all(cpu_arg, gpu_arg)([&](auto cpu, auto gpu) {

--- a/test/gpu/ops_test.cpp
+++ b/test/gpu/ops_test.cpp
@@ -1035,18 +1035,80 @@ struct test_layernorm : verify_program<test_layernorm>
         migraphx::program p;
         std::vector<size_t> dims{1, 1, 5};
         auto x        = p.add_parameter("x", migraphx::shape{migraphx::shape::float_type, dims});
-        auto scale    = p.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {5}});
-        auto bias     = p.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {5}});
+        auto scale    = p.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
+        auto bias     = p.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
         auto epsilon  = p.add_literal(1e-12f);
-        auto exponent = p.add_literal(migraphx::literal{
-            migraphx::shape{migraphx::shape::float_type, {1, 1, 5}}, {2, 2, 2, 2, 2}});
+        auto exponent = p.add_literal(2.0f);
 
         auto mean           = p.add_instruction(migraphx::op::reduce_mean({2}), x);
         auto mean_mbcast    = p.add_instruction(migraphx::op::multibroadcast{{dims}}, mean);
         auto sub            = p.add_instruction(migraphx::op::sub{}, x, mean_mbcast);
-        auto pow            = p.add_instruction(migraphx::op::pow{}, sub, exponent);
+        auto exponent_mbcast = p.add_instruction(migraphx::op::multibroadcast{{dims}}, exponent);
+        auto pow            = p.add_instruction(migraphx::op::pow{}, sub, exponent_mbcast);
         auto var            = p.add_instruction(migraphx::op::reduce_mean({2}), pow);
-        auto epsilon_mbcast = p.add_instruction(migraphx::op::multibroadcast{{1, 1, 1}}, epsilon);
+        auto epsilon_mbcast = p.add_instruction(migraphx::op::multibroadcast{{1, dims.at(1), 1}}, epsilon);
+        auto add_epsilon    = p.add_instruction(migraphx::op::add{}, var, epsilon_mbcast);
+        auto sqrt           = p.add_instruction(migraphx::op::sqrt{}, add_epsilon);
+        auto sqrt_mbcast    = p.add_instruction(migraphx::op::multibroadcast{dims}, sqrt);
+        auto div            = p.add_instruction(migraphx::op::div{}, sub, sqrt_mbcast);
+        auto scale_mbcast   = p.add_instruction(migraphx::op::multibroadcast{dims}, scale);
+        auto mul            = p.add_instruction(migraphx::op::mul{}, scale_mbcast, div);
+        auto bias_mbcast    = p.add_instruction(migraphx::op::multibroadcast{dims}, bias);
+        p.add_instruction(migraphx::op::add{}, mul, bias_mbcast);
+        return p;
+    }
+};
+
+struct test_layernorm2 : verify_program<test_layernorm2>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        std::vector<size_t> dims{1, 8, 8};
+        auto x        = p.add_parameter("x", migraphx::shape{migraphx::shape::float_type, dims});
+        auto scale    = p.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
+        auto bias     = p.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
+        auto epsilon  = p.add_literal(1e-12f);
+        auto exponent = p.add_literal(2.0f);
+
+        auto mean           = p.add_instruction(migraphx::op::reduce_mean({2}), x);
+        auto mean_mbcast    = p.add_instruction(migraphx::op::multibroadcast{{dims}}, mean);
+        auto sub            = p.add_instruction(migraphx::op::sub{}, x, mean_mbcast);
+        auto exponent_mbcast = p.add_instruction(migraphx::op::multibroadcast{{dims}}, exponent);
+        auto pow            = p.add_instruction(migraphx::op::pow{}, sub, exponent_mbcast);
+        auto var            = p.add_instruction(migraphx::op::reduce_mean({2}), pow);
+        auto epsilon_mbcast = p.add_instruction(migraphx::op::multibroadcast{{1, dims.at(1), 1}}, epsilon);
+        auto add_epsilon    = p.add_instruction(migraphx::op::add{}, var, epsilon_mbcast);
+        auto sqrt           = p.add_instruction(migraphx::op::sqrt{}, add_epsilon);
+        auto sqrt_mbcast    = p.add_instruction(migraphx::op::multibroadcast{dims}, sqrt);
+        auto div            = p.add_instruction(migraphx::op::div{}, sub, sqrt_mbcast);
+        auto scale_mbcast   = p.add_instruction(migraphx::op::multibroadcast{dims}, scale);
+        auto mul            = p.add_instruction(migraphx::op::mul{}, scale_mbcast, div);
+        auto bias_mbcast    = p.add_instruction(migraphx::op::multibroadcast{dims}, bias);
+        p.add_instruction(migraphx::op::add{}, mul, bias_mbcast);
+        return p;
+    }
+};
+
+struct test_layernorm3 : verify_program<test_layernorm3>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        std::vector<size_t> dims{1, 128, 768};
+        auto x        = p.add_parameter("x", migraphx::shape{migraphx::shape::float_type, dims});
+        auto scale    = p.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
+        auto bias     = p.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
+        auto epsilon  = p.add_literal(1e-12f);
+        auto exponent = p.add_literal(2.0f);
+
+        auto mean           = p.add_instruction(migraphx::op::reduce_mean({2}), x);
+        auto mean_mbcast    = p.add_instruction(migraphx::op::multibroadcast{{dims}}, mean);
+        auto sub            = p.add_instruction(migraphx::op::sub{}, x, mean_mbcast);
+        auto exponent_mbcast = p.add_instruction(migraphx::op::multibroadcast{{dims}}, exponent);
+        auto pow            = p.add_instruction(migraphx::op::pow{}, sub, exponent_mbcast);
+        auto var            = p.add_instruction(migraphx::op::reduce_mean({2}), pow);
+        auto epsilon_mbcast = p.add_instruction(migraphx::op::multibroadcast{{1, dims.at(1), 1}}, epsilon);
         auto add_epsilon    = p.add_instruction(migraphx::op::add{}, var, epsilon_mbcast);
         auto sqrt           = p.add_instruction(migraphx::op::sqrt{}, add_epsilon);
         auto sqrt_mbcast    = p.add_instruction(migraphx::op::multibroadcast{dims}, sqrt);

--- a/test/gpu/ops_test.cpp
+++ b/test/gpu/ops_test.cpp
@@ -1067,41 +1067,7 @@ struct test_layernorm2 : verify_program<test_layernorm2>
     migraphx::program create_program() const
     {
         migraphx::program p;
-        std::vector<size_t> dims{1, 8, 8};
-        auto x = p.add_parameter("x", migraphx::shape{migraphx::shape::float_type, dims});
-        auto scale =
-            p.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
-        auto bias =
-            p.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
-        auto epsilon  = p.add_literal(1e-12f);
-        auto exponent = p.add_literal(2.0f);
-
-        auto mean            = p.add_instruction(migraphx::op::reduce_mean({2}), x);
-        auto mean_mbcast     = p.add_instruction(migraphx::op::multibroadcast{{dims}}, mean);
-        auto sub             = p.add_instruction(migraphx::op::sub{}, x, mean_mbcast);
-        auto exponent_mbcast = p.add_instruction(migraphx::op::multibroadcast{{dims}}, exponent);
-        auto pow             = p.add_instruction(migraphx::op::pow{}, sub, exponent_mbcast);
-        auto var             = p.add_instruction(migraphx::op::reduce_mean({2}), pow);
-        auto epsilon_mbcast =
-            p.add_instruction(migraphx::op::multibroadcast{{1, dims.at(1), 1}}, epsilon);
-        auto add_epsilon  = p.add_instruction(migraphx::op::add{}, var, epsilon_mbcast);
-        auto sqrt         = p.add_instruction(migraphx::op::sqrt{}, add_epsilon);
-        auto sqrt_mbcast  = p.add_instruction(migraphx::op::multibroadcast{dims}, sqrt);
-        auto div          = p.add_instruction(migraphx::op::div{}, sub, sqrt_mbcast);
-        auto scale_mbcast = p.add_instruction(migraphx::op::multibroadcast{dims}, scale);
-        auto mul          = p.add_instruction(migraphx::op::mul{}, scale_mbcast, div);
-        auto bias_mbcast  = p.add_instruction(migraphx::op::multibroadcast{dims}, bias);
-        p.add_instruction(migraphx::op::add{}, mul, bias_mbcast);
-        return p;
-    }
-};
-
-struct test_layernorm3 : verify_program<test_layernorm3>
-{
-    migraphx::program create_program() const
-    {
-        migraphx::program p;
-        std::vector<size_t> dims{1, 128, 768};
+        std::vector<size_t> dims{1, 4, 24};
         auto x = p.add_parameter("x", migraphx::shape{migraphx::shape::float_type, dims});
         auto scale =
             p.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {dims.back()}});

--- a/test/gpu/ops_test.cpp
+++ b/test/gpu/ops_test.cpp
@@ -1034,26 +1034,29 @@ struct test_layernorm : verify_program<test_layernorm>
     {
         migraphx::program p;
         std::vector<size_t> dims{1, 1, 5};
-        auto x        = p.add_parameter("x", migraphx::shape{migraphx::shape::float_type, dims});
-        auto scale    = p.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
-        auto bias     = p.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
+        auto x = p.add_parameter("x", migraphx::shape{migraphx::shape::float_type, dims});
+        auto scale =
+            p.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
+        auto bias =
+            p.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
         auto epsilon  = p.add_literal(1e-12f);
         auto exponent = p.add_literal(2.0f);
 
-        auto mean           = p.add_instruction(migraphx::op::reduce_mean({2}), x);
-        auto mean_mbcast    = p.add_instruction(migraphx::op::multibroadcast{{dims}}, mean);
-        auto sub            = p.add_instruction(migraphx::op::sub{}, x, mean_mbcast);
+        auto mean            = p.add_instruction(migraphx::op::reduce_mean({2}), x);
+        auto mean_mbcast     = p.add_instruction(migraphx::op::multibroadcast{{dims}}, mean);
+        auto sub             = p.add_instruction(migraphx::op::sub{}, x, mean_mbcast);
         auto exponent_mbcast = p.add_instruction(migraphx::op::multibroadcast{{dims}}, exponent);
-        auto pow            = p.add_instruction(migraphx::op::pow{}, sub, exponent_mbcast);
-        auto var            = p.add_instruction(migraphx::op::reduce_mean({2}), pow);
-        auto epsilon_mbcast = p.add_instruction(migraphx::op::multibroadcast{{1, dims.at(1), 1}}, epsilon);
-        auto add_epsilon    = p.add_instruction(migraphx::op::add{}, var, epsilon_mbcast);
-        auto sqrt           = p.add_instruction(migraphx::op::sqrt{}, add_epsilon);
-        auto sqrt_mbcast    = p.add_instruction(migraphx::op::multibroadcast{dims}, sqrt);
-        auto div            = p.add_instruction(migraphx::op::div{}, sub, sqrt_mbcast);
-        auto scale_mbcast   = p.add_instruction(migraphx::op::multibroadcast{dims}, scale);
-        auto mul            = p.add_instruction(migraphx::op::mul{}, scale_mbcast, div);
-        auto bias_mbcast    = p.add_instruction(migraphx::op::multibroadcast{dims}, bias);
+        auto pow             = p.add_instruction(migraphx::op::pow{}, sub, exponent_mbcast);
+        auto var             = p.add_instruction(migraphx::op::reduce_mean({2}), pow);
+        auto epsilon_mbcast =
+            p.add_instruction(migraphx::op::multibroadcast{{1, dims.at(1), 1}}, epsilon);
+        auto add_epsilon  = p.add_instruction(migraphx::op::add{}, var, epsilon_mbcast);
+        auto sqrt         = p.add_instruction(migraphx::op::sqrt{}, add_epsilon);
+        auto sqrt_mbcast  = p.add_instruction(migraphx::op::multibroadcast{dims}, sqrt);
+        auto div          = p.add_instruction(migraphx::op::div{}, sub, sqrt_mbcast);
+        auto scale_mbcast = p.add_instruction(migraphx::op::multibroadcast{dims}, scale);
+        auto mul          = p.add_instruction(migraphx::op::mul{}, scale_mbcast, div);
+        auto bias_mbcast  = p.add_instruction(migraphx::op::multibroadcast{dims}, bias);
         p.add_instruction(migraphx::op::add{}, mul, bias_mbcast);
         return p;
     }
@@ -1065,26 +1068,29 @@ struct test_layernorm2 : verify_program<test_layernorm2>
     {
         migraphx::program p;
         std::vector<size_t> dims{1, 8, 8};
-        auto x        = p.add_parameter("x", migraphx::shape{migraphx::shape::float_type, dims});
-        auto scale    = p.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
-        auto bias     = p.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
+        auto x = p.add_parameter("x", migraphx::shape{migraphx::shape::float_type, dims});
+        auto scale =
+            p.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
+        auto bias =
+            p.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
         auto epsilon  = p.add_literal(1e-12f);
         auto exponent = p.add_literal(2.0f);
 
-        auto mean           = p.add_instruction(migraphx::op::reduce_mean({2}), x);
-        auto mean_mbcast    = p.add_instruction(migraphx::op::multibroadcast{{dims}}, mean);
-        auto sub            = p.add_instruction(migraphx::op::sub{}, x, mean_mbcast);
+        auto mean            = p.add_instruction(migraphx::op::reduce_mean({2}), x);
+        auto mean_mbcast     = p.add_instruction(migraphx::op::multibroadcast{{dims}}, mean);
+        auto sub             = p.add_instruction(migraphx::op::sub{}, x, mean_mbcast);
         auto exponent_mbcast = p.add_instruction(migraphx::op::multibroadcast{{dims}}, exponent);
-        auto pow            = p.add_instruction(migraphx::op::pow{}, sub, exponent_mbcast);
-        auto var            = p.add_instruction(migraphx::op::reduce_mean({2}), pow);
-        auto epsilon_mbcast = p.add_instruction(migraphx::op::multibroadcast{{1, dims.at(1), 1}}, epsilon);
-        auto add_epsilon    = p.add_instruction(migraphx::op::add{}, var, epsilon_mbcast);
-        auto sqrt           = p.add_instruction(migraphx::op::sqrt{}, add_epsilon);
-        auto sqrt_mbcast    = p.add_instruction(migraphx::op::multibroadcast{dims}, sqrt);
-        auto div            = p.add_instruction(migraphx::op::div{}, sub, sqrt_mbcast);
-        auto scale_mbcast   = p.add_instruction(migraphx::op::multibroadcast{dims}, scale);
-        auto mul            = p.add_instruction(migraphx::op::mul{}, scale_mbcast, div);
-        auto bias_mbcast    = p.add_instruction(migraphx::op::multibroadcast{dims}, bias);
+        auto pow             = p.add_instruction(migraphx::op::pow{}, sub, exponent_mbcast);
+        auto var             = p.add_instruction(migraphx::op::reduce_mean({2}), pow);
+        auto epsilon_mbcast =
+            p.add_instruction(migraphx::op::multibroadcast{{1, dims.at(1), 1}}, epsilon);
+        auto add_epsilon  = p.add_instruction(migraphx::op::add{}, var, epsilon_mbcast);
+        auto sqrt         = p.add_instruction(migraphx::op::sqrt{}, add_epsilon);
+        auto sqrt_mbcast  = p.add_instruction(migraphx::op::multibroadcast{dims}, sqrt);
+        auto div          = p.add_instruction(migraphx::op::div{}, sub, sqrt_mbcast);
+        auto scale_mbcast = p.add_instruction(migraphx::op::multibroadcast{dims}, scale);
+        auto mul          = p.add_instruction(migraphx::op::mul{}, scale_mbcast, div);
+        auto bias_mbcast  = p.add_instruction(migraphx::op::multibroadcast{dims}, bias);
         p.add_instruction(migraphx::op::add{}, mul, bias_mbcast);
         return p;
     }
@@ -1096,26 +1102,29 @@ struct test_layernorm3 : verify_program<test_layernorm3>
     {
         migraphx::program p;
         std::vector<size_t> dims{1, 128, 768};
-        auto x        = p.add_parameter("x", migraphx::shape{migraphx::shape::float_type, dims});
-        auto scale    = p.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
-        auto bias     = p.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
+        auto x = p.add_parameter("x", migraphx::shape{migraphx::shape::float_type, dims});
+        auto scale =
+            p.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
+        auto bias =
+            p.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
         auto epsilon  = p.add_literal(1e-12f);
         auto exponent = p.add_literal(2.0f);
 
-        auto mean           = p.add_instruction(migraphx::op::reduce_mean({2}), x);
-        auto mean_mbcast    = p.add_instruction(migraphx::op::multibroadcast{{dims}}, mean);
-        auto sub            = p.add_instruction(migraphx::op::sub{}, x, mean_mbcast);
+        auto mean            = p.add_instruction(migraphx::op::reduce_mean({2}), x);
+        auto mean_mbcast     = p.add_instruction(migraphx::op::multibroadcast{{dims}}, mean);
+        auto sub             = p.add_instruction(migraphx::op::sub{}, x, mean_mbcast);
         auto exponent_mbcast = p.add_instruction(migraphx::op::multibroadcast{{dims}}, exponent);
-        auto pow            = p.add_instruction(migraphx::op::pow{}, sub, exponent_mbcast);
-        auto var            = p.add_instruction(migraphx::op::reduce_mean({2}), pow);
-        auto epsilon_mbcast = p.add_instruction(migraphx::op::multibroadcast{{1, dims.at(1), 1}}, epsilon);
-        auto add_epsilon    = p.add_instruction(migraphx::op::add{}, var, epsilon_mbcast);
-        auto sqrt           = p.add_instruction(migraphx::op::sqrt{}, add_epsilon);
-        auto sqrt_mbcast    = p.add_instruction(migraphx::op::multibroadcast{dims}, sqrt);
-        auto div            = p.add_instruction(migraphx::op::div{}, sub, sqrt_mbcast);
-        auto scale_mbcast   = p.add_instruction(migraphx::op::multibroadcast{dims}, scale);
-        auto mul            = p.add_instruction(migraphx::op::mul{}, scale_mbcast, div);
-        auto bias_mbcast    = p.add_instruction(migraphx::op::multibroadcast{dims}, bias);
+        auto pow             = p.add_instruction(migraphx::op::pow{}, sub, exponent_mbcast);
+        auto var             = p.add_instruction(migraphx::op::reduce_mean({2}), pow);
+        auto epsilon_mbcast =
+            p.add_instruction(migraphx::op::multibroadcast{{1, dims.at(1), 1}}, epsilon);
+        auto add_epsilon  = p.add_instruction(migraphx::op::add{}, var, epsilon_mbcast);
+        auto sqrt         = p.add_instruction(migraphx::op::sqrt{}, add_epsilon);
+        auto sqrt_mbcast  = p.add_instruction(migraphx::op::multibroadcast{dims}, sqrt);
+        auto div          = p.add_instruction(migraphx::op::div{}, sub, sqrt_mbcast);
+        auto scale_mbcast = p.add_instruction(migraphx::op::multibroadcast{dims}, scale);
+        auto mul          = p.add_instruction(migraphx::op::mul{}, scale_mbcast, div);
+        auto bias_mbcast  = p.add_instruction(migraphx::op::multibroadcast{dims}, bias);
         p.add_instruction(migraphx::op::add{}, mul, bias_mbcast);
         return p;
     }

--- a/test/gpu/ops_test.cpp
+++ b/test/gpu/ops_test.cpp
@@ -1028,36 +1028,40 @@ struct test_triadd_tanh : verify_program<test_triadd_tanh>
     }
 };
 
+migraphx::instruction_ref add_layernorm(migraphx::program& p, std::vector<size_t> dims)
+{
+    auto x = p.add_parameter("x", migraphx::shape{migraphx::shape::float_type, dims});
+    auto scale =
+        p.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
+    auto bias =
+        p.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
+    auto epsilon  = p.add_literal(1e-12f);
+    auto exponent = p.add_literal(2.0f);
+
+    auto mean            = p.add_instruction(migraphx::op::reduce_mean({2}), x);
+    auto mean_mbcast     = p.add_instruction(migraphx::op::multibroadcast{{dims}}, mean);
+    auto sub             = p.add_instruction(migraphx::op::sub{}, x, mean_mbcast);
+    auto exponent_mbcast = p.add_instruction(migraphx::op::multibroadcast{{dims}}, exponent);
+    auto pow             = p.add_instruction(migraphx::op::pow{}, sub, exponent_mbcast);
+    auto var             = p.add_instruction(migraphx::op::reduce_mean({2}), pow);
+    auto epsilon_mbcast =
+        p.add_instruction(migraphx::op::multibroadcast{{1, dims.at(1), 1}}, epsilon);
+    auto add_epsilon  = p.add_instruction(migraphx::op::add{}, var, epsilon_mbcast);
+    auto sqrt         = p.add_instruction(migraphx::op::sqrt{}, add_epsilon);
+    auto sqrt_mbcast  = p.add_instruction(migraphx::op::multibroadcast{dims}, sqrt);
+    auto div          = p.add_instruction(migraphx::op::div{}, sub, sqrt_mbcast);
+    auto scale_mbcast = p.add_instruction(migraphx::op::multibroadcast{dims}, scale);
+    auto mul          = p.add_instruction(migraphx::op::mul{}, scale_mbcast, div);
+    auto bias_mbcast  = p.add_instruction(migraphx::op::multibroadcast{dims}, bias);
+    return p.add_instruction(migraphx::op::add{}, mul, bias_mbcast);
+}
+
 struct test_layernorm : verify_program<test_layernorm>
 {
     migraphx::program create_program() const
     {
         migraphx::program p;
-        std::vector<size_t> dims{1, 1, 5};
-        auto x = p.add_parameter("x", migraphx::shape{migraphx::shape::float_type, dims});
-        auto scale =
-            p.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
-        auto bias =
-            p.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
-        auto epsilon  = p.add_literal(1e-12f);
-        auto exponent = p.add_literal(2.0f);
-
-        auto mean            = p.add_instruction(migraphx::op::reduce_mean({2}), x);
-        auto mean_mbcast     = p.add_instruction(migraphx::op::multibroadcast{{dims}}, mean);
-        auto sub             = p.add_instruction(migraphx::op::sub{}, x, mean_mbcast);
-        auto exponent_mbcast = p.add_instruction(migraphx::op::multibroadcast{{dims}}, exponent);
-        auto pow             = p.add_instruction(migraphx::op::pow{}, sub, exponent_mbcast);
-        auto var             = p.add_instruction(migraphx::op::reduce_mean({2}), pow);
-        auto epsilon_mbcast =
-            p.add_instruction(migraphx::op::multibroadcast{{1, dims.at(1), 1}}, epsilon);
-        auto add_epsilon  = p.add_instruction(migraphx::op::add{}, var, epsilon_mbcast);
-        auto sqrt         = p.add_instruction(migraphx::op::sqrt{}, add_epsilon);
-        auto sqrt_mbcast  = p.add_instruction(migraphx::op::multibroadcast{dims}, sqrt);
-        auto div          = p.add_instruction(migraphx::op::div{}, sub, sqrt_mbcast);
-        auto scale_mbcast = p.add_instruction(migraphx::op::multibroadcast{dims}, scale);
-        auto mul          = p.add_instruction(migraphx::op::mul{}, scale_mbcast, div);
-        auto bias_mbcast  = p.add_instruction(migraphx::op::multibroadcast{dims}, bias);
-        p.add_instruction(migraphx::op::add{}, mul, bias_mbcast);
+        add_layernorm(p, {1, 1, 5});
         return p;
     }
 };
@@ -1067,31 +1071,7 @@ struct test_layernorm2 : verify_program<test_layernorm2>
     migraphx::program create_program() const
     {
         migraphx::program p;
-        std::vector<size_t> dims{1, 4, 24};
-        auto x = p.add_parameter("x", migraphx::shape{migraphx::shape::float_type, dims});
-        auto scale =
-            p.add_parameter("scale", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
-        auto bias =
-            p.add_parameter("bias", migraphx::shape{migraphx::shape::float_type, {dims.back()}});
-        auto epsilon  = p.add_literal(1e-12f);
-        auto exponent = p.add_literal(2.0f);
-
-        auto mean            = p.add_instruction(migraphx::op::reduce_mean({2}), x);
-        auto mean_mbcast     = p.add_instruction(migraphx::op::multibroadcast{{dims}}, mean);
-        auto sub             = p.add_instruction(migraphx::op::sub{}, x, mean_mbcast);
-        auto exponent_mbcast = p.add_instruction(migraphx::op::multibroadcast{{dims}}, exponent);
-        auto pow             = p.add_instruction(migraphx::op::pow{}, sub, exponent_mbcast);
-        auto var             = p.add_instruction(migraphx::op::reduce_mean({2}), pow);
-        auto epsilon_mbcast =
-            p.add_instruction(migraphx::op::multibroadcast{{1, dims.at(1), 1}}, epsilon);
-        auto add_epsilon  = p.add_instruction(migraphx::op::add{}, var, epsilon_mbcast);
-        auto sqrt         = p.add_instruction(migraphx::op::sqrt{}, add_epsilon);
-        auto sqrt_mbcast  = p.add_instruction(migraphx::op::multibroadcast{dims}, sqrt);
-        auto div          = p.add_instruction(migraphx::op::div{}, sub, sqrt_mbcast);
-        auto scale_mbcast = p.add_instruction(migraphx::op::multibroadcast{dims}, scale);
-        auto mul          = p.add_instruction(migraphx::op::mul{}, scale_mbcast, div);
-        auto bias_mbcast  = p.add_instruction(migraphx::op::multibroadcast{dims}, bias);
-        p.add_instruction(migraphx::op::add{}, mul, bias_mbcast);
+        add_layernorm(p, {1, 4, 24});
         return p;
     }
 };


### PR DESCRIPTION
This does a vectorized layernorm which seems to avoid the performance issue with using an array. This runs over 10x faster. It was running at 12ms on machine, and now it runs in under 1ms. The matcher is also updated so it won't fuse if its too large. 

It also adds `--fill1` to the verify driver so I can verify this change with bert(which it passes).

