### PR TITLE
Bug as shape

### DIFF
--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -685,12 +685,11 @@ struct find_add_convs
                     auto n = compute_stride_factor(b_op, a_op);
                     if(n == 0)
                         return;
-                    new_op  = a_op;
-		    if(not b_input->get_shape().standard())
-		    {
-                        b_input =
-                            p.insert_instruction(ins, make_op("contiguous"), b_input);
-		    }
+                    new_op = a_op;
+                    if(not b_input->get_shape().standard())
+                    {
+                        b_input = p.insert_instruction(ins, make_op("contiguous"), b_input);
+                    }
                     b_input = p.insert_instruction(
                         ins,
                         make_op(
@@ -703,12 +702,11 @@ struct find_add_convs
                     auto n = compute_stride_factor(a_op, b_op);
                     if(n == 0)
                         return;
-                    new_op  = b_op;
-		    if(not a_input->get_shape().standard())
-		    {
-                        a_input =
-                            p.insert_instruction(ins, make_op("contiguous"), a_input);
-		    }
+                    new_op = b_op;
+                    if(not a_input->get_shape().standard())
+                    {
+                        a_input = p.insert_instruction(ins, make_op("contiguous"), a_input);
+                    }
                     a_input = p.insert_instruction(
                         ins,
                         make_op(

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -686,6 +686,11 @@ struct find_add_convs
                     if(n == 0)
                         return;
                     new_op  = a_op;
+		    if(not b_input->get_shape().standard())
+		    {
+                        b_input =
+                            p.insert_instruction(ins, make_op("contiguous"), b_input);
+		    }
                     b_input = p.insert_instruction(
                         ins,
                         make_op(
@@ -699,6 +704,11 @@ struct find_add_convs
                     if(n == 0)
                         return;
                     new_op  = b_op;
+		    if(not a_input->get_shape().standard())
+		    {
+                        a_input =
+                            p.insert_instruction(ins, make_op("contiguous"), a_input);
+		    }
                     a_input = p.insert_instruction(
                         ins,
                         make_op(

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -426,11 +426,11 @@ TEST_CASE(simplify_add_conv_1x1_diff_strides1)
 TEST_CASE(simplify_add_conv_1x1_diff_strides1_transpose)
 {
     migraphx::module m;
-    auto x = m.add_parameter("x", {migraphx::shape::float_type, {1, 14, 128, 14}});
+    auto x  = m.add_parameter("x", {migraphx::shape::float_type, {1, 14, 128, 14}});
     auto tx = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 1, 3}}}), x);
     auto w =
         m.add_literal(migraphx::generate_literal({migraphx::shape::float_type, {256, 128, 1, 1}}));
-    auto y = m.add_parameter("y", {migraphx::shape::float_type, {1, 128, 28, 28}});
+    auto y  = m.add_parameter("y", {migraphx::shape::float_type, {1, 128, 28, 28}});
     auto ty = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), y);
     auto v =
         m.add_literal(migraphx::generate_literal({migraphx::shape::float_type, {256, 128, 1, 1}}));
@@ -470,11 +470,11 @@ TEST_CASE(simplify_add_conv_1x1_diff_strides2)
 TEST_CASE(simplify_add_conv_1x1_diff_strides2_transpose)
 {
     migraphx::module m;
-    auto x = m.add_parameter("x", {migraphx::shape::float_type, {1, 28, 128, 28}});
+    auto x  = m.add_parameter("x", {migraphx::shape::float_type, {1, 28, 128, 28}});
     auto tx = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 1, 3}}}), x);
     auto w =
         m.add_literal(migraphx::generate_literal({migraphx::shape::float_type, {256, 128, 1, 1}}));
-    auto y = m.add_parameter("y", {migraphx::shape::float_type, {1, 128, 14, 14}});
+    auto y  = m.add_parameter("y", {migraphx::shape::float_type, {1, 128, 14, 14}});
     auto ty = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), y);
     auto v =
         m.add_literal(migraphx::generate_literal({migraphx::shape::float_type, {256, 128, 1, 1}}));


### PR DESCRIPTION
in the optimization find_add_conv, change the input shape to be standard if not. This bug surfaced when running the pnasnet_large model from msft.