### PR TITLE
check for divisor encodable or not, fallback if needed

### DIFF
--- a/src/targets/gpu/device/include/migraphx/gpu/device/nary.hpp
+++ b/src/targets/gpu/device/include/migraphx/gpu/device/nary.hpp
@@ -352,7 +352,8 @@ bool broadcastable(bool& divisible_by_4,
         auto b_len          = result.get_shape().lens()[b_idx];
         auto b_stride       = result.get_shape().strides()[b_idx];
         assert(bshape.lens()[b_idx] == b_len);
-        if(b_len <= max_size and std::none_of(std::next(b_it), strides.end(), not_zero) and is_divisor_encodable(b_stride * b_len))
+        if(b_len <= max_size and std::none_of(std::next(b_it), strides.end(), not_zero) and
+           is_divisor_encodable(b_stride * b_len))
         {
 
             divisible_by_4 = (b_len % 4 == 0) and (b_stride % 4 == 0) and

--- a/src/targets/gpu/device/include/migraphx/gpu/device/nary.hpp
+++ b/src/targets/gpu/device/include/migraphx/gpu/device/nary.hpp
@@ -352,7 +352,7 @@ bool broadcastable(bool& divisible_by_4,
         auto b_len          = result.get_shape().lens()[b_idx];
         auto b_stride       = result.get_shape().strides()[b_idx];
         assert(bshape.lens()[b_idx] == b_len);
-        if(b_len <= max_size and std::none_of(std::next(b_it), strides.end(), not_zero))
+        if(b_len <= max_size and std::none_of(std::next(b_it), strides.end(), not_zero) and is_divisor_encodable(b_stride * b_len))
         {
 
             divisible_by_4 = (b_len % 4 == 0) and (b_stride % 4 == 0) and

--- a/test/verify/test_add_broadcast6.cpp
+++ b/test/verify/test_add_broadcast6.cpp
@@ -1,0 +1,22 @@
+
+#include "verify_program.hpp"
+#include <migraphx/program.hpp>
+#include <migraphx/generate.hpp>
+#include <migraphx/make_op.hpp>
+
+#include <migraphx/instruction.hpp>
+
+struct test_add_broadcast6: verify_program<test_add_broadcast6>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+        auto x  = mm->add_parameter("x", {migraphx::shape::float_type, {1, 64, 568, 1328}});
+        auto y  = mm->add_parameter("y", {migraphx::shape::float_type, {64}});
+        auto by = mm->add_instruction(
+            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {1, 64, 568, 1328}}}), y);
+        mm->add_instruction(migraphx::make_op("add"), x, by);
+        return p;
+    }
+};

--- a/test/verify/test_add_broadcast6.cpp
+++ b/test/verify/test_add_broadcast6.cpp
@@ -6,15 +6,15 @@
 
 #include <migraphx/instruction.hpp>
 
-struct test_add_broadcast6: verify_program<test_add_broadcast6>
+struct test_add_broadcast6 : verify_program<test_add_broadcast6>
 {
     migraphx::program create_program() const
     {
         migraphx::program p;
         auto* mm = p.get_main_module();
-        auto x  = mm->add_parameter("x", {migraphx::shape::float_type, {1, 64, 568, 1328}});
-        auto y  = mm->add_parameter("y", {migraphx::shape::float_type, {64}});
-        auto by = mm->add_instruction(
+        auto x   = mm->add_parameter("x", {migraphx::shape::float_type, {1, 64, 568, 1328}});
+        auto y   = mm->add_parameter("y", {migraphx::shape::float_type, {64}});
+        auto by  = mm->add_instruction(
             migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {1, 64, 568, 1328}}}), y);
         mm->add_instruction(migraphx::make_op("add"), x, by);
         return p;


### PR DESCRIPTION
Fixes bug in #903.

Problem: For broadcast operator, the divisor needs to be encoded for fast_div op, if the divisor is too big (which is the case for retinaface) it causes overflow during encoding causing mismatch between ref and gpu.

Thanks @pfultz2 @kahmed10 @scxiao 

<b>Before:</b>
<i> Assumes broadcastable, which in reality it is not:</i>

```
Run instruction: main:@8 = gpu::add(main:@5,main:@7,output) -> float_type, {1, 64, 568, 1328}, {48275456, 754304, 1328, 1}
RESULT:float_type, {1, 64, 754304}, {48275456, 754304, 1}
ARG1:float_type, {1, 64, 754304}, {48275456, 754304, 1}
ARG2:float_type, {1, 64, 754304}, {0, 1, 0}
BROADCASTABLE
Time: 11.3589ms, 12.0266ms
[...]
FAILED: ../RetinaFace_1p9.onnx
error: 0.0010996
Max diff: 1.08082
Mismatch at 5753843: 0.124554 != 0.124554
```

<b>After:</b>
```
Run instruction: main:@8 = gpu::add(main:@5,main:@7,output) -> float_type, {1, 64, 568, 1328}, {48275456, 754304, 1328, 1}
RESULT:float_type, {1, 64, 754304}, {48275456, 754304, 1}
ARG1:float_type, {1, 64, 754304}, {48275456, 754304, 1}
ARG2:float_type, {1, 64, 754304}, {0, 1, 0}
NOT BROADCASTABLE
Calling nary_nonstandard_nonpacked_impl...
Time: 10.8908ms, 12.3001ms
```


Closes #903 