### PR TITLE
Remove Alpha Beta from onnx gemm parsing

### DIFF
--- a/src/onnx/parse_gemm.cpp
+++ b/src/onnx/parse_gemm.cpp
@@ -42,10 +42,7 @@ struct parse_gemm : op_parser<parse_gemm>
         // swap the last two elements
         std::swap(*perm.rbegin(), *(perm.rbegin() + 1));
 
-        auto l1 = (transa) ? info.add_instruction(make_op("transpose", {{"dims", perm}}), args[0])
-                           : args[0];
-        auto l2 = (transb) ? info.add_instruction(make_op("transpose", {{"dims", perm}}), args[1])
-                           : args[1];
+        auto l1 = args[0];
 
         if(alpha != 1.0f)
         {
@@ -54,6 +51,10 @@ struct parse_gemm : op_parser<parse_gemm>
             l1 = info.add_instruction(make_op("convert", {{"target_type", l1->get_shape().type()}}),
                                       alpha_l1);
         }
+
+        l1      = (transa) ? info.add_instruction(make_op("transpose", {{"dims", perm}}), l1) : l1;
+        auto l2 = (transb) ? info.add_instruction(make_op("transpose", {{"dims", perm}}), args[1])
+                           : args[1];
 
         if(args.size() == 3 && beta != 0.0f)
         {

--- a/src/onnx/parse_gemm.cpp
+++ b/src/onnx/parse_gemm.cpp
@@ -56,9 +56,9 @@ struct parse_gemm : op_parser<parse_gemm>
         auto l2 = (transb) ? info.add_instruction(make_op("transpose", {{"dims", perm}}), args[1])
                            : args[1];
 
-        if(args.size() == 3 && beta != 0.0f)
+        if(args.size() == 3)
         {
-            if(beta != 1.0f && args[2]->get_shape().elements() > 0)
+            if(beta != 0.0f && args[2]->get_shape().elements() > 0)
             {
                 auto out_lens   = l1->get_shape().lens();
                 out_lens.back() = l2->get_shape().lens().back();

--- a/src/onnx/parse_gemm.cpp
+++ b/src/onnx/parse_gemm.cpp
@@ -49,14 +49,13 @@ struct parse_gemm : op_parser<parse_gemm>
 
         if(alpha != 1.0f)
         {
-            auto alpha_literal   = info.add_literal(alpha);
-            auto alpha_broadcast = info.add_instruction(
-                make_op("multibroadcast", {{"output_lens", l1->get_shape().lens()}}),
-                alpha_literal);
-            l1 = info.add_instruction(make_op("mul"), l1, alpha_broadcast);
+            auto alpha_literal = info.add_literal(alpha);
+            auto alpha_l1      = info.add_broadcastable_binary_op("mul", alpha_literal, l1);
+            l1 = info.add_instruction(make_op("convert", {{"target_type", l1->get_shape().type()}}),
+                                      alpha_l1);
         }
 
-        if(args.size() == 3)
+        if(args.size() == 3 && beta != 0.0f)
         {
             if(beta != 1.0f && args[2]->get_shape().elements() > 0)
             {

--- a/src/onnx/parse_gemm.cpp
+++ b/src/onnx/parse_gemm.cpp
@@ -46,9 +46,19 @@ struct parse_gemm : op_parser<parse_gemm>
                            : args[0];
         auto l2 = (transb) ? info.add_instruction(make_op("transpose", {{"dims", perm}}), args[1])
                            : args[1];
+
+        if(alpha != 1.0f)
+        {
+            auto alpha_literal   = info.add_literal(alpha);
+            auto alpha_broadcast = info.add_instruction(
+                make_op("multibroadcast", {{"output_lens", l1->get_shape().lens()}}),
+                alpha_literal);
+            l1 = info.add_instruction(make_op("mul"), l1, alpha_broadcast);
+        }
+
         if(args.size() == 3)
         {
-            if(beta != 0.f && args[2]->get_shape().elements() > 0)
+            if(beta != 1.0f && args[2]->get_shape().elements() > 0)
             {
                 auto out_lens   = l1->get_shape().lens();
                 out_lens.back() = l2->get_shape().lens().back();
@@ -59,12 +69,17 @@ struct parse_gemm : op_parser<parse_gemm>
                     l3 = info.add_instruction(
                         make_op("multibroadcast", {{"output_lens", out_lens}}), args[2]);
                 }
+                auto beta_literal   = info.add_literal(beta);
+                auto beta_broadcast = info.add_instruction(
+                    make_op("multibroadcast", {{"output_lens", out_lens}}), beta_literal);
+                l3 = info.add_instruction(make_op("mul"), l3, beta_broadcast);
+
                 return info.add_instruction(
-                    make_op("dot", {{"alpha", alpha}, {"beta", beta}}), l1, l2, l3);
+                    make_op("dot", {{"alpha", 1.0f}, {"beta", 1.0f}}), l1, l2, l3);
             }
         }
 
-        return info.add_instruction(make_op("dot", {{"alpha", alpha}, {"beta", beta}}), l1, l2);
+        return info.add_instruction(make_op("dot", {{"alpha", 1.0f}, {"beta", 1.0f}}), l1, l2);
     }
 };
 

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -1279,7 +1279,9 @@ TEST_CASE(gemm_test)
     auto a_l   = mm->add_literal(alpha);
     auto a_b   = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"output_lens", t0->get_shape().lens()}}), a_l);
