### PR TITLE
upgrade protobuf to 3.16.0 to be compatible with onnxruntime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-google/protobuf@v3.11.0 -DCMAKE_POSITION_INDEPENDENT_CODE=On -X subdir -Dprotobuf_BUILD_TESTS=Off
+google/protobuf@v3.16.0 -DCMAKE_POSITION_INDEPENDENT_CODE=On -X subdir -Dprotobuf_BUILD_TESTS=Off
 RadeonOpenCompute/rocm-cmake@ececd2eccae4d01e7ec154efe90ac43ebf4df317 --build
 ROCmSoftwarePlatform/rocBLAS@abd98a2b48b29326ebaef471630786a548622c06
 ROCmSoftwarePlatform/MIOpen@2.4.0


### PR DESCRIPTION
As we discussed in the standup meeting, there is an error happened when running models in onnxruntime. After investigation, the reason is the protobuf (version 3.11.0) used in the migraphx dependency is out of date. After upgrading to 3.16.0, it works fine, and no regression is observed for migraphx unit tests. So we can upgrade protobuf to 3.16.0 to fix the issue.