### PR TITLE
Updates for module name

### DIFF
--- a/src/include/migraphx/module.hpp
+++ b/src/include/migraphx/module.hpp
@@ -28,7 +28,7 @@ using parameter_map = std::unordered_map<std::string, argument>;
  */
 struct module
 {
-    module();
+    module(const std::string name="");
 
     // move constructor
     module(module&&) noexcept;
@@ -41,7 +41,7 @@ struct module
 
     ~module() noexcept;
 
-    std::string name() const { return module_name; }
+    std::string name() const;
 
     template <class... Ts>
     instruction_ref add_instruction(operation op, Ts... args)
@@ -133,7 +133,6 @@ struct module
     private:
     void assign(const module& m);
     std::unique_ptr<module_impl> impl;
-    std::string module_name;
 };
 
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/include/migraphx/module.hpp
+++ b/src/include/migraphx/module.hpp
@@ -28,7 +28,7 @@ using parameter_map = std::unordered_map<std::string, argument>;
  */
 struct module
 {
-    module(const std::string name="");
+    module(const std::string name = "");
 
     // move constructor
     module(module&&) noexcept;

--- a/src/include/migraphx/module.hpp
+++ b/src/include/migraphx/module.hpp
@@ -28,7 +28,7 @@ using parameter_map = std::unordered_map<std::string, argument>;
  */
 struct module
 {
-    module(const std::string name = "");
+    module(const std::string& name = "");
 
     // move constructor
     module(module&&) noexcept;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -25,6 +25,7 @@ struct module_impl
     // A list is used to keep references to an instruction stable
     std::list<instruction> instructions;
     std::vector<std::string> input_names;
+    std::string name;
 };
 
 const operation& get_operation(instruction_ref ins) { return ins->get_operator(); }
@@ -61,7 +62,9 @@ static void print_instruction(std::ostream& os,
         os << " -> " << ins->get_shape();
 }
 
-module::module() : impl(std::make_unique<module_impl>()) {}
+module::module(const std::string name) : impl(std::make_unique<module_impl>()) {
+    impl->name = name;
+}
 
 module::module(module&&) noexcept = default;
 module::~module() noexcept        = default;
@@ -76,6 +79,11 @@ module& module::operator=(module m)
     return *this;
 }
 
+std::string module::name() const
+{
+    return impl->name;
+}
+
 void module::assign(const module& m)
 {
     // clean the current module
@@ -88,6 +96,7 @@ void module::assign(const module& m)
         impl->instructions.clear();
     }
     impl->input_names = m.impl->input_names;
+    impl->name = m.impl->name;
 
     std::unordered_map<instruction_ref, instruction_ref> ins_map;
     for(auto ins : iterator_for(m))

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -62,7 +62,7 @@ static void print_instruction(std::ostream& os,
         os << " -> " << ins->get_shape();
 }
 
-module::module(const std::string name) : impl(std::make_unique<module_impl>())
+module::module(const std::string& name) : impl(std::make_unique<module_impl>())
 {
     impl->name = name;
 }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -62,7 +62,8 @@ static void print_instruction(std::ostream& os,
         os << " -> " << ins->get_shape();
 }
 
-module::module(const std::string name) : impl(std::make_unique<module_impl>()) {
+module::module(const std::string name) : impl(std::make_unique<module_impl>())
+{
     impl->name = name;
 }
 
@@ -79,10 +80,7 @@ module& module::operator=(module m)
     return *this;
 }
 
-std::string module::name() const
-{
-    return impl->name;
-}
+std::string module::name() const { return impl->name; }
 
 void module::assign(const module& m)
 {
@@ -96,7 +94,7 @@ void module::assign(const module& m)
         impl->instructions.clear();
     }
     impl->input_names = m.impl->input_names;
-    impl->name = m.impl->name;
+    impl->name        = m.impl->name;
 
     std::unordered_map<instruction_ref, instruction_ref> ins_map;
     for(auto ins : iterator_for(m))

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -62,7 +62,7 @@ static void print_instruction(std::ostream& os,
         os << " -> " << ins->get_shape();
 }
 
-program::program() : impl(std::make_unique<program_impl>()) { impl->modules["main"] = {}; }
+program::program() : impl(std::make_unique<program_impl>()) { impl->modules["main"] = {"main"}; }
 
 program::program(program&&) noexcept = default;
 program::~program() noexcept         = default;
@@ -324,7 +324,7 @@ void program::from_value(const value& v)
     {
         const auto& key = vv.get_key();
         auto val        = vv.without_key();
-        module modl;
+        module modl{key};
         modl.from_value(val);
         impl->modules[key] = modl;
     }
@@ -505,9 +505,9 @@ void program::annotate(std::ostream& os, const std::function<void(instruction_re
     }
 }
 
-module* program::get_main_module() { return &impl->modules["main"]; }
+module* program::get_main_module() { return &impl->modules.at("main"); }
 
-const module* program::get_main_module() const { return &impl->modules["main"]; }
+const module* program::get_main_module() const { return &impl->modules.at("main"); }
 
 program& program::sort()
 {

--- a/test/module_test.cpp
+++ b/test/module_test.cpp
@@ -90,7 +90,7 @@ TEST_CASE(module_name)
     migraphx::module m1("name");
     EXPECT(m1.name() == "name");
 
-    auto m2 = m1;
+    auto m2 = m1; // NOLINT
     EXPECT(m2.name() == "name");
     migraphx::module m3;
     m3 = m1;

--- a/test/module_test.cpp
+++ b/test/module_test.cpp
@@ -85,4 +85,22 @@ TEST_CASE(module_annotate)
     EXPECT(ss1.str() == ss2.str());
 }
 
+TEST_CASE(module_name)
+{
+    migraphx::module m1("name");
+    EXPECT(m1.name() == "name");
+
+    auto m2 = m1;
+    EXPECT(m2.name() == "name");
+    migraphx::module m3;
+    m3 = m1;
+    EXPECT(m3.name() == "name");
+}
+TEST_CASE(module_name_main)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    EXPECT(mm->name() == "main");
+}
+
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
This refactors the handling of module names:

- Move name to the impl class
- Set the module name during construction
- Set the main's module name to "main"
- Add tests