-    auto t_a = mm->add_instruction(migraphx::make_op("mul"), t0, a_b);
+    auto t_a = mm->add_instruction(migraphx::make_op("mul"), a_b, t0);
+    t_a      = mm->add_instruction(
+        migraphx::make_op("convert", {{"target_type", l1->get_shape().type()}}), t_a);
     auto b_l = mm->add_literal(beta);
     auto l2_b =
         mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {7, 11}}}), l2);
@@ -1305,7 +1307,9 @@ TEST_CASE(gemm_ex_test)
     auto a_l   = mm->add_literal(alpha);
     auto a_b   = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"output_lens", t0->get_shape().lens()}}), a_l);
-    auto t_a = mm->add_instruction(migraphx::make_op("mul"), t0, a_b);
+    auto t_a = mm->add_instruction(migraphx::make_op("mul"), a_b, t0);
+    t_a      = mm->add_instruction(
+        migraphx::make_op("convert", {{"target_type", l1->get_shape().type()}}), t_a);
     auto b_l = mm->add_literal(beta);
     auto b_b = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"output_lens", l2->get_shape().lens()}}), b_l);
@@ -1331,7 +1335,9 @@ TEST_CASE(gemm_ex_brcst_test)
     auto a_l   = mm->add_literal(alpha);
     auto a_b   = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"output_lens", t0->get_shape().lens()}}), a_l);
-    auto t_a = mm->add_instruction(migraphx::make_op("mul"), t0, a_b);
+    auto t_a = mm->add_instruction(migraphx::make_op("mul"), a_b, t0);
+    t_a      = mm->add_instruction(
+        migraphx::make_op("convert", {{"target_type", l1->get_shape().type()}}), t_a);
     auto b_l = mm->add_literal(beta);
     auto l2_b =
         mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", out_lens}}), l2);

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -1273,14 +1273,15 @@ TEST_CASE(gemm_test)
     auto l0    = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {5, 7}});
     auto l1    = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {11, 5}});
     auto l2    = mm->add_parameter("2", migraphx::shape{migraphx::shape::float_type});
-    auto t0    = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l0);
-    auto t1    = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l1);
     auto alpha = 2.f;
     auto beta  = 2.0f;
     auto a_l   = mm->add_literal(alpha);
-    auto t_a   = add_common_op(*mm, migraphx::make_op("mul"), {a_l, t0});
+    auto t_a   = add_common_op(*mm, migraphx::make_op("mul"), {a_l, l0});
     t_a        = mm->add_instruction(
         migraphx::make_op("convert", {{"target_type", l1->get_shape().type()}}), t_a);
+    t_a     = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), t_a);
+    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l1);
+
     auto b_l = mm->add_literal(beta);
     auto l2_b =
         mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {7, 11}}}), l2);
@@ -1300,13 +1301,15 @@ TEST_CASE(gemm_ex_test)
     auto l0    = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {1, 1, 8, 6}});
     auto l1    = mm->add_parameter("2", migraphx::shape{migraphx::shape::float_type, {1, 1, 8, 7}});
     auto l2    = mm->add_parameter("3", migraphx::shape{migraphx::shape::float_type, {1, 1, 6, 7}});
-    auto t0    = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l0);
     auto alpha = 0.5f;
     auto beta  = 0.8f;
     auto a_l   = mm->add_literal(alpha);
-    auto t_a   = add_common_op(*mm, migraphx::make_op("mul"), {a_l, t0});
+    auto t_a   = add_common_op(*mm, migraphx::make_op("mul"), {a_l, l0});
     t_a        = mm->add_instruction(
         migraphx::make_op("convert", {{"target_type", l1->get_shape().type()}}), t_a);
+
+    t_a = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), t_a);
+
     auto b_l = mm->add_literal(beta);
     auto b_b = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"output_lens", l2->get_shape().lens()}}), b_l);
@@ -1325,14 +1328,16 @@ TEST_CASE(gemm_ex_brcst_test)
     auto l0  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {1, 1, 5, 6}});
     auto l1  = mm->add_parameter("2", migraphx::shape{migraphx::shape::float_type, {1, 1, 5, 7}});
     auto l2  = mm->add_parameter("3", migraphx::shape{migraphx::shape::float_type, {1, 1, 6, 1}});
-    auto t0  = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l0);
     std::vector<std::size_t> out_lens{1, 1, 6, 7};
     auto alpha = 0.5f;
     auto beta  = 0.8f;
     auto a_l   = mm->add_literal(alpha);
-    auto t_a   = add_common_op(*mm, migraphx::make_op("mul"), {a_l, t0});
+    auto t_a   = add_common_op(*mm, migraphx::make_op("mul"), {a_l, l0});
     t_a        = mm->add_instruction(
         migraphx::make_op("convert", {{"target_type", l1->get_shape().type()}}), t_a);
+
+    t_a = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), t_a);
+
     auto b_l = mm->add_literal(beta);
     auto l2_b =
         mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", out_lens}}), l2);

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <fstream>
 #include <vector>
+#include <migraphx/common.hpp>
 #include <migraphx/literal.hpp>
 #include <migraphx/program.hpp>
 #include <migraphx/instruction.hpp>
@@ -1277,10 +1278,8 @@ TEST_CASE(gemm_test)
     auto alpha = 2.f;
     auto beta  = 2.0f;
     auto a_l   = mm->add_literal(alpha);
-    auto a_b   = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", t0->get_shape().lens()}}), a_l);
-    auto t_a = mm->add_instruction(migraphx::make_op("mul"), a_b, t0);
-    t_a      = mm->add_instruction(
+    auto t_a   = add_common_op(*mm, migraphx::make_op("mul"), {a_l, t0});
+    t_a        = mm->add_instruction(
         migraphx::make_op("convert", {{"target_type", l1->get_shape().type()}}), t_a);
     auto b_l = mm->add_literal(beta);
     auto l2_b =
@@ -1305,10 +1304,8 @@ TEST_CASE(gemm_ex_test)
     auto alpha = 0.5f;
     auto beta  = 0.8f;
     auto a_l   = mm->add_literal(alpha);
-    auto a_b   = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", t0->get_shape().lens()}}), a_l);
-    auto t_a = mm->add_instruction(migraphx::make_op("mul"), a_b, t0);
-    t_a      = mm->add_instruction(
+    auto t_a   = add_common_op(*mm, migraphx::make_op("mul"), {a_l, t0});
+    t_a        = mm->add_instruction(
         migraphx::make_op("convert", {{"target_type", l1->get_shape().type()}}), t_a);
     auto b_l = mm->add_literal(beta);
     auto b_b = mm->add_instruction(
@@ -1333,10 +1330,8 @@ TEST_CASE(gemm_ex_brcst_test)
     auto alpha = 0.5f;
     auto beta  = 0.8f;
     auto a_l   = mm->add_literal(alpha);
-    auto a_b   = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", t0->get_shape().lens()}}), a_l);
-    auto t_a = mm->add_instruction(migraphx::make_op("mul"), a_b, t0);
-    t_a      = mm->add_instruction(
+    auto t_a   = add_common_op(*mm, migraphx::make_op("mul"), {a_l, t0});
+    t_a        = mm->add_instruction(
         migraphx::make_op("convert", {{"target_type", l1->get_shape().type()}}), t_a);
     auto b_l = mm->add_literal(beta);
     auto l2_b =


### PR DESCRIPTION
This PR only changes the frontend onnx parser.  Parses does the mutiplication with alpha and beta after doing necessary broadcasting. It then calls to `dot` operator. 

PR doesn't include changes related to following: 

Removal of alpha and beta fields from `dot` operator requires larger changes including in `quant_dot`. 

Removal of `decompose` pass also requires further changes. 