### PR TITLE
Change attributes names to be more consistent and reflect better meaning

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -96,7 +96,7 @@ instruction_ref insert_common_op(module& m,
         if(input->get_shape().lens() != common.lens())
         {
             input = m.insert_instruction(
-                ins, make_op("multibroadcast", {{"output_lens", common.lens()}}), input);
+                ins, make_op("multibroadcast", {{"out_lens", common.lens()}}), input);
         }
         if(input->get_shape().type() != common.type())
         {

--- a/src/decompose.cpp
+++ b/src/decompose.cpp
@@ -39,9 +39,7 @@ struct find_dot_add
         {
             auto alpha = p.add_literal(literal{shape{a_ins->get_shape().type()}, {dot.alpha}});
             auto alpha_broadcast = p.insert_instruction(
-                ins,
-                make_op("multibroadcast", {{"out_lens", a_ins->get_shape().lens()}}),
-                alpha);
+                ins, make_op("multibroadcast", {{"out_lens", a_ins->get_shape().lens()}}), alpha);
             a_ins = p.insert_instruction(ins, make_op("mul"), a_ins, alpha_broadcast);
         }
         auto dot_ins = p.insert_instruction(ins, make_op(ins->name(), {{"beta", 0}}), a_ins, b_ins);
@@ -72,9 +70,7 @@ struct find_dot_alpha
         {
             auto alpha = p.add_literal(literal{shape{a_ins->get_shape().type()}, {dot.alpha}});
             auto alpha_broadcast = p.insert_instruction(
-                ins,
-                make_op("multibroadcast", {{"out_lens", a_ins->get_shape().lens()}}),
-                alpha);
+                ins, make_op("multibroadcast", {{"out_lens", a_ins->get_shape().lens()}}), alpha);
             a_ins = p.insert_instruction(ins, make_op("mul"), a_ins, alpha_broadcast);
         }
         p.replace_instruction(ins, make_op(ins->name(), {{"beta", 0}}), a_ins, b_ins);

--- a/src/decompose.cpp
+++ b/src/decompose.cpp
@@ -40,7 +40,7 @@ struct find_dot_add
             auto alpha = p.add_literal(literal{shape{a_ins->get_shape().type()}, {dot.alpha}});
             auto alpha_broadcast = p.insert_instruction(
                 ins,
-                make_op("multibroadcast", {{"output_lens", a_ins->get_shape().lens()}}),
+                make_op("multibroadcast", {{"out_lens", a_ins->get_shape().lens()}}),
                 alpha);
             a_ins = p.insert_instruction(ins, make_op("mul"), a_ins, alpha_broadcast);
         }
@@ -51,7 +51,7 @@ struct find_dot_add
         {
             auto beta = p.add_literal(literal{shape{c_ins->get_shape().type()}, {dot.beta}});
             auto beta_broadcast = p.insert_instruction(
-                ins, make_op("multibroadcast", {{"output_lens", ins->get_shape().lens()}}), beta);
+                ins, make_op("multibroadcast", {{"out_lens", ins->get_shape().lens()}}), beta);
             c_ins = p.insert_instruction(ins, make_op("mul"), c_ins, beta_broadcast);
         }
         p.replace_instruction(ins, make_op("add"), dot_ins, c_ins);
@@ -73,7 +73,7 @@ struct find_dot_alpha
             auto alpha = p.add_literal(literal{shape{a_ins->get_shape().type()}, {dot.alpha}});
             auto alpha_broadcast = p.insert_instruction(
                 ins,
-                make_op("multibroadcast", {{"output_lens", a_ins->get_shape().lens()}}),
+                make_op("multibroadcast", {{"out_lens", a_ins->get_shape().lens()}}),
                 alpha);
             a_ins = p.insert_instruction(ins, make_op("mul"), a_ins, alpha_broadcast);
         }

--- a/src/include/migraphx/op/broadcast.hpp
+++ b/src/include/migraphx/op/broadcast.hpp
@@ -30,7 +30,7 @@ struct broadcast
     template <class Self, class F>
     static auto reflect(Self& self, F f)
     {
-        return pack(f(self.axis, "axis"), f(self.broadcast_lens, "dims"));
+        return pack(f(self.axis, "axis"), f(self.broadcast_lens, "out_lens"));
     }
 
     std::string name() const { return "broadcast"; }

--- a/src/include/migraphx/op/multibroadcast.hpp
+++ b/src/include/migraphx/op/multibroadcast.hpp
@@ -23,7 +23,7 @@ struct multibroadcast
     template <class Self, class F>
     static auto reflect(Self& self, F f)
     {
-        return pack(f(self.output_lens, "output_lens"));
+        return pack(f(self.output_lens, "out_lens"));
     }
 
     std::string name() const { return "multibroadcast"; }

--- a/src/include/migraphx/op/reshape.hpp
+++ b/src/include/migraphx/op/reshape.hpp
@@ -23,7 +23,7 @@ struct reshape
     template <class Self, class F>
     static auto reflect(Self& self, F f)
     {
-        return pack(f(self.dims, "dims"));
+        return pack(f(self.dims, "out_lens"));
     }
 
     std::string name() const { return "reshape"; }

--- a/src/include/migraphx/op/reshape.hpp
+++ b/src/include/migraphx/op/reshape.hpp
@@ -23,7 +23,7 @@ struct reshape
     template <class Self, class F>
     static auto reflect(Self& self, F f)
     {
-        return pack(f(self.dims, "out_lens"));
+        return pack(f(self.dims, "dims"));
     }
 
     std::string name() const { return "reshape"; }

--- a/src/include/migraphx/op/transpose.hpp
+++ b/src/include/migraphx/op/transpose.hpp
@@ -21,7 +21,7 @@ struct transpose
     template <class Self, class F>
     static auto reflect(Self& self, F f)
     {
-        return pack(f(self.dims, "perm"));
+        return pack(f(self.dims, "permutation"));
     }
 
     std::string name() const { return "transpose"; }

--- a/src/include/migraphx/op/transpose.hpp
+++ b/src/include/migraphx/op/transpose.hpp
@@ -21,7 +21,7 @@ struct transpose
     template <class Self, class F>
     static auto reflect(Self& self, F f)
     {
-        return pack(f(self.dims, "dims"));
+        return pack(f(self.dims, "perm"));
     }
 
     std::string name() const { return "transpose"; }

--- a/src/onnx/onnx_parser.cpp
+++ b/src/onnx/onnx_parser.cpp
@@ -85,7 +85,7 @@ instruction_ref onnx_parser::node_info::add_bias(const std::vector<instruction_r
     if(args.size() == 3)
     {
         auto bias_bcast = mod->add_instruction(
-            make_op("broadcast", {{"axis", axis}, {"dims", curr_ins->get_shape().lens()}}),
+            make_op("broadcast", {{"axis", axis}, {"out_lens", curr_ins->get_shape().lens()}}),
             args[2]);
         return mod->add_instruction(make_op("add"), curr_ins, bias_bcast);
     }

--- a/src/onnx/parse_binary_op.cpp
+++ b/src/onnx/parse_binary_op.cpp
@@ -36,7 +36,8 @@ struct parse_binary_op : op_parser<parse_binary_op>
             {
                 uint64_t axis = parser.parse_value(info.attributes.at("axis")).at<uint64_t>();
                 auto l        = info.add_instruction(
-                    make_op("broadcast", {{"axis", axis}, {"out_lens", args[0]->get_shape().lens()}}),
+                    make_op("broadcast",
+                            {{"axis", axis}, {"out_lens", args[0]->get_shape().lens()}}),
                     args[1]);
                 return info.add_instruction(make_op(opd.op_name), args[0], l);
             }

--- a/src/onnx/parse_binary_op.cpp
+++ b/src/onnx/parse_binary_op.cpp
@@ -36,7 +36,7 @@ struct parse_binary_op : op_parser<parse_binary_op>
             {
                 uint64_t axis = parser.parse_value(info.attributes.at("axis")).at<uint64_t>();
                 auto l        = info.add_instruction(
-                    make_op("broadcast", {{"axis", axis}, {"dims", args[0]->get_shape().lens()}}),
+                    make_op("broadcast", {{"axis", axis}, {"out_lens", args[0]->get_shape().lens()}}),
                     args[1]);
                 return info.add_instruction(make_op(opd.op_name), args[0], l);
             }

--- a/src/onnx/parse_clip.cpp
+++ b/src/onnx/parse_clip.cpp
@@ -47,13 +47,13 @@ struct parse_clip : op_parser<parse_clip>
 
         if(min_used)
         {
-            min_arg = info.add_instruction(make_op("multibroadcast", {{"output_lens", input_lens}}),
+            min_arg = info.add_instruction(make_op("multibroadcast", {{"out_lens", input_lens}}),
                                            min_arg);
         }
 
         if(max_used)
         {
-            max_arg = info.add_instruction(make_op("multibroadcast", {{"output_lens", input_lens}}),
+            max_arg = info.add_instruction(make_op("multibroadcast", {{"out_lens", input_lens}}),
                                            max_arg);
         }
 

--- a/src/onnx/parse_dequantizelinear.cpp
+++ b/src/onnx/parse_dequantizelinear.cpp
@@ -29,11 +29,11 @@ struct parse_dequantizelinear : op_parser<parse_dequantizelinear>
         {
             auto tuned_axis = tune_axis(n_dim, axis, opd.op_name);
             x_scale         = info.add_instruction(
-                make_op("broadcast", {{"axis", tuned_axis}, {"dims", input_lens}}), args[1]);
+                make_op("broadcast", {{"axis", tuned_axis}, {"out_lens", input_lens}}), args[1]);
         }
         else
         {
-            x_scale = info.add_instruction(make_op("multibroadcast", {{"output_lens", input_lens}}),
+            x_scale = info.add_instruction(make_op("multibroadcast", {{"out_lens", input_lens}}),
                                            args[1]);
         }
 
@@ -44,13 +44,13 @@ struct parse_dequantizelinear : op_parser<parse_dequantizelinear>
             {
                 auto tuned_axis = tune_axis(n_dim, axis, opd.op_name);
                 x_zero_point    = info.add_instruction(
-                    make_op("broadcast", {{"axis", tuned_axis}, {"dims", input_lens}}),
+                    make_op("broadcast", {{"axis", tuned_axis}, {"out_lens", input_lens}}),
                     x_zero_point);
             }
             else
             {
                 x_zero_point = info.add_instruction(
-                    make_op("multibroadcast", {{"output_lens", input_lens}}), x_zero_point);
+                    make_op("multibroadcast", {{"out_lens", input_lens}}), x_zero_point);
             }
 
             return info.add_instruction(

--- a/src/onnx/parse_expand.cpp
+++ b/src/onnx/parse_expand.cpp
@@ -24,7 +24,7 @@ struct parse_expand : op_parser<parse_expand>
         std::vector<std::size_t> dims;
         arg_s.visit([&](auto input) { dims.assign(input.begin(), input.end()); });
         auto out_lens = compute_broadcasted_lens(in_lens, dims);
-        return info.add_instruction(make_op("multibroadcast", {{"output_lens", out_lens}}),
+        return info.add_instruction(make_op("multibroadcast", {{"out_lens", out_lens}}),
                                     args[0]);
     }
 };

--- a/src/onnx/parse_expand.cpp
+++ b/src/onnx/parse_expand.cpp
@@ -24,8 +24,7 @@ struct parse_expand : op_parser<parse_expand>
         std::vector<std::size_t> dims;
         arg_s.visit([&](auto input) { dims.assign(input.begin(), input.end()); });
         auto out_lens = compute_broadcasted_lens(in_lens, dims);
-        return info.add_instruction(make_op("multibroadcast", {{"out_lens", out_lens}}),
-                                    args[0]);
+        return info.add_instruction(make_op("multibroadcast", {{"out_lens", out_lens}}), args[0]);
     }
 };
 

--- a/src/onnx/parse_gather_elements.cpp
+++ b/src/onnx/parse_gather_elements.cpp
@@ -42,7 +42,7 @@ struct parse_gather_elements : op_parser<parse_gather_elements>
         int64_t data_elem_num = static_cast<int64_t>(data_s.elements());
         // reshape the input data as one dimension and used as input data
         // to the gather operator
-        arg_data = info.add_instruction(make_op("reshape", {{"dims", {data_elem_num}}}), arg_data);
+        arg_data = info.add_instruction(make_op("reshape", {{"out_lens", {data_elem_num}}}), arg_data);
 
         std::size_t elem_num = ind_s.elements();
         std::vector<int> ind_index(elem_num);
@@ -63,8 +63,8 @@ struct parse_gather_elements : op_parser<parse_gather_elements>
             info.add_literal(literal(ind_s, data_indices.begin(), data_indices.end()));
         auto l_dim_idx = info.add_literal(literal(ind_s, vec_axis_ind.begin(), vec_axis_ind.end()));
         auto l_stride  = info.add_literal(literal{{ind_s.type(), {1}}, {axis_stride}});
-        l_stride = info.add_instruction(make_op("multibroadcast", {{"out_lens", ind_s.lens()}}),
-                                        l_stride);
+        l_stride =
+            info.add_instruction(make_op("multibroadcast", {{"out_lens", ind_s.lens()}}), l_stride);
         auto dim_diff = info.add_instruction(make_op("sub"), arg_ind, l_dim_idx);
         auto delta    = info.add_instruction(make_op("mul"), dim_diff, l_stride);
         auto ind      = info.add_instruction(make_op("add"), l_shape_idx, delta);

--- a/src/onnx/parse_gather_elements.cpp
+++ b/src/onnx/parse_gather_elements.cpp
@@ -42,8 +42,7 @@ struct parse_gather_elements : op_parser<parse_gather_elements>
         int64_t data_elem_num = static_cast<int64_t>(data_s.elements());
         // reshape the input data as one dimension and used as input data
         // to the gather operator
-        arg_data =
-            info.add_instruction(make_op("reshape", {{"out_lens", {data_elem_num}}}), arg_data);
+        arg_data = info.add_instruction(make_op("reshape", {{"dims", {data_elem_num}}}), arg_data);
 
         std::size_t elem_num = ind_s.elements();
         std::vector<int> ind_index(elem_num);

--- a/src/onnx/parse_gather_elements.cpp
+++ b/src/onnx/parse_gather_elements.cpp
@@ -42,7 +42,8 @@ struct parse_gather_elements : op_parser<parse_gather_elements>
         int64_t data_elem_num = static_cast<int64_t>(data_s.elements());
         // reshape the input data as one dimension and used as input data
         // to the gather operator
-        arg_data = info.add_instruction(make_op("reshape", {{"out_lens", {data_elem_num}}}), arg_data);
+        arg_data =
+            info.add_instruction(make_op("reshape", {{"out_lens", {data_elem_num}}}), arg_data);
 
         std::size_t elem_num = ind_s.elements();
         std::vector<int> ind_index(elem_num);

--- a/src/onnx/parse_gather_elements.cpp
+++ b/src/onnx/parse_gather_elements.cpp
@@ -63,7 +63,7 @@ struct parse_gather_elements : op_parser<parse_gather_elements>
             info.add_literal(literal(ind_s, data_indices.begin(), data_indices.end()));
         auto l_dim_idx = info.add_literal(literal(ind_s, vec_axis_ind.begin(), vec_axis_ind.end()));
         auto l_stride  = info.add_literal(literal{{ind_s.type(), {1}}, {axis_stride}});
-        l_stride = info.add_instruction(make_op("multibroadcast", {{"output_lens", ind_s.lens()}}),
+        l_stride = info.add_instruction(make_op("multibroadcast", {{"out_lens", ind_s.lens()}}),
                                         l_stride);
         auto dim_diff = info.add_instruction(make_op("sub"), arg_ind, l_dim_idx);
         auto delta    = info.add_instruction(make_op("mul"), dim_diff, l_stride);

--- a/src/onnx/parse_gemm.cpp
+++ b/src/onnx/parse_gemm.cpp
@@ -72,7 +72,7 @@ struct parse_gemm : op_parser<parse_gemm>
                 if(!std::equal(out_lens.begin(), out_lens.end(), l3_lens.begin(), l3_lens.end()))
                 {
                     l3 = info.add_instruction(
-                        make_op("multibroadcast", {{"output_lens", out_lens}}), args[2]);
+                        make_op("multibroadcast", {{"out_lens", out_lens}}), args[2]);
                 }
                 auto beta_literal = info.add_literal(beta);
                 auto beta_l3      = info.add_broadcastable_binary_op("mul", l3, beta_literal);

--- a/src/onnx/parse_gemm.cpp
+++ b/src/onnx/parse_gemm.cpp
@@ -71,8 +71,8 @@ struct parse_gemm : op_parser<parse_gemm>
                 auto l3_lens    = l3->get_shape().lens();
                 if(!std::equal(out_lens.begin(), out_lens.end(), l3_lens.begin(), l3_lens.end()))
                 {
-                    l3 = info.add_instruction(
-                        make_op("multibroadcast", {{"out_lens", out_lens}}), args[2]);
+                    l3 = info.add_instruction(make_op("multibroadcast", {{"out_lens", out_lens}}),
+                                              args[2]);
                 }
                 auto beta_literal = info.add_literal(beta);
                 auto beta_l3      = info.add_broadcastable_binary_op("mul", l3, beta_literal);

--- a/src/onnx/parse_gemm.cpp
+++ b/src/onnx/parse_gemm.cpp
@@ -55,9 +55,11 @@ struct parse_gemm : op_parser<parse_gemm>
             }
         }
 
-        l1      = (transa) ? info.add_instruction(make_op("transpose", {{"perm", perm}}), l1) : l1;
-        auto l2 = (transb) ? info.add_instruction(make_op("transpose", {{"perm", perm}}), args[1])
-                           : args[1];
+        l1 =
+            (transa) ? info.add_instruction(make_op("transpose", {{"permutation", perm}}), l1) : l1;
+        auto l2 = (transb)
+                      ? info.add_instruction(make_op("transpose", {{"permutation", perm}}), args[1])
+                      : args[1];
 
         auto ret = info.add_instruction(make_op("dot", {{"alpha", 1.0f}, {"beta", 0.0f}}), l1, l2);
 

--- a/src/onnx/parse_gemm.cpp
+++ b/src/onnx/parse_gemm.cpp
@@ -55,8 +55,8 @@ struct parse_gemm : op_parser<parse_gemm>
             }
         }
 
-        l1      = (transa) ? info.add_instruction(make_op("transpose", {{"dims", perm}}), l1) : l1;
-        auto l2 = (transb) ? info.add_instruction(make_op("transpose", {{"dims", perm}}), args[1])
+        l1      = (transa) ? info.add_instruction(make_op("transpose", {{"perm", perm}}), l1) : l1;
+        auto l2 = (transb) ? info.add_instruction(make_op("transpose", {{"perm", perm}}), args[1])
                            : args[1];
 
         auto ret = info.add_instruction(make_op("dot", {{"alpha", 1.0f}, {"beta", 0.0f}}), l1, l2);

--- a/src/onnx/parse_imagescalar.cpp
+++ b/src/onnx/parse_imagescalar.cpp
@@ -40,7 +40,7 @@ struct parse_imagescalar : op_parser<parse_imagescalar>
         auto img_scaled =
             info.add_instruction(migraphx::make_op("mul"), args.front(), scale_tensor);
         auto bias_bcast = info.add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", input_lens}}), bias_vals);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", input_lens}}), bias_vals);
         return info.add_instruction(migraphx::make_op("add"), img_scaled, bias_bcast);
     }
 };

--- a/src/onnx/parse_instancenorm.cpp
+++ b/src/onnx/parse_instancenorm.cpp
@@ -38,23 +38,23 @@ struct parse_instancenorm : op_parser<parse_instancenorm>
 
         auto mean = info.add_instruction(make_op("reduce_mean", {{"axes", axes}}), x);
         auto mean_bcast =
-            info.add_instruction(make_op("multibroadcast", {{"output_lens", dims}}), mean);
+            info.add_instruction(make_op("multibroadcast", {{"out_lens", dims}}), mean);
         auto l0              = info.add_instruction(make_op("sqdiff"), x, mean_bcast);
         auto variance        = info.add_instruction(make_op("reduce_mean", {{"axes", axes}}), l0);
         auto l1              = info.add_instruction(make_op("sub"), x, mean_bcast);
         auto epsilon_literal = info.add_literal(epsilon);
         auto epsilon_bcast   = info.add_instruction(
-            make_op("multibroadcast", {{"output_lens", dims}}), epsilon_literal);
+            make_op("multibroadcast", {{"out_lens", dims}}), epsilon_literal);
         auto variance_bcast =
-            info.add_instruction(make_op("multibroadcast", {{"output_lens", dims}}), variance);
+            info.add_instruction(make_op("multibroadcast", {{"out_lens", dims}}), variance);
         auto l2 = info.add_instruction(make_op("add"), variance_bcast, epsilon_bcast);
         auto l3 = info.add_instruction(make_op("rsqrt"), l2);
         auto l4 = info.add_instruction(make_op("mul"), l1, l3);
         auto scale_bcast =
-            info.add_instruction(make_op("broadcast", {{"axis", 1}, {"dims", dims}}), scale);
+            info.add_instruction(make_op("broadcast", {{"axis", 1}, {"out_lens", dims}}), scale);
         ;
         auto bias_bcast =
-            info.add_instruction(make_op("broadcast", {{"axis", 1}, {"dims", dims}}), bias);
+            info.add_instruction(make_op("broadcast", {{"axis", 1}, {"out_lens", dims}}), bias);
         auto l5 = info.add_instruction(make_op("mul"), l4, scale_bcast);
         return info.add_instruction(make_op("add"), l5, bias_bcast);
     }

--- a/src/onnx/parse_instancenorm.cpp
+++ b/src/onnx/parse_instancenorm.cpp
@@ -43,8 +43,8 @@ struct parse_instancenorm : op_parser<parse_instancenorm>
         auto variance        = info.add_instruction(make_op("reduce_mean", {{"axes", axes}}), l0);
         auto l1              = info.add_instruction(make_op("sub"), x, mean_bcast);
         auto epsilon_literal = info.add_literal(epsilon);
-        auto epsilon_bcast   = info.add_instruction(
-            make_op("multibroadcast", {{"out_lens", dims}}), epsilon_literal);
+        auto epsilon_bcast =
+            info.add_instruction(make_op("multibroadcast", {{"out_lens", dims}}), epsilon_literal);
         auto variance_bcast =
             info.add_instruction(make_op("multibroadcast", {{"out_lens", dims}}), variance);
         auto l2 = info.add_instruction(make_op("add"), variance_bcast, epsilon_bcast);

--- a/src/onnx/parse_matmul.cpp
+++ b/src/onnx/parse_matmul.cpp
@@ -58,12 +58,12 @@ struct parse_matmul : op_parser<parse_matmul>
             if(l0_lens != l0_broadcasted_lens)
             {
                 bl0 = info.add_instruction(
-                    make_op("multibroadcast", {{"output_lens", l0_broadcasted_lens}}), l0);
+                    make_op("multibroadcast", {{"out_lens", l0_broadcasted_lens}}), l0);
             }
             if(l1_lens != l1_broadcasted_lens)
             {
                 bl1 = info.add_instruction(
-                    make_op("multibroadcast", {{"output_lens", l1_broadcasted_lens}}), l1);
+                    make_op("multibroadcast", {{"out_lens", l1_broadcasted_lens}}), l1);
             }
         }
 

--- a/src/onnx/parse_onehot.cpp
+++ b/src/onnx/parse_onehot.cpp
@@ -45,7 +45,7 @@ struct parse_onehot : op_parser<parse_onehot>
         std::vector<int64_t> perm(n_rank - 1);
         std::iota(perm.begin(), perm.end(), 0);
         perm.insert(perm.begin() + tuned_axis, n_rank - 1);
-        auto tr_out = info.add_instruction(make_op("transpose", {{"dims", perm}}), gather_out);
+        auto tr_out = info.add_instruction(make_op("transpose", {{"perm", perm}}), gather_out);
         auto lens   = tr_out->get_shape().lens();
 
         auto off_val = info.add_instruction(

--- a/src/onnx/parse_onehot.cpp
+++ b/src/onnx/parse_onehot.cpp
@@ -45,8 +45,9 @@ struct parse_onehot : op_parser<parse_onehot>
         std::vector<int64_t> perm(n_rank - 1);
         std::iota(perm.begin(), perm.end(), 0);
         perm.insert(perm.begin() + tuned_axis, n_rank - 1);
-        auto tr_out = info.add_instruction(make_op("transpose", {{"perm", perm}}), gather_out);
-        auto lens   = tr_out->get_shape().lens();
+        auto tr_out =
+            info.add_instruction(make_op("transpose", {{"permutation", perm}}), gather_out);
+        auto lens = tr_out->get_shape().lens();
 
         auto off_val = info.add_instruction(
             make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", {1}}}), args[2]);

--- a/src/onnx/parse_onehot.cpp
+++ b/src/onnx/parse_onehot.cpp
@@ -54,9 +54,9 @@ struct parse_onehot : op_parser<parse_onehot>
             make_op("slice", {{"axes", {0}}, {"starts", {1}}, {"ends", {2}}}), args[2]);
         auto diff = info.add_instruction(make_op("sub"), on_val, off_val);
         auto unsq_off_val =
-            info.add_instruction(make_op("multibroadcast", {{"output_lens", lens}}), off_val);
+            info.add_instruction(make_op("multibroadcast", {{"out_lens", lens}}), off_val);
         auto unsq_diff_val =
-            info.add_instruction(make_op("multibroadcast", {{"output_lens", lens}}), diff);
+            info.add_instruction(make_op("multibroadcast", {{"out_lens", lens}}), diff);
         auto l_mul = info.add_instruction(make_op("mul"), tr_out, unsq_diff_val);
         return info.add_instruction(make_op("add"), l_mul, unsq_off_val);
     }

--- a/src/onnx/parse_quantizelinear.cpp
+++ b/src/onnx/parse_quantizelinear.cpp
@@ -29,11 +29,11 @@ struct parse_quantizelinear : op_parser<parse_quantizelinear>
         {
             auto tuned_axis = tune_axis(n_dim, axis, opd.op_name);
             y_scale         = info.add_instruction(
-                make_op("broadcast", {{"axis", tuned_axis}, {"dims", input_lens}}), args[1]);
+                make_op("broadcast", {{"axis", tuned_axis}, {"out_lens", input_lens}}), args[1]);
         }
         else
         {
-            y_scale = info.add_instruction(make_op("multibroadcast", {{"output_lens", input_lens}}),
+            y_scale = info.add_instruction(make_op("multibroadcast", {{"out_lens", input_lens}}),
                                            args[1]);
         }
 
@@ -44,13 +44,13 @@ struct parse_quantizelinear : op_parser<parse_quantizelinear>
             {
                 auto tuned_axis = tune_axis(n_dim, axis, opd.op_name);
                 y_zero_point    = info.add_instruction(
-                    make_op("broadcast", {{"axis", tuned_axis}, {"dims", input_lens}}),
+                    make_op("broadcast", {{"axis", tuned_axis}, {"out_lens", input_lens}}),
                     y_zero_point);
             }
             else
             {
                 y_zero_point = info.add_instruction(
-                    make_op("multibroadcast", {{"output_lens", input_lens}}), y_zero_point);
+                    make_op("multibroadcast", {{"out_lens", input_lens}}), y_zero_point);
             }
 
             return info.add_instruction(make_op("quantizelinear"), args[0], y_scale, y_zero_point);

--- a/src/onnx/parse_reshape.cpp
+++ b/src/onnx/parse_reshape.cpp
@@ -30,7 +30,7 @@ struct parse_reshape : op_parser<parse_reshape>
             s.visit([&](auto v) { copy(v, std::back_inserter(dims)); });
         }
 
-        return info.add_instruction(make_op("reshape", {{"dims", dims}}),
+        return info.add_instruction(make_op("reshape", {{"out_lens", dims}}),
                                     info.make_contiguous(args[0]));
     }
 };

--- a/src/onnx/parse_reshape.cpp
+++ b/src/onnx/parse_reshape.cpp
@@ -30,7 +30,7 @@ struct parse_reshape : op_parser<parse_reshape>
             s.visit([&](auto v) { copy(v, std::back_inserter(dims)); });
         }
 
-        return info.add_instruction(make_op("reshape", {{"out_lens", dims}}),
+        return info.add_instruction(make_op("reshape", {{"dims", dims}}),
                                     info.make_contiguous(args[0]));
     }
 };

--- a/src/onnx/parse_resize.cpp
+++ b/src/onnx/parse_resize.cpp
@@ -265,7 +265,7 @@ struct parse_resize : op_parser<parse_resize>
         // reshape input to one-dimension
         std::vector<int64_t> rsp_lens = {static_cast<int64_t>(in_s.elements())};
         args[0]                       = info.make_contiguous(args[0]);
-        auto rsp = info.add_instruction(make_op("reshape", {{"out_lens", rsp_lens}}), args[0]);
+        auto rsp = info.add_instruction(make_op("reshape", {{"dims", rsp_lens}}), args[0]);
 
         if(mode == "nearest")
         {

--- a/src/onnx/parse_resize.cpp
+++ b/src/onnx/parse_resize.cpp
@@ -265,7 +265,7 @@ struct parse_resize : op_parser<parse_resize>
         // reshape input to one-dimension
         std::vector<int64_t> rsp_lens = {static_cast<int64_t>(in_s.elements())};
         args[0]                       = info.make_contiguous(args[0]);
-        auto rsp = info.add_instruction(make_op("reshape", {{"dims", rsp_lens}}), args[0]);
+        auto rsp = info.add_instruction(make_op("reshape", {{"out_lens", rsp_lens}}), args[0]);
 
         if(mode == "nearest")
         {

--- a/src/onnx/parse_selu.cpp
+++ b/src/onnx/parse_selu.cpp
@@ -35,9 +35,9 @@ struct parse_selu : op_parser<parse_selu>
         if(lens != std::vector<std::size_t>{1})
         {
             l_alpha =
-                info.add_instruction(make_op("multibroadcast", {{"output_lens", lens}}), l_alpha);
+                info.add_instruction(make_op("multibroadcast", {{"out_lens", lens}}), l_alpha);
             l_gamma =
-                info.add_instruction(make_op("multibroadcast", {{"output_lens", lens}}), l_gamma);
+                info.add_instruction(make_op("multibroadcast", {{"out_lens", lens}}), l_gamma);
         }
 
         auto sign_x = info.add_instruction(make_op("sign"), args[0]);

--- a/src/onnx/parse_transpose.cpp
+++ b/src/onnx/parse_transpose.cpp
@@ -21,7 +21,7 @@ struct parse_transpose : op_parser<parse_transpose>
             auto&& perm_vals = info.attributes["perm"].ints();
             perm             = std::vector<int64_t>(perm_vals.begin(), perm_vals.end());
         }
-        return info.add_instruction(make_op("transpose", {{"dims", perm}}), args.front());
+        return info.add_instruction(make_op("transpose", {{"perm", perm}}), args.front());
     }
 };
 

--- a/src/onnx/parse_transpose.cpp
+++ b/src/onnx/parse_transpose.cpp
@@ -21,7 +21,7 @@ struct parse_transpose : op_parser<parse_transpose>
             auto&& perm_vals = info.attributes["perm"].ints();
             perm             = std::vector<int64_t>(perm_vals.begin(), perm_vals.end());
         }
-        return info.add_instruction(make_op("transpose", {{"perm", perm}}), args.front());
+        return info.add_instruction(make_op("transpose", {{"permutation", perm}}), args.front());
     }
 };
 

--- a/src/onnx/parse_upsample.cpp
+++ b/src/onnx/parse_upsample.cpp
@@ -75,7 +75,7 @@ struct parse_upsample : op_parser<parse_upsample>
         // reshape input to one-dimension
         std::vector<int64_t> rsp_lens = {static_cast<int64_t>(in_s.elements())};
         shape ind_s{shape::int32_type, out_lens};
-        auto rsp     = info.add_instruction(make_op("reshape", {{"out_lens", rsp_lens}}), args[0]);
+        auto rsp     = info.add_instruction(make_op("reshape", {{"dims", rsp_lens}}), args[0]);
         auto ins_ind = info.add_literal(literal(ind_s, ind));
         return info.add_instruction(make_op("gather", {{"axis", 0}}), rsp, ins_ind);
     }

--- a/src/onnx/parse_upsample.cpp
+++ b/src/onnx/parse_upsample.cpp
@@ -75,7 +75,7 @@ struct parse_upsample : op_parser<parse_upsample>
         // reshape input to one-dimension
         std::vector<int64_t> rsp_lens = {static_cast<int64_t>(in_s.elements())};
         shape ind_s{shape::int32_type, out_lens};
-        auto rsp     = info.add_instruction(make_op("reshape", {{"dims", rsp_lens}}), args[0]);
+        auto rsp     = info.add_instruction(make_op("reshape", {{"out_lens", rsp_lens}}), args[0]);
         auto ins_ind = info.add_literal(literal(ind_s, ind));
         return info.add_instruction(make_op("gather", {{"axis", 0}}), rsp, ins_ind);
     }

--- a/src/onnx/parse_where.cpp
+++ b/src/onnx/parse_where.cpp
@@ -23,19 +23,19 @@ struct parse_where : op_parser<parse_where>
         lens      = compute_broadcasted_lens(lens, args[2]->get_shape().lens());
         if(cond->get_shape().lens() != lens)
         {
-            cond = info.add_instruction(make_op("multibroadcast", {{"output_lens", lens}}), cond);
+            cond = info.add_instruction(make_op("multibroadcast", {{"out_lens", lens}}), cond);
         }
 
         if(args[1]->get_shape().lens() != lens)
         {
             args[1] =
-                info.add_instruction(make_op("multibroadcast", {{"output_lens", lens}}), args[1]);
+                info.add_instruction(make_op("multibroadcast", {{"out_lens", lens}}), args[1]);
         }
 
         if(args[2]->get_shape().lens() != lens)
         {
             args[2] =
-                info.add_instruction(make_op("multibroadcast", {{"output_lens", lens}}), args[2]);
+                info.add_instruction(make_op("multibroadcast", {{"out_lens", lens}}), args[2]);
         }
 
         // compute index

--- a/src/onnx/parse_where.cpp
+++ b/src/onnx/parse_where.cpp
@@ -44,7 +44,7 @@ struct parse_where : op_parser<parse_where>
         // concatenation of input data
         auto concat_data = info.add_instruction(make_op("concat", {{"axis", 0}}), args[2], args[1]);
         std::vector<int64_t> dims = {static_cast<int64_t>(2 * elem_num)};
-        auto rsp_data = info.add_instruction(make_op("reshape", {{"dims", dims}}), concat_data);
+        auto rsp_data = info.add_instruction(make_op("reshape", {{"out_lens", dims}}), concat_data);
 
         std::vector<int> ind(elem_num);
         std::iota(ind.begin(), ind.end(), 0);

--- a/src/onnx/parse_where.cpp
+++ b/src/onnx/parse_where.cpp
@@ -44,7 +44,7 @@ struct parse_where : op_parser<parse_where>
         // concatenation of input data
         auto concat_data = info.add_instruction(make_op("concat", {{"axis", 0}}), args[2], args[1]);
         std::vector<int64_t> dims = {static_cast<int64_t>(2 * elem_num)};
-        auto rsp_data = info.add_instruction(make_op("reshape", {{"out_lens", dims}}), concat_data);
+        auto rsp_data = info.add_instruction(make_op("reshape", {{"dims", dims}}), concat_data);
 
         std::vector<int> ind(elem_num);
         std::iota(ind.begin(), ind.end(), 0);

--- a/src/quantization.cpp
+++ b/src/quantization.cpp
@@ -93,9 +93,9 @@ instruction_ref insert_quant_ins(module& modl,
         auto max_clip     = modl.add_literal(127.0f);
         auto min_clip     = modl.add_literal(-128.0f);
         max_clip          = modl.insert_instruction(
-            insert_loc, make_op("multibroadcast", {{"output_lens", rounded_lens}}), max_clip);
+            insert_loc, make_op("multibroadcast", {{"out_lens", rounded_lens}}), max_clip);
         min_clip = modl.insert_instruction(
-            insert_loc, make_op("multibroadcast", {{"output_lens", rounded_lens}}), min_clip);
+            insert_loc, make_op("multibroadcast", {{"out_lens", rounded_lens}}), min_clip);
         auto clipped_ins =
             modl.insert_instruction(insert_loc, make_op("clip"), rounded_ins, min_clip, max_clip);
         quant_ins = modl.insert_instruction(

--- a/src/rewrite_pooling.cpp
+++ b/src/rewrite_pooling.cpp
@@ -34,7 +34,7 @@ void rewrite_pooling::apply(module& prog) const
         std::int64_t n = s.lens()[0];
         std::int64_t c = s.lens()[1];
         auto reshape   = prog.insert_instruction(
-            ins, make_op("reshape", {{"dims", {n * c, -1}}}), ins->inputs().front());
+            ins, make_op("reshape", {{"out_lens", {n * c, -1}}}), ins->inputs().front());
         instruction_ref pooling{};
 
         // average pooling
@@ -52,7 +52,7 @@ void rewrite_pooling::apply(module& prog) const
         std::vector<int64_t> rsp_lens(lens.size(), 1);
         rsp_lens[0] = n;
         rsp_lens[1] = c;
-        prog.replace_instruction(ins, make_op("reshape", {{"dims", rsp_lens}}), pooling);
+        prog.replace_instruction(ins, make_op("reshape", {{"out_lens", rsp_lens}}), pooling);
     }
 }
 

--- a/src/rewrite_pooling.cpp
+++ b/src/rewrite_pooling.cpp
@@ -34,7 +34,7 @@ void rewrite_pooling::apply(module& prog) const
         std::int64_t n = s.lens()[0];
         std::int64_t c = s.lens()[1];
         auto reshape   = prog.insert_instruction(
-            ins, make_op("reshape", {{"out_lens", {n * c, -1}}}), ins->inputs().front());
+            ins, make_op("reshape", {{"dims", {n * c, -1}}}), ins->inputs().front());
         instruction_ref pooling{};
 
         // average pooling
@@ -52,7 +52,7 @@ void rewrite_pooling::apply(module& prog) const
         std::vector<int64_t> rsp_lens(lens.size(), 1);
         rsp_lens[0] = n;
         rsp_lens[1] = c;
-        prog.replace_instruction(ins, make_op("reshape", {{"out_lens", rsp_lens}}), pooling);
+        prog.replace_instruction(ins, make_op("reshape", {{"dims", rsp_lens}}), pooling);
     }
 }
 

--- a/src/rewrite_rnn.cpp
+++ b/src/rewrite_rnn.cpp
@@ -263,7 +263,7 @@ std::vector<instruction_ref> rewrite_rnn::vanilla_rnn_cell(bool is_forward,
             ins, make_op("slice", {{"axes", {0}}, {"starts", {hs}}, {"ends", {2 * hs}}}), sbias);
         auto wrb = prog.insert_instruction(ins, make_op("add"), wb, rb);
         bb       = prog.insert_instruction(
-            ins, make_op("broadcast", {{"axis", 1}, {"dims", sih_lens}}), wrb);
+            ins, make_op("broadcast", {{"axis", 1}, {"out_lens", sih_lens}}), wrb);
     }
 
     instruction_ref hidden_out = prog.end();
@@ -592,7 +592,7 @@ std::vector<instruction_ref> rewrite_rnn::gru_cell(bool is_forward,
             ins, make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", {3 * hs}}}), sbias);
         bwb = prog.insert_instruction(
             ins,
-            make_op("broadcast", {{"axis", 1}, {"dims", {bs, static_cast<size_t>(3 * hs)}}}),
+            make_op("broadcast", {{"axis", 1}, {"out_lens", {bs, static_cast<size_t>(3 * hs)}}}),
             wb);
 
         auto rb_zr = prog.insert_instruction(
@@ -605,11 +605,11 @@ std::vector<instruction_ref> rewrite_rnn::gru_cell(bool is_forward,
             sbias);
         brb_zr = prog.insert_instruction(
             ins,
-            make_op("broadcast", {{"axis", 1}, {"dims", {bs, static_cast<size_t>(2 * hs)}}}),
+            make_op("broadcast", {{"axis", 1}, {"out_lens", {bs, static_cast<size_t>(2 * hs)}}}),
             rb_zr);
         brb_h = prog.insert_instruction(
             ins,
-            make_op("broadcast", {{"axis", 1}, {"dims", {bs, static_cast<size_t>(hs)}}}),
+            make_op("broadcast", {{"axis", 1}, {"out_lens", {bs, static_cast<size_t>(hs)}}}),
             rb_h);
     }
 
@@ -1067,7 +1067,7 @@ std::vector<instruction_ref> rewrite_rnn::lstm_cell(bool is_forward,
 
         wrb = prog.insert_instruction(
             ins,
-            make_op("broadcast", {{"axis", 1}, {"dims", {bs, 4 * static_cast<size_t>(hs)}}}),
+            make_op("broadcast", {{"axis", 1}, {"out_lens", {bs, 4 * static_cast<size_t>(hs)}}}),
             ub_wrb);
     }
 
@@ -1081,17 +1081,17 @@ std::vector<instruction_ref> rewrite_rnn::lstm_cell(bool is_forward,
         auto pphi = prog.insert_instruction(
             ins, make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", {hs}}}), spph);
         pphi_brcst = prog.insert_instruction(
-            ins, make_op("broadcast", {{"axis", 1}, {"dims", ic_lens}}), pphi);
+            ins, make_op("broadcast", {{"axis", 1}, {"out_lens", ic_lens}}), pphi);
 
         auto ppho = prog.insert_instruction(
             ins, make_op("slice", {{"axes", {0}}, {"starts", {hs}}, {"ends", {2 * hs}}}), spph);
         ppho_brcst = prog.insert_instruction(
-            ins, make_op("broadcast", {{"axis", 1}, {"dims", ic_lens}}), ppho);
+            ins, make_op("broadcast", {{"axis", 1}, {"out_lens", ic_lens}}), ppho);
 
         auto pphf = prog.insert_instruction(
             ins, make_op("slice", {{"axes", {0}}, {"starts", {2 * hs}}, {"ends", {3 * hs}}}), spph);
         pphf_brcst = prog.insert_instruction(
-            ins, make_op("broadcast", {{"axis", 1}, {"dims", ic_lens}}), pphf);
+            ins, make_op("broadcast", {{"axis", 1}, {"out_lens", ic_lens}}), pphf);
     }
 
     long seq_len = static_cast<long>(get_seq_len(prog, seq, seq_lens));

--- a/src/rewrite_rnn.cpp
+++ b/src/rewrite_rnn.cpp
@@ -241,11 +241,11 @@ std::vector<instruction_ref> rewrite_rnn::vanilla_rnn_cell(bool is_forward,
     // squeeze and transpose w
     std::vector<int64_t> perm{1, 0};
     auto sw      = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), w);
-    auto tran_sw = prog.insert_instruction(ins, make_op("transpose", {{"perm", perm}}), sw);
+    auto tran_sw = prog.insert_instruction(ins, make_op("transpose", {{"permutation", perm}}), sw);
 
     // squeeze and transpose r
     auto sr      = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), r);
-    auto tran_sr = prog.insert_instruction(ins, make_op("transpose", {{"perm", perm}}), sr);
+    auto tran_sr = prog.insert_instruction(ins, make_op("transpose", {{"permutation", perm}}), sr);
 
     // initial hidden state
     auto sih      = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), ih);
@@ -565,17 +565,17 @@ std::vector<instruction_ref> rewrite_rnn::gru_cell(bool is_forward,
     // w matrix squeeze to 2-dim and do a transpose
     std::vector<int64_t> perm{1, 0};
     auto sw = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), w);
-    auto tw = prog.insert_instruction(ins, make_op("transpose", {{"perm", perm}}), sw);
+    auto tw = prog.insert_instruction(ins, make_op("transpose", {{"permutation", perm}}), sw);
 
     // r slide to two part, zr and h
     auto sr  = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), r);
     auto rzr = prog.insert_instruction(
         ins, make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", {2 * hs}}}), sr);
-    auto trzr = prog.insert_instruction(ins, make_op("transpose", {{"perm", perm}}), rzr);
+    auto trzr = prog.insert_instruction(ins, make_op("transpose", {{"permutation", perm}}), rzr);
 
     auto rh = prog.insert_instruction(
         ins, make_op("slice", {{"axes", {0}}, {"starts", {2 * hs}}, {"ends", {3 * hs}}}), sr);
-    auto trh = prog.insert_instruction(ins, make_op("transpose", {{"perm", perm}}), rh);
+    auto trh = prog.insert_instruction(ins, make_op("transpose", {{"permutation", perm}}), rh);
 
     // initial states
     auto sih  = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), ih);
@@ -1038,11 +1038,11 @@ std::vector<instruction_ref> rewrite_rnn::lstm_cell(bool is_forward,
     std::vector<int64_t> perm{1, 0};
     // w matrix, squeeze and transpose
     auto sw  = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), w);
-    auto tsw = prog.insert_instruction(ins, make_op("transpose", {{"perm", perm}}), sw);
+    auto tsw = prog.insert_instruction(ins, make_op("transpose", {{"permutation", perm}}), sw);
 
     // r matrix, squeeze and transpose
     auto sr  = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), r);
-    auto tsr = prog.insert_instruction(ins, make_op("transpose", {{"perm", perm}}), sr);
+    auto tsr = prog.insert_instruction(ins, make_op("transpose", {{"permutation", perm}}), sr);
 
     // initial hidden state
     auto sih = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), ih);

--- a/src/rewrite_rnn.cpp
+++ b/src/rewrite_rnn.cpp
@@ -241,11 +241,11 @@ std::vector<instruction_ref> rewrite_rnn::vanilla_rnn_cell(bool is_forward,
     // squeeze and transpose w
     std::vector<int64_t> perm{1, 0};
     auto sw      = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), w);
-    auto tran_sw = prog.insert_instruction(ins, make_op("transpose", {{"dims", perm}}), sw);
+    auto tran_sw = prog.insert_instruction(ins, make_op("transpose", {{"perm", perm}}), sw);
 
     // squeeze and transpose r
     auto sr      = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), r);
-    auto tran_sr = prog.insert_instruction(ins, make_op("transpose", {{"dims", perm}}), sr);
+    auto tran_sr = prog.insert_instruction(ins, make_op("transpose", {{"perm", perm}}), sr);
 
     // initial hidden state
     auto sih      = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), ih);
@@ -565,17 +565,17 @@ std::vector<instruction_ref> rewrite_rnn::gru_cell(bool is_forward,
     // w matrix squeeze to 2-dim and do a transpose
     std::vector<int64_t> perm{1, 0};
     auto sw = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), w);
-    auto tw = prog.insert_instruction(ins, make_op("transpose", {{"dims", perm}}), sw);
+    auto tw = prog.insert_instruction(ins, make_op("transpose", {{"perm", perm}}), sw);
 
     // r slide to two part, zr and h
     auto sr  = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), r);
     auto rzr = prog.insert_instruction(
         ins, make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", {2 * hs}}}), sr);
-    auto trzr = prog.insert_instruction(ins, make_op("transpose", {{"dims", perm}}), rzr);
+    auto trzr = prog.insert_instruction(ins, make_op("transpose", {{"perm", perm}}), rzr);
 
     auto rh = prog.insert_instruction(
         ins, make_op("slice", {{"axes", {0}}, {"starts", {2 * hs}}, {"ends", {3 * hs}}}), sr);
-    auto trh = prog.insert_instruction(ins, make_op("transpose", {{"dims", perm}}), rh);
+    auto trh = prog.insert_instruction(ins, make_op("transpose", {{"perm", perm}}), rh);
 
     // initial states
     auto sih  = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), ih);
@@ -1038,11 +1038,11 @@ std::vector<instruction_ref> rewrite_rnn::lstm_cell(bool is_forward,
     std::vector<int64_t> perm{1, 0};
     // w matrix, squeeze and transpose
     auto sw  = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), w);
-    auto tsw = prog.insert_instruction(ins, make_op("transpose", {{"dims", perm}}), sw);
+    auto tsw = prog.insert_instruction(ins, make_op("transpose", {{"perm", perm}}), sw);
 
     // r matrix, squeeze and transpose
     auto sr  = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), r);
-    auto tsr = prog.insert_instruction(ins, make_op("transpose", {{"dims", perm}}), sr);
+    auto tsr = prog.insert_instruction(ins, make_op("transpose", {{"perm", perm}}), sr);
 
     // initial hidden state
     auto sih = prog.insert_instruction(ins, make_op("squeeze", {{"axes", {0}}}), ih);

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -938,7 +938,7 @@ struct find_split_reshape
 
         // insert the reshape instruction
         auto rsp_ins = p.insert_instruction(
-            std::next(input), make_op("reshape", {{"out_lens", rsp_out_lens}}), input);
+            std::next(input), make_op("reshape", {{"dims", rsp_out_lens}}), input);
 
         // replace the original reshape with slice
         int64_t start = 0;

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -55,7 +55,7 @@ struct find_mul_conv
 
         auto new_a = p.insert_instruction(
             ins,
-            make_op("broadcast", {{"axis", 0}, {"dims", w_ins->get_shape().lens()}}),
+            make_op("broadcast", {{"axis", 0}, {"out_lens", w_ins->get_shape().lens()}}),
             a_ins->inputs().front());
         auto new_mul  = p.insert_instruction(ins, make_op("mul"), new_a, w_ins);
         auto new_conv = p.insert_instruction(
@@ -120,7 +120,7 @@ struct find_mul_slice_conv
 
         auto new_a = p.insert_instruction(
             ins,
-            make_op("broadcast", {{"axis", 0}, {"dims", slice_w_ins->get_shape().lens()}}),
+            make_op("broadcast", {{"axis", 0}, {"out_lens", slice_w_ins->get_shape().lens()}}),
             a_ins->inputs().front());
         auto new_mul = p.insert_instruction(ins, make_op("mul"), new_a, slice_w_ins);
 

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -989,8 +989,8 @@ struct find_split_transpose
         }
 
         // insert an transpose instruction
-        auto tr =
-            p.insert_instruction(std::next(input), make_op("transpose", {{"perm", perm}}), input);
+        auto tr = p.insert_instruction(
+            std::next(input), make_op("transpose", {{"permutation", perm}}), input);
 
         // compute the axis in the slice
         auto axis = any_cast<op::slice>(slc->get_operator()).axes.front();

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -990,7 +990,7 @@ struct find_split_transpose
 
         // insert an transpose instruction
         auto tr =
-            p.insert_instruction(std::next(input), make_op("transpose", {{"dims", perm}}), input);
+            p.insert_instruction(std::next(input), make_op("transpose", {{"perm", perm}}), input);
 
         // compute the axis in the slice
         auto axis = any_cast<op::slice>(slc->get_operator()).axes.front();

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -938,7 +938,7 @@ struct find_split_reshape
 
         // insert the reshape instruction
         auto rsp_ins = p.insert_instruction(
-            std::next(input), make_op("reshape", {{"dims", rsp_out_lens}}), input);
+            std::next(input), make_op("reshape", {{"out_lens", rsp_out_lens}}), input);
 
         // replace the original reshape with slice
         int64_t start = 0;

--- a/src/simplify_qdq.cpp
+++ b/src/simplify_qdq.cpp
@@ -96,7 +96,7 @@ struct match_find_quantizable_ops
 
         auto lens = dq->get_shape().lens();
         auto scale_mb =
-            m.insert_instruction(qop, make_op("multibroadcast", {{"output_lens", lens}}), dq_scale);
+            m.insert_instruction(qop, make_op("multibroadcast", {{"out_lens", lens}}), dq_scale);
         dq = m.insert_instruction(qop, make_op("dequantizelinear"), dq, scale_mb);
         m.replace_instruction(qop, dq);
     }

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -419,12 +419,12 @@ struct find_resize
 
         auto in_rsp   = ins_rsp->inputs().front();
         auto rsp_data = p.insert_instruction(
-            ins_rsp, migraphx::make_op("reshape", {{"out_lens", in_dims}}), in_rsp);
+            ins_rsp, migraphx::make_op("reshape", {{"dims", in_dims}}), in_rsp);
         auto mb_rsp = p.insert_instruction(
             ins_rsp, migraphx::make_op("multibroadcast", {{"out_lens", out_dims}}), rsp_data);
         auto std_mb = p.insert_instruction(ins, migraphx::make_op("contiguous"), mb_rsp);
         std::vector<int64_t> rsp_dims(out_lens.begin(), out_lens.end());
-        p.replace_instruction(ins, migraphx::make_op("reshape", {{"out_lens", rsp_dims}}), std_mb);
+        p.replace_instruction(ins, migraphx::make_op("reshape", {{"dims", rsp_dims}}), std_mb);
     }
 };
 
@@ -531,11 +531,11 @@ struct find_reshape_cont
             else
             {
                 inputs.push_back(
-                    p.insert_instruction(ins, make_op("reshape", {{"out_lens", dims}}), in));
+                    p.insert_instruction(ins, make_op("reshape", {{"dims", dims}}), in));
             }
         }
         auto out = p.insert_instruction(ins, ins->get_operator(), inputs);
-        p.replace_instruction(ins, make_op("reshape", {{"out_lens", out_dims}}), out);
+        p.replace_instruction(ins, make_op("reshape", {{"dims", out_dims}}), out);
     }
 };
 

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -416,12 +416,12 @@ struct find_resize
 
         auto in_rsp   = ins_rsp->inputs().front();
         auto rsp_data = p.insert_instruction(
-            ins_rsp, migraphx::make_op("reshape", {{"dims", in_dims}}), in_rsp);
+            ins_rsp, migraphx::make_op("reshape", {{"out_lens", in_dims}}), in_rsp);
         auto mb_rsp = p.insert_instruction(
             ins_rsp, migraphx::make_op("multibroadcast", {{"out_lens", out_dims}}), rsp_data);
         auto std_mb = p.insert_instruction(ins, migraphx::make_op("contiguous"), mb_rsp);
         std::vector<int64_t> rsp_dims(out_lens.begin(), out_lens.end());
-        p.replace_instruction(ins, migraphx::make_op("reshape", {{"dims", rsp_dims}}), std_mb);
+        p.replace_instruction(ins, migraphx::make_op("reshape", {{"out_lens", rsp_dims}}), std_mb);
     }
 };
 
@@ -528,11 +528,11 @@ struct find_reshape_cont
             else
             {
                 inputs.push_back(
-                    p.insert_instruction(ins, make_op("reshape", {{"dims", dims}}), in));
+                    p.insert_instruction(ins, make_op("reshape", {{"out_lens", dims}}), in));
             }
         }
         auto out = p.insert_instruction(ins, ins->get_operator(), inputs);
-        p.replace_instruction(ins, make_op("reshape", {{"dims", out_dims}}), out);
+        p.replace_instruction(ins, make_op("reshape", {{"out_lens", out_dims}}), out);
     }
 };
 

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -153,7 +153,8 @@ struct find_transpose
         }
         else
         {
-            p.replace_instruction(ins, make_op("transpose", {{"perm", dims}}), t->inputs().front());
+            p.replace_instruction(
+                ins, make_op("transpose", {{"permutation", dims}}), t->inputs().front());
         }
     }
 };
@@ -278,10 +279,12 @@ struct find_concat_transpose
         std::vector<instruction_ref> inputs;
         std::transform(
             ins->inputs().begin(), ins->inputs().end(), std::back_inserter(inputs), [&](auto i) {
-                return p.insert_instruction(ins, make_op("transpose", {{"perm", permutation}}), i);
+                return p.insert_instruction(
+                    ins, make_op("transpose", {{"permutation", permutation}}), i);
             });
         auto concat = p.insert_instruction(ins, op, inputs);
-        auto t = p.insert_instruction(ins, make_op("transpose", {{"perm", ipermutation}}), concat);
+        auto t      = p.insert_instruction(
+            ins, make_op("transpose", {{"permutation", ipermutation}}), concat);
         assert(ins->get_shape().lens() == t->get_shape().lens());
         p.replace_instruction(ins, t);
     }

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -153,7 +153,7 @@ struct find_transpose
         }
         else
         {
-            p.replace_instruction(ins, make_op("transpose", {{"dims", dims}}), t->inputs().front());
+            p.replace_instruction(ins, make_op("transpose", {{"perm", dims}}), t->inputs().front());
         }
     }
 };
@@ -278,10 +278,10 @@ struct find_concat_transpose
         std::vector<instruction_ref> inputs;
         std::transform(
             ins->inputs().begin(), ins->inputs().end(), std::back_inserter(inputs), [&](auto i) {
-                return p.insert_instruction(ins, make_op("transpose", {{"dims", permutation}}), i);
+                return p.insert_instruction(ins, make_op("transpose", {{"perm", permutation}}), i);
             });
         auto concat = p.insert_instruction(ins, op, inputs);
-        auto t = p.insert_instruction(ins, make_op("transpose", {{"dims", ipermutation}}), concat);
+        auto t = p.insert_instruction(ins, make_op("transpose", {{"perm", ipermutation}}), concat);
         assert(ins->get_shape().lens() == t->get_shape().lens());
         p.replace_instruction(ins, t);
     }

--- a/src/simplify_reshapes.cpp
+++ b/src/simplify_reshapes.cpp
@@ -418,7 +418,7 @@ struct find_resize
         auto rsp_data = p.insert_instruction(
             ins_rsp, migraphx::make_op("reshape", {{"dims", in_dims}}), in_rsp);
         auto mb_rsp = p.insert_instruction(
-            ins_rsp, migraphx::make_op("multibroadcast", {{"output_lens", out_dims}}), rsp_data);
+            ins_rsp, migraphx::make_op("multibroadcast", {{"out_lens", out_dims}}), rsp_data);
         auto std_mb = p.insert_instruction(ins, migraphx::make_op("contiguous"), mb_rsp);
         std::vector<int64_t> rsp_dims(out_lens.begin(), out_lens.end());
         p.replace_instruction(ins, migraphx::make_op("reshape", {{"dims", rsp_dims}}), std_mb);

--- a/src/targets/gpu/pack_int8_args.cpp
+++ b/src/targets/gpu/pack_int8_args.cpp
@@ -55,7 +55,8 @@ static std::vector<instruction_ref> pad_inputs(module& m, instruction_ref ins)
             auto t_in  = in0->inputs().front();
             auto p_in  = pad_ins(m, t_in, offset);
             auto dims  = val.at("dims").to_vector<int64_t>();
-            auto r_in  = m.insert_instruction(ins, make_op("transpose", {{"perm", dims}}), p_in);
+            auto r_in =
+                m.insert_instruction(ins, make_op("transpose", {{"permutation", dims}}), p_in);
             ret_inputs.push_back(r_in);
         }
         else
@@ -85,7 +86,8 @@ static std::vector<instruction_ref> pad_inputs(module& m, instruction_ref ins)
             auto t_in  = in1->inputs().front();
             auto p_in  = pad_ins(m, t_in, offset);
             auto dims  = val.at("dims").to_vector<int64_t>();
-            auto r_in  = m.insert_instruction(ins, make_op("transpose", {{"perm", dims}}), p_in);
+            auto r_in =
+                m.insert_instruction(ins, make_op("transpose", {{"permutation", dims}}), p_in);
             ret_inputs.push_back(r_in);
         }
         else

--- a/src/targets/gpu/pack_int8_args.cpp
+++ b/src/targets/gpu/pack_int8_args.cpp
@@ -55,7 +55,7 @@ static std::vector<instruction_ref> pad_inputs(module& m, instruction_ref ins)
             auto t_in  = in0->inputs().front();
             auto p_in  = pad_ins(m, t_in, offset);
             auto dims  = val.at("dims").to_vector<int64_t>();
-            auto r_in  = m.insert_instruction(ins, make_op("transpose", {{"dims", dims}}), p_in);
+            auto r_in  = m.insert_instruction(ins, make_op("transpose", {{"perm", dims}}), p_in);
             ret_inputs.push_back(r_in);
         }
         else
@@ -85,7 +85,7 @@ static std::vector<instruction_ref> pad_inputs(module& m, instruction_ref ins)
             auto t_in  = in1->inputs().front();
             auto p_in  = pad_ins(m, t_in, offset);
             auto dims  = val.at("dims").to_vector<int64_t>();
-            auto r_in  = m.insert_instruction(ins, make_op("transpose", {{"dims", dims}}), p_in);
+            auto r_in  = m.insert_instruction(ins, make_op("transpose", {{"perm", dims}}), p_in);
             ret_inputs.push_back(r_in);
         }
         else

--- a/src/tf/parse_biasadd.cpp
+++ b/src/tf/parse_biasadd.cpp
@@ -20,7 +20,8 @@ struct parse_biasadd : op_parser<parse_biasadd>
         uint64_t axis = 1; // assume output of previous layer is in NCHW (broadcast on channel)
 
         auto l0 = info.add_instruction(
-            make_op("broadcast", {{"axis", axis}, {"out_lens", args[0]->get_shape().lens()}}), args[1]);
+            make_op("broadcast", {{"axis", axis}, {"out_lens", args[0]->get_shape().lens()}}),
+            args[1]);
         return info.add_instruction(make_op("add"), args[0], l0);
     }
 };

--- a/src/tf/parse_biasadd.cpp
+++ b/src/tf/parse_biasadd.cpp
@@ -20,7 +20,7 @@ struct parse_biasadd : op_parser<parse_biasadd>
         uint64_t axis = 1; // assume output of previous layer is in NCHW (broadcast on channel)
 
         auto l0 = info.add_instruction(
-            make_op("broadcast", {{"axis", axis}, {"dims", args[0]->get_shape().lens()}}), args[1]);
+            make_op("broadcast", {{"axis", axis}, {"out_lens", args[0]->get_shape().lens()}}), args[1]);
         return info.add_instruction(make_op("add"), args[0], l0);
     }
 };

--- a/src/tf/parse_depthwiseconv.cpp
+++ b/src/tf/parse_depthwiseconv.cpp
@@ -95,8 +95,8 @@ struct parse_depthwiseconv : op_parser<parse_depthwiseconv>
         new_weights_shape[0] = out_channels;
         new_weights_shape[1] = 1;
         // Make sure weights are contiguous before doing reshape
-        auto new_weights = info.add_instruction(make_op("reshape", {{"out_lens", new_weights_shape}}),
-                                                info.make_contiguous(weights));
+        auto new_weights = info.add_instruction(
+            make_op("reshape", {{"out_lens", new_weights_shape}}), info.make_contiguous(weights));
 
         return info.add_instruction(op, {l0, new_weights});
     }

--- a/src/tf/parse_depthwiseconv.cpp
+++ b/src/tf/parse_depthwiseconv.cpp
@@ -95,7 +95,7 @@ struct parse_depthwiseconv : op_parser<parse_depthwiseconv>
         new_weights_shape[0] = out_channels;
         new_weights_shape[1] = 1;
         // Make sure weights are contiguous before doing reshape
-        auto new_weights = info.add_instruction(make_op("reshape", {{"dims", new_weights_shape}}),
+        auto new_weights = info.add_instruction(make_op("reshape", {{"out_lens", new_weights_shape}}),
                                                 info.make_contiguous(weights));
 
         return info.add_instruction(op, {l0, new_weights});

--- a/src/tf/parse_depthwiseconv.cpp
+++ b/src/tf/parse_depthwiseconv.cpp
@@ -95,8 +95,8 @@ struct parse_depthwiseconv : op_parser<parse_depthwiseconv>
         new_weights_shape[0] = out_channels;
         new_weights_shape[1] = 1;
         // Make sure weights are contiguous before doing reshape
-        auto new_weights = info.add_instruction(
-            make_op("reshape", {{"out_lens", new_weights_shape}}), info.make_contiguous(weights));
+        auto new_weights = info.add_instruction(make_op("reshape", {{"dims", new_weights_shape}}),
+                                                info.make_contiguous(weights));
 
         return info.add_instruction(op, {l0, new_weights});
     }

--- a/src/tf/parse_expanddims.cpp
+++ b/src/tf/parse_expanddims.cpp
@@ -30,7 +30,7 @@ struct parse_expanddims : op_parser<parse_expanddims>
         {
             new_dims.insert(new_dims.begin() + dim, 1);
         }
-        return info.add_instruction(make_op("reshape", {{"dims", new_dims}}), args[0]);
+        return info.add_instruction(make_op("reshape", {{"out_lens", new_dims}}), args[0]);
     }
 };
 

--- a/src/tf/parse_expanddims.cpp
+++ b/src/tf/parse_expanddims.cpp
@@ -30,7 +30,7 @@ struct parse_expanddims : op_parser<parse_expanddims>
         {
             new_dims.insert(new_dims.begin() + dim, 1);
         }
-        return info.add_instruction(make_op("reshape", {{"out_lens", new_dims}}), args[0]);
+        return info.add_instruction(make_op("reshape", {{"dims", new_dims}}), args[0]);
     }
 };
 

--- a/src/tf/parse_matmul.cpp
+++ b/src/tf/parse_matmul.cpp
@@ -46,10 +46,12 @@ struct parse_matmul : op_parser<parse_matmul>
         // swap the last two elements
         std::iter_swap(perm.end() - 1, perm.end() - 2);
 
-        auto l1 = (transa) ? info.add_instruction(make_op("transpose", {{"perm", perm}}), args[0])
-                           : args[0];
-        auto l2 = (transb) ? info.add_instruction(make_op("transpose", {{"perm", perm}}), args[1])
-                           : args[1];
+        auto l1 = (transa)
+                      ? info.add_instruction(make_op("transpose", {{"permutation", perm}}), args[0])
+                      : args[0];
+        auto l2 = (transb)
+                      ? info.add_instruction(make_op("transpose", {{"permutation", perm}}), args[1])
+                      : args[1];
 
         return info.add_instruction(make_op("dot"), l1, l2);
     }

--- a/src/tf/parse_matmul.cpp
+++ b/src/tf/parse_matmul.cpp
@@ -46,9 +46,9 @@ struct parse_matmul : op_parser<parse_matmul>
         // swap the last two elements
         std::iter_swap(perm.end() - 1, perm.end() - 2);
 
-        auto l1 = (transa) ? info.add_instruction(make_op("transpose", {{"dims", perm}}), args[0])
+        auto l1 = (transa) ? info.add_instruction(make_op("transpose", {{"perm", perm}}), args[0])
                            : args[0];
-        auto l2 = (transb) ? info.add_instruction(make_op("transpose", {{"dims", perm}}), args[1])
+        auto l2 = (transb) ? info.add_instruction(make_op("transpose", {{"perm", perm}}), args[1])
                            : args[1];
 
         return info.add_instruction(make_op("dot"), l1, l2);

--- a/src/tf/parse_relu6.cpp
+++ b/src/tf/parse_relu6.cpp
@@ -23,9 +23,9 @@ struct parse_relu6 : op_parser<parse_relu6>
         auto max_val    = info.add_literal(6.0f);
 
         min_val =
-            info.add_instruction(make_op("multibroadcast", {{"output_lens", input_lens}}), min_val);
+            info.add_instruction(make_op("multibroadcast", {{"out_lens", input_lens}}), min_val);
         max_val =
-            info.add_instruction(make_op("multibroadcast", {{"output_lens", input_lens}}), max_val);
+            info.add_instruction(make_op("multibroadcast", {{"out_lens", input_lens}}), max_val);
         return info.add_instruction(make_op("clip"), args.front(), min_val, max_val);
     }
 };

--- a/src/tf/parse_reshape.cpp
+++ b/src/tf/parse_reshape.cpp
@@ -22,7 +22,7 @@ struct parse_reshape : op_parser<parse_reshape>
         auto s = args[1]->eval();
         std::vector<int64_t> dims;
         s.visit([&](auto v) { copy(v, std::back_inserter(dims)); });
-        return info.add_instruction(make_op("reshape", {{"dims", dims}}),
+        return info.add_instruction(make_op("reshape", {{"out_lens", dims}}),
                                     info.make_contiguous(args[0]));
     }
 };

--- a/src/tf/parse_reshape.cpp
+++ b/src/tf/parse_reshape.cpp
@@ -22,7 +22,7 @@ struct parse_reshape : op_parser<parse_reshape>
         auto s = args[1]->eval();
         std::vector<int64_t> dims;
         s.visit([&](auto v) { copy(v, std::back_inserter(dims)); });
-        return info.add_instruction(make_op("reshape", {{"out_lens", dims}}),
+        return info.add_instruction(make_op("reshape", {{"dims", dims}}),
                                     info.make_contiguous(args[0]));
     }
 };

--- a/src/tf/parse_transpose.cpp
+++ b/src/tf/parse_transpose.cpp
@@ -20,7 +20,7 @@ struct parse_transpose : op_parser<parse_transpose>
         auto perm = args[1]->eval().get<int32_t>().to_vector();
         std::vector<int64_t> dims(perm.begin(), perm.end());
 
-        return info.add_instruction(make_op("transpose", {{"perm", dims}}), args.front());
+        return info.add_instruction(make_op("transpose", {{"permutation", dims}}), args.front());
     }
 };
 

--- a/src/tf/parse_transpose.cpp
+++ b/src/tf/parse_transpose.cpp
@@ -20,7 +20,7 @@ struct parse_transpose : op_parser<parse_transpose>
         auto perm = args[1]->eval().get<int32_t>().to_vector();
         std::vector<int64_t> dims(perm.begin(), perm.end());
 
-        return info.add_instruction(make_op("transpose", {{"dims", dims}}), args.front());
+        return info.add_instruction(make_op("transpose", {{"perm", dims}}), args.front());
     }
 };
 

--- a/src/tf/tf_parser.cpp
+++ b/src/tf/tf_parser.cpp
@@ -35,20 +35,20 @@ bool tf_parser::should_transpose(instruction_ref ins) const
 instruction_ref tf_parser::to_nhwc(instruction_ref ins) const
 {
     if(should_transpose(ins))
-        return mm->add_instruction(make_op("transpose", {{"dims", {0, 2, 3, 1}}}), ins);
+        return mm->add_instruction(make_op("transpose", {{"perm", {0, 2, 3, 1}}}), ins);
     return ins;
 }
 
 instruction_ref tf_parser::to_nchw(instruction_ref ins) const
 {
     if(should_transpose(ins))
-        return mm->add_instruction(make_op("transpose", {{"dims", {0, 3, 1, 2}}}), ins);
+        return mm->add_instruction(make_op("transpose", {{"perm", {0, 3, 1, 2}}}), ins);
     return ins;
 }
 
 instruction_ref tf_parser::to_kcxy(instruction_ref ins) const
 {
-    return mm->add_instruction(make_op("transpose", {{"dims", {3, 2, 0, 1}}}), ins);
+    return mm->add_instruction(make_op("transpose", {{"perm", {3, 2, 0, 1}}}), ins);
 }
 
 std::vector<instruction_ref> tf_parser::to_nchw(const std::vector<instruction_ref>& args) const

--- a/src/tf/tf_parser.cpp
+++ b/src/tf/tf_parser.cpp
@@ -35,20 +35,20 @@ bool tf_parser::should_transpose(instruction_ref ins) const
 instruction_ref tf_parser::to_nhwc(instruction_ref ins) const
 {
     if(should_transpose(ins))
-        return mm->add_instruction(make_op("transpose", {{"perm", {0, 2, 3, 1}}}), ins);
+        return mm->add_instruction(make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), ins);
     return ins;
 }
 
 instruction_ref tf_parser::to_nchw(instruction_ref ins) const
 {
     if(should_transpose(ins))
-        return mm->add_instruction(make_op("transpose", {{"perm", {0, 3, 1, 2}}}), ins);
+        return mm->add_instruction(make_op("transpose", {{"permutation", {0, 3, 1, 2}}}), ins);
     return ins;
 }
 
 instruction_ref tf_parser::to_kcxy(instruction_ref ins) const
 {
-    return mm->add_instruction(make_op("transpose", {{"perm", {3, 2, 0, 1}}}), ins);
+    return mm->add_instruction(make_op("transpose", {{"permutation", {3, 2, 0, 1}}}), ins);
 }
 
 std::vector<instruction_ref> tf_parser::to_nchw(const std::vector<instruction_ref>& args) const

--- a/test/auto_contiguous_test.cpp
+++ b/test/auto_contiguous_test.cpp
@@ -40,7 +40,7 @@ TEST_CASE(after_literal_transpose)
     auto l = m.add_literal(get_2x2());
     EXPECT(m.get_output_shapes().back().standard());
     EXPECT(not m.get_output_shapes().back().transposed());
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
     m.add_instruction(pass_op{}, t);
     EXPECT(not m.get_output_shapes().back().standard());
     EXPECT(m.get_output_shapes().back().transposed());
@@ -74,7 +74,7 @@ TEST_CASE(after_param_transpose)
     auto l = m.add_parameter("2x2", {migraphx::shape::float_type, {2, 2}});
     EXPECT(m.get_output_shapes().back().standard());
     EXPECT(not m.get_output_shapes().back().transposed());
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
     m.add_instruction(pass_op{}, t);
     EXPECT(not m.get_output_shapes().back().standard());
     EXPECT(m.get_output_shapes().back().transposed());

--- a/test/auto_contiguous_test.cpp
+++ b/test/auto_contiguous_test.cpp
@@ -58,7 +58,7 @@ TEST_CASE(after_literal_broadcast)
     EXPECT(m.get_output_shapes().back().standard());
     EXPECT(not m.get_output_shapes().back().broadcasted());
     auto b = m.add_instruction(
-        migraphx::make_op("broadcast", {{"axis", 0}, {"dims", l1->get_shape().lens()}}), l2);
+        migraphx::make_op("broadcast", {{"axis", 0}, {"out_lens", l1->get_shape().lens()}}), l2);
     m.add_instruction(pass_op{}, b);
     EXPECT(not m.get_output_shapes().back().standard());
     EXPECT(m.get_output_shapes().back().broadcasted());
@@ -92,7 +92,7 @@ TEST_CASE(after_param_broadcast)
     EXPECT(m.get_output_shapes().back().standard());
     EXPECT(not m.get_output_shapes().back().broadcasted());
     auto b = m.add_instruction(
-        migraphx::make_op("broadcast", {{"axis", 0}, {"dims", l1->get_shape().lens()}}), l2);
+        migraphx::make_op("broadcast", {{"axis", 0}, {"out_lens", l1->get_shape().lens()}}), l2);
     m.add_instruction(pass_op{}, b);
     EXPECT(not m.get_output_shapes().back().standard());
     EXPECT(m.get_output_shapes().back().broadcasted());

--- a/test/auto_contiguous_test.cpp
+++ b/test/auto_contiguous_test.cpp
@@ -40,7 +40,7 @@ TEST_CASE(after_literal_transpose)
     auto l = m.add_literal(get_2x2());
     EXPECT(m.get_output_shapes().back().standard());
     EXPECT(not m.get_output_shapes().back().transposed());
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l);
     m.add_instruction(pass_op{}, t);
     EXPECT(not m.get_output_shapes().back().standard());
     EXPECT(m.get_output_shapes().back().transposed());
@@ -74,7 +74,7 @@ TEST_CASE(after_param_transpose)
     auto l = m.add_parameter("2x2", {migraphx::shape::float_type, {2, 2}});
     EXPECT(m.get_output_shapes().back().standard());
     EXPECT(not m.get_output_shapes().back().transposed());
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l);
     m.add_instruction(pass_op{}, t);
     EXPECT(not m.get_output_shapes().back().standard());
     EXPECT(m.get_output_shapes().back().transposed());

--- a/test/decompose_test.cpp
+++ b/test/decompose_test.cpp
@@ -50,8 +50,8 @@ TEST_CASE(dot_add_beta_float)
         auto dot = m2.add_instruction(migraphx::make_op("dot", {{"alpha", 1}, {"beta", 0}}), x, y);
         auto beta =
             m2.add_literal(migraphx::literal{migraphx::shape{migraphx::shape::float_type}, {0.5}});
-        auto beta_broadcast = m2.add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2}}}), beta);
+        auto beta_broadcast =
+            m2.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 2}}}), beta);
         auto mul = m2.add_instruction(migraphx::make_op("mul"), z, beta_broadcast);
         auto add = m2.add_instruction(migraphx::make_op("add"), dot, mul);
         m2.add_instruction(migraphx::make_op("identity"), add);
@@ -79,8 +79,8 @@ TEST_CASE(dot_add_beta_half)
         auto dot = m2.add_instruction(migraphx::make_op("dot", {{"alpha", 1}, {"beta", 0}}), x, y);
         auto beta =
             m2.add_literal(migraphx::literal{migraphx::shape{migraphx::shape::half_type}, {0.5}});
-        auto beta_broadcast = m2.add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2}}}), beta);
+        auto beta_broadcast =
+            m2.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 2}}}), beta);
         auto mul = m2.add_instruction(migraphx::make_op("mul"), z, beta_broadcast);
         auto add = m2.add_instruction(migraphx::make_op("add"), dot, mul);
         m2.add_instruction(migraphx::make_op("identity"), add);
@@ -108,8 +108,8 @@ TEST_CASE(dot_add_beta_double)
         auto dot = m2.add_instruction(migraphx::make_op("dot", {{"alpha", 1}, {"beta", 0}}), x, y);
         auto beta =
             m2.add_literal(migraphx::literal{migraphx::shape{migraphx::shape::double_type}, {0.5}});
-        auto beta_broadcast = m2.add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2}}}), beta);
+        auto beta_broadcast =
+            m2.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 2}}}), beta);
         auto mul = m2.add_instruction(migraphx::make_op("mul"), z, beta_broadcast);
         auto add = m2.add_instruction(migraphx::make_op("add"), dot, mul);
         m2.add_instruction(migraphx::make_op("identity"), add);
@@ -137,8 +137,8 @@ TEST_CASE(dot_add_beta_int)
         auto dot = m2.add_instruction(migraphx::make_op("dot", {{"alpha", 1}, {"beta", 0}}), x, y);
         auto beta =
             m2.add_literal(migraphx::literal{migraphx::shape{migraphx::shape::int32_type}, {0.5}});
-        auto beta_broadcast = m2.add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2}}}), beta);
+        auto beta_broadcast =
+            m2.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 2}}}), beta);
         auto mul = m2.add_instruction(migraphx::make_op("mul"), z, beta_broadcast);
         auto add = m2.add_instruction(migraphx::make_op("add"), dot, mul);
         m2.add_instruction(migraphx::make_op("identity"), add);

--- a/test/decompose_test.cpp
+++ b/test/decompose_test.cpp
@@ -51,7 +51,7 @@ TEST_CASE(dot_add_beta_float)
         auto beta =
             m2.add_literal(migraphx::literal{migraphx::shape{migraphx::shape::float_type}, {0.5}});
         auto beta_broadcast = m2.add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 2}}}), beta);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2}}}), beta);
         auto mul = m2.add_instruction(migraphx::make_op("mul"), z, beta_broadcast);
         auto add = m2.add_instruction(migraphx::make_op("add"), dot, mul);
         m2.add_instruction(migraphx::make_op("identity"), add);
@@ -80,7 +80,7 @@ TEST_CASE(dot_add_beta_half)
         auto beta =
             m2.add_literal(migraphx::literal{migraphx::shape{migraphx::shape::half_type}, {0.5}});
         auto beta_broadcast = m2.add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 2}}}), beta);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2}}}), beta);
         auto mul = m2.add_instruction(migraphx::make_op("mul"), z, beta_broadcast);
         auto add = m2.add_instruction(migraphx::make_op("add"), dot, mul);
         m2.add_instruction(migraphx::make_op("identity"), add);
@@ -109,7 +109,7 @@ TEST_CASE(dot_add_beta_double)
         auto beta =
             m2.add_literal(migraphx::literal{migraphx::shape{migraphx::shape::double_type}, {0.5}});
         auto beta_broadcast = m2.add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 2}}}), beta);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2}}}), beta);
         auto mul = m2.add_instruction(migraphx::make_op("mul"), z, beta_broadcast);
         auto add = m2.add_instruction(migraphx::make_op("add"), dot, mul);
         m2.add_instruction(migraphx::make_op("identity"), add);
@@ -138,7 +138,7 @@ TEST_CASE(dot_add_beta_int)
         auto beta =
             m2.add_literal(migraphx::literal{migraphx::shape{migraphx::shape::int32_type}, {0.5}});
         auto beta_broadcast = m2.add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 2}}}), beta);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2}}}), beta);
         auto mul = m2.add_instruction(migraphx::make_op("mul"), z, beta_broadcast);
         auto add = m2.add_instruction(migraphx::make_op("add"), dot, mul);
         m2.add_instruction(migraphx::make_op("identity"), add);

--- a/test/eliminate_contiguous_test.cpp
+++ b/test/eliminate_contiguous_test.cpp
@@ -17,7 +17,7 @@ TEST_CASE(standard_op)
     migraphx::module m;
 
     auto l = m.add_parameter("x", {migraphx::shape::float_type, {2, 2}});
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l);
     auto c = m.add_instruction(migraphx::make_op("contiguous"), t);
     m.add_instruction(pass_standard_op{}, c);
     auto count = std::distance(m.begin(), m.end());
@@ -30,7 +30,7 @@ TEST_CASE(standard_op_const)
     migraphx::module m;
 
     auto l = m.add_literal(get_2x2());
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l);
     auto c = m.add_instruction(migraphx::make_op("contiguous"), t);
     m.add_instruction(pass_standard_op{}, c);
     run_pass(m);
@@ -42,7 +42,7 @@ TEST_CASE(non_standard_op)
     migraphx::module m;
 
     auto l = m.add_parameter("x", {migraphx::shape::float_type, {2, 2}});
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l);
     auto c = m.add_instruction(migraphx::make_op("contiguous"), t);
     m.add_instruction(pass_op{}, c);
     auto count = std::distance(m.begin(), m.end());
@@ -55,7 +55,7 @@ TEST_CASE(non_standard_op_const)
     migraphx::module m;
 
     auto l = m.add_literal(get_2x2());
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l);
     auto c = m.add_instruction(migraphx::make_op("contiguous"), t);
     m.add_instruction(pass_op{}, c);
     run_pass(m);
@@ -67,7 +67,7 @@ TEST_CASE(transpose_gem)
     migraphx::module m;
 
     auto l  = m.add_literal(get_2x2());
-    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
+    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l);
     auto c  = m.add_instruction(migraphx::make_op("contiguous"), t);
     auto ic = m.add_instruction(migraphx::make_op("identity"), c);
     m.add_instruction(migraphx::make_op("dot"), ic, l);
@@ -81,7 +81,7 @@ TEST_CASE(transpose_standard_op)
     migraphx::module m;
 
     auto l  = m.add_parameter("x", {migraphx::shape::float_type, {2, 2}});
-    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
+    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l);
     auto c  = m.add_instruction(migraphx::make_op("contiguous"), t);
     auto sn = m.add_instruction(migraphx::make_op("sin"), c);
     m.add_instruction(pass_standard_op{}, sn);
@@ -95,7 +95,7 @@ TEST_CASE(transpose_standard_op_const)
     migraphx::module m;
 
     auto l  = m.add_literal(get_2x2());
-    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
+    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l);
     auto c  = m.add_instruction(migraphx::make_op("contiguous"), t);
     auto sn = m.add_instruction(migraphx::make_op("sin"), c);
     m.add_instruction(pass_standard_op{}, sn);
@@ -123,7 +123,7 @@ TEST_CASE(non_standard_return_input)
     migraphx::module m;
 
     auto l  = m.add_literal(get_2x2());
-    auto tl = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
+    auto tl = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l);
     auto c  = m.add_instruction(migraphx::make_op("contiguous"), tl);
     m.add_return({c});
     auto count = std::distance(m.begin(), m.end());

--- a/test/eliminate_contiguous_test.cpp
+++ b/test/eliminate_contiguous_test.cpp
@@ -17,7 +17,7 @@ TEST_CASE(standard_op)
     migraphx::module m;
 
     auto l = m.add_parameter("x", {migraphx::shape::float_type, {2, 2}});
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
     auto c = m.add_instruction(migraphx::make_op("contiguous"), t);
     m.add_instruction(pass_standard_op{}, c);
     auto count = std::distance(m.begin(), m.end());
@@ -30,7 +30,7 @@ TEST_CASE(standard_op_const)
     migraphx::module m;
 
     auto l = m.add_literal(get_2x2());
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
     auto c = m.add_instruction(migraphx::make_op("contiguous"), t);
     m.add_instruction(pass_standard_op{}, c);
     run_pass(m);
@@ -42,7 +42,7 @@ TEST_CASE(non_standard_op)
     migraphx::module m;
 
     auto l = m.add_parameter("x", {migraphx::shape::float_type, {2, 2}});
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
     auto c = m.add_instruction(migraphx::make_op("contiguous"), t);
     m.add_instruction(pass_op{}, c);
     auto count = std::distance(m.begin(), m.end());
@@ -55,7 +55,7 @@ TEST_CASE(non_standard_op_const)
     migraphx::module m;
 
     auto l = m.add_literal(get_2x2());
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
     auto c = m.add_instruction(migraphx::make_op("contiguous"), t);
     m.add_instruction(pass_op{}, c);
     run_pass(m);
@@ -67,7 +67,7 @@ TEST_CASE(transpose_gem)
     migraphx::module m;
 
     auto l  = m.add_literal(get_2x2());
-    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l);
+    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
     auto c  = m.add_instruction(migraphx::make_op("contiguous"), t);
     auto ic = m.add_instruction(migraphx::make_op("identity"), c);
     m.add_instruction(migraphx::make_op("dot"), ic, l);
@@ -81,7 +81,7 @@ TEST_CASE(transpose_standard_op)
     migraphx::module m;
 
     auto l  = m.add_parameter("x", {migraphx::shape::float_type, {2, 2}});
-    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l);
+    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
     auto c  = m.add_instruction(migraphx::make_op("contiguous"), t);
     auto sn = m.add_instruction(migraphx::make_op("sin"), c);
     m.add_instruction(pass_standard_op{}, sn);
@@ -95,7 +95,7 @@ TEST_CASE(transpose_standard_op_const)
     migraphx::module m;
 
     auto l  = m.add_literal(get_2x2());
-    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l);
+    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
     auto c  = m.add_instruction(migraphx::make_op("contiguous"), t);
     auto sn = m.add_instruction(migraphx::make_op("sin"), c);
     m.add_instruction(pass_standard_op{}, sn);
@@ -123,7 +123,7 @@ TEST_CASE(non_standard_return_input)
     migraphx::module m;
 
     auto l  = m.add_literal(get_2x2());
-    auto tl = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l);
+    auto tl = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
     auto c  = m.add_instruction(migraphx::make_op("contiguous"), tl);
     m.add_return({c});
     auto count = std::distance(m.begin(), m.end());

--- a/test/gpu/pack_int8_args.cpp
+++ b/test/gpu/pack_int8_args.cpp
@@ -100,11 +100,13 @@ TEST_CASE(quant_dot_trans)
         migraphx::shape s1{migraphx::shape::int8_type, {3, 2, 8, 5}};
         migraphx::shape s2{migraphx::shape::int8_type, {3, 2, 7, 8}};
 
-        auto l1  = m.add_parameter("a", s1);
-        auto tl1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l1);
-        auto l2  = m.add_parameter("b", s2);
-        auto tl2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l2);
-        auto r   = m.add_instruction(
+        auto l1 = m.add_parameter("a", s1);
+        auto tl1 =
+            m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), l1);
+        auto l2 = m.add_parameter("b", s2);
+        auto tl2 =
+            m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), l2);
+        auto r = m.add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 3}, {"beta", 2}}), tl1, tl2);
         m.add_return({r});
         return m;
@@ -120,13 +122,15 @@ TEST_CASE(quant_dot_trans)
         auto l2     = m.add_parameter("b", s2);
         auto output = m.add_parameter("test:#output_0", s3);
 
-        auto tl1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l1);
+        auto tl1 =
+            m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), l1);
         migraphx::shape ts1{migraphx::shape::int8_type, {3, 2, 5, 8}};
         auto alloca = m.add_instruction(
             migraphx::make_op("hip::allocate", {{"shape", migraphx::to_value(ts1)}}));
         auto conta = m.add_instruction(migraphx::make_op("gpu::contiguous"), tl1, alloca);
 
-        auto tl2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l2);
+        auto tl2 =
+            m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), l2);
         migraphx::shape ts2{migraphx::shape::int8_type, {3, 2, 8, 7}};
         auto allocb = m.add_instruction(
             migraphx::make_op("hip::allocate", {{"shape", migraphx::to_value(ts2)}}));
@@ -245,11 +249,13 @@ TEST_CASE(quant_dot_trans_pad)
         migraphx::shape s1{migraphx::shape::int8_type, {3, 2, 9, 5}};
         migraphx::shape s2{migraphx::shape::int8_type, {3, 2, 7, 9}};
 
-        auto l1  = m.add_parameter("a", s1);
-        auto tl1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l1);
-        auto l2  = m.add_parameter("b", s2);
-        auto tl2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l2);
-        auto r   = m.add_instruction(
+        auto l1 = m.add_parameter("a", s1);
+        auto tl1 =
+            m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), l1);
+        auto l2 = m.add_parameter("b", s2);
+        auto tl2 =
+            m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), l2);
+        auto r = m.add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 3}, {"beta", 2}}), tl1, tl2);
         m.add_return({r});
         return m;
@@ -267,7 +273,8 @@ TEST_CASE(quant_dot_trans_pad)
         auto l2     = m.add_parameter("b", s2);
         auto output = m.add_parameter("test:#output_0", s3);
 
-        auto tl1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l1);
+        auto tl1 =
+            m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), l1);
         migraphx::shape ts1{migraphx::shape::int8_type, {3, 2, 5, 9}};
         auto ta = m.add_instruction(
             migraphx::make_op("hip::allocate", {{"shape", migraphx::to_value(ts1)}}));
@@ -287,7 +294,8 @@ TEST_CASE(quant_dot_trans_pad)
                 pta);
         }
 
-        auto tl2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l2);
+        auto tl2 =
+            m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), l2);
         migraphx::shape ts2{migraphx::shape::int8_type, {3, 2, 9, 7}};
         auto tb = m.add_instruction(
             migraphx::make_op("hip::allocate", {{"shape", migraphx::to_value(ts2)}}));

--- a/test/gpu/pack_int8_args.cpp
+++ b/test/gpu/pack_int8_args.cpp
@@ -101,9 +101,9 @@ TEST_CASE(quant_dot_trans)
         migraphx::shape s2{migraphx::shape::int8_type, {3, 2, 7, 8}};
 
         auto l1  = m.add_parameter("a", s1);
-        auto tl1 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l1);
+        auto tl1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l1);
         auto l2  = m.add_parameter("b", s2);
-        auto tl2 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l2);
+        auto tl2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l2);
         auto r   = m.add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 3}, {"beta", 2}}), tl1, tl2);
         m.add_return({r});
@@ -120,13 +120,13 @@ TEST_CASE(quant_dot_trans)
         auto l2     = m.add_parameter("b", s2);
         auto output = m.add_parameter("test:#output_0", s3);
 
-        auto tl1 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l1);
+        auto tl1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l1);
         migraphx::shape ts1{migraphx::shape::int8_type, {3, 2, 5, 8}};
         auto alloca = m.add_instruction(
             migraphx::make_op("hip::allocate", {{"shape", migraphx::to_value(ts1)}}));
         auto conta = m.add_instruction(migraphx::make_op("gpu::contiguous"), tl1, alloca);
 
-        auto tl2 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l2);
+        auto tl2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l2);
         migraphx::shape ts2{migraphx::shape::int8_type, {3, 2, 8, 7}};
         auto allocb = m.add_instruction(
             migraphx::make_op("hip::allocate", {{"shape", migraphx::to_value(ts2)}}));
@@ -246,9 +246,9 @@ TEST_CASE(quant_dot_trans_pad)
         migraphx::shape s2{migraphx::shape::int8_type, {3, 2, 7, 9}};
 
         auto l1  = m.add_parameter("a", s1);
-        auto tl1 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l1);
+        auto tl1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l1);
         auto l2  = m.add_parameter("b", s2);
-        auto tl2 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l2);
+        auto tl2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l2);
         auto r   = m.add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 3}, {"beta", 2}}), tl1, tl2);
         m.add_return({r});
@@ -267,7 +267,7 @@ TEST_CASE(quant_dot_trans_pad)
         auto l2     = m.add_parameter("b", s2);
         auto output = m.add_parameter("test:#output_0", s3);
 
-        auto tl1 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l1);
+        auto tl1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l1);
         migraphx::shape ts1{migraphx::shape::int8_type, {3, 2, 5, 9}};
         auto ta = m.add_instruction(
             migraphx::make_op("hip::allocate", {{"shape", migraphx::to_value(ts1)}}));
@@ -287,7 +287,7 @@ TEST_CASE(quant_dot_trans_pad)
                 pta);
         }
 
-        auto tl2 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l2);
+        auto tl2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l2);
         migraphx::shape ts2{migraphx::shape::int8_type, {3, 2, 9, 7}};
         auto tb = m.add_instruction(
             migraphx::make_op("hip::allocate", {{"shape", migraphx::to_value(ts2)}}));

--- a/test/inline_module_test.cpp
+++ b/test/inline_module_test.cpp
@@ -364,19 +364,19 @@ TEST_CASE(inline_tuple_true_test)
 
         auto* then_mod = p.create_module("If_6_if");
         auto m1        = then_mod->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {1, 4}}}), l1);
+            migraphx::make_op("multibroadcast", {{"out_lens", {1, 4}}}), l1);
         auto add0 = then_mod->add_instruction(migraphx::make_op("add"), x, m1);
         auto m2   = then_mod->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {3, 4}}}), l2);
+            migraphx::make_op("multibroadcast", {{"out_lens", {3, 4}}}), l2);
         auto mul0 = then_mod->add_instruction(migraphx::make_op("mul"), y, m2);
         then_mod->add_return({add0, mul0});
 
         auto* else_mod = p.create_module("If_6_else");
         auto me1       = else_mod->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {1, 4}}}), l3);
+            migraphx::make_op("multibroadcast", {{"out_lens", {1, 4}}}), l3);
         auto mul1 = else_mod->add_instruction(migraphx::make_op("mul"), x, me1);
         auto me2  = else_mod->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {3, 4}}}), l3);
+            migraphx::make_op("multibroadcast", {{"out_lens", {3, 4}}}), l3);
         auto add1 = else_mod->add_instruction(migraphx::make_op("add"), y, me2);
         else_mod->add_return({mul1, add1});
 
@@ -401,10 +401,10 @@ TEST_CASE(inline_tuple_true_test)
         auto y = mm->add_parameter("y", sy);
 
         auto m1 =
-            mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {1, 4}}}), l1);
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {1, 4}}}), l1);
         auto add = mm->add_instruction(migraphx::make_op("add"), x, m1);
         auto m2 =
-            mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {3, 4}}}), l2);
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 4}}}), l2);
         auto mul = mm->add_instruction(migraphx::make_op("mul"), y, m2);
         mm->add_return({add, mul});
 
@@ -434,19 +434,19 @@ TEST_CASE(inline_tuple_false_test)
 
         auto* then_mod = p.create_module("If_6_if");
         auto m1        = then_mod->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {1, 4}}}), l1);
+            migraphx::make_op("multibroadcast", {{"out_lens", {1, 4}}}), l1);
         auto add0 = then_mod->add_instruction(migraphx::make_op("add"), x, m1);
         auto m2   = then_mod->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {3, 4}}}), l2);
+            migraphx::make_op("multibroadcast", {{"out_lens", {3, 4}}}), l2);
         auto mul0 = then_mod->add_instruction(migraphx::make_op("mul"), y, m2);
         then_mod->add_return({add0, mul0});
 
         auto* else_mod = p.create_module("If_6_else");
         auto me1       = else_mod->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {1, 4}}}), l3);
+            migraphx::make_op("multibroadcast", {{"out_lens", {1, 4}}}), l3);
         auto mul1 = else_mod->add_instruction(migraphx::make_op("mul"), x, me1);
         auto me2  = else_mod->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {3, 4}}}), l3);
+            migraphx::make_op("multibroadcast", {{"out_lens", {3, 4}}}), l3);
         auto add1 = else_mod->add_instruction(migraphx::make_op("add"), y, me2);
         else_mod->add_return({mul1, add1});
 
@@ -473,10 +473,10 @@ TEST_CASE(inline_tuple_false_test)
         auto y = mm->add_parameter("y", sy);
 
         auto m1 =
-            mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {1, 4}}}), l3);
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {1, 4}}}), l3);
         auto mul = mm->add_instruction(migraphx::make_op("mul"), x, m1);
         auto m2 =
-            mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {3, 4}}}), l3);
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 4}}}), l3);
         auto add = mm->add_instruction(migraphx::make_op("add"), y, m2);
         mm->add_return({mul, add});
 

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -74,7 +74,7 @@ TEST_CASE(add_bcast_test)
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3, 4, 5}});
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {3, 4}});
     auto l2  = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", 1}, {"dims", l0->get_shape().lens()}}), l1);
+        migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", l0->get_shape().lens()}}), l1);
     mm->add_instruction(migraphx::make_op("add"), l0, l2);
 
     auto prog = optimize_onnx("add_bcast_test.onnx");
@@ -103,7 +103,7 @@ TEST_CASE(add_scalar_test)
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::uint8_type, {2, 3, 4, 5}});
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::uint8_type});
     auto m1  = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {2, 3, 4, 5}}}), l1);
+        migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}), l1);
     auto r = mm->add_instruction(migraphx::make_op("add"), l0, m1);
     mm->add_return({r});
     auto prog = migraphx::parse_onnx("add_scalar_test.onnx");
@@ -373,9 +373,9 @@ TEST_CASE(clip_test)
     auto min_val = mm->add_literal(0.0f);
     auto max_val = mm->add_literal(6.0f);
     min_val =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {3}}}), min_val);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3}}}), min_val);
     max_val =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {3}}}), max_val);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3}}}), max_val);
     mm->add_instruction(migraphx::make_op("clip"), l0, min_val, max_val);
     auto prog = optimize_onnx("clip_test.onnx");
 
@@ -390,7 +390,7 @@ TEST_CASE(clip_test_op11_max_only)
     auto l0      = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {3}});
     mm->add_instruction(migraphx::make_op("undefined"));
     max_val =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {3}}}), max_val);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3}}}), max_val);
     auto r = mm->add_instruction(migraphx::make_op("min"), l0, max_val);
     mm->add_return({r});
 
@@ -407,9 +407,9 @@ TEST_CASE(clip_test_op11)
     auto max_val = mm->add_literal(6.0f);
     auto l0      = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {3}});
     min_val =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {3}}}), min_val);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3}}}), min_val);
     max_val =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {3}}}), max_val);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3}}}), max_val);
     mm->add_instruction(migraphx::make_op("clip"), l0, min_val, max_val);
     auto prog = optimize_onnx("clip_test_op11.onnx");
 
@@ -423,7 +423,7 @@ TEST_CASE(clip_test_op11_min_only)
     auto min_val = mm->add_literal(0.0f);
     auto l0      = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {3}});
     min_val =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {3}}}), min_val);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3}}}), min_val);
     mm->add_instruction(migraphx::make_op("max"), l0, min_val);
     auto prog = optimize_onnx("clip_test_op11_min_only.onnx");
 
@@ -638,7 +638,7 @@ TEST_CASE(conv_bias_test)
     uint64_t axis = 1;
     auto l3       = mm->add_instruction(migraphx::make_op("convolution"), l0, l1);
     auto l4       = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", axis}, {"dims", l3->get_shape().lens()}}), l2);
+        migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", l3->get_shape().lens()}}), l2);
     mm->add_instruction(migraphx::make_op("add"), l3, l4);
 
     auto prog = optimize_onnx("conv_bias_test.onnx");
@@ -661,7 +661,7 @@ TEST_CASE(conv_bn_relu_maxpool_test)
     auto l3 =
         mm->add_instruction(migraphx::make_op("convolution", {{"padding", {0, 0, 0, 0}}}), l0, l1);
     auto l4 = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", axis}, {"dims", l3->get_shape().lens()}}), l2);
+        migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", l3->get_shape().lens()}}), l2);
     auto l5 = mm->add_instruction(migraphx::make_op("add"), l3, l4);
     auto l6 = mm->add_instruction(
         migraphx::make_op("batch_norm_inference", {{"epsilon", 1.0e-5f}}), l5, p3, p4, p5, p6);
@@ -687,7 +687,7 @@ TEST_CASE(conv_relu_maxpool_test)
     auto l3 =
         mm->add_instruction(migraphx::make_op("convolution", {{"padding", {0, 0, 0, 0}}}), l0, l1);
     auto l4 = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", axis}, {"dims", l3->get_shape().lens()}}), l2);
+        migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", l3->get_shape().lens()}}), l2);
     auto l5 = mm->add_instruction(migraphx::make_op("add"), l3, l4);
     auto l6 = mm->add_instruction(migraphx::make_op("relu"), l5);
     mm->add_instruction(
@@ -711,7 +711,7 @@ TEST_CASE(conv_relu_maxpool_x2_test)
     auto l3 =
         mm->add_instruction(migraphx::make_op("convolution", {{"padding", {0, 0, 0, 0}}}), l0, l1);
     auto l4 = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", axis}, {"dims", l3->get_shape().lens()}}), l2);
+        migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", l3->get_shape().lens()}}), l2);
     auto l5 = mm->add_instruction(migraphx::make_op("add"), l3, l4);
     auto l6 = mm->add_instruction(migraphx::make_op("relu"), l5);
     auto l7 = mm->add_instruction(
@@ -725,7 +725,7 @@ TEST_CASE(conv_relu_maxpool_x2_test)
     auto l10 =
         mm->add_instruction(migraphx::make_op("convolution", {{"padding", {0, 0, 0, 0}}}), l7, l8);
     auto l11 = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", axis}, {"dims", l10->get_shape().lens()}}), l9);
+        migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", l10->get_shape().lens()}}), l9);
     auto l12 = mm->add_instruction(migraphx::make_op("add"), l10, l11);
     auto l13 = mm->add_instruction(migraphx::make_op("relu"), l12);
     mm->add_instruction(
@@ -749,7 +749,7 @@ TEST_CASE(convinteger_bias_test)
     uint64_t axis = 1;
     auto l3       = mm->add_instruction(migraphx::make_op("quant_convolution"), l0, l1);
     auto l4       = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", axis}, {"dims", l3->get_shape().lens()}}), l2);
+        migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", l3->get_shape().lens()}}), l2);
     mm->add_instruction(migraphx::make_op("add"), l3, l4);
 
     auto prog = optimize_onnx("convinteger_bias_test.onnx");
@@ -801,7 +801,7 @@ TEST_CASE(deconv_bias_test)
     uint64_t axis = 1;
     auto l3       = mm->add_instruction(migraphx::make_op("deconvolution"), l0, l1);
     auto l4       = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", axis}, {"dims", l3->get_shape().lens()}}), l2);
+        migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", l3->get_shape().lens()}}), l2);
     mm->add_instruction(migraphx::make_op("add"), l3, l4);
 
     auto prog = optimize_onnx("deconv_bias_test.onnx");
@@ -923,7 +923,7 @@ TEST_CASE(dequantizelinear_test)
     auto l0  = mm->add_parameter("0", {migraphx::shape::int8_type, {5}});
     auto l1  = mm->add_parameter("1", {migraphx::shape::float_type, {1}});
     auto l1_mbcast =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {5}}}), l1);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {5}}}), l1);
     auto dequant = mm->add_instruction(
         migraphx::make_op("convert",
                           {{"target_type", migraphx::to_value(migraphx::shape::float_type)}}),
@@ -942,9 +942,9 @@ TEST_CASE(dequantizelinear_zero_point_test)
     auto l1  = mm->add_parameter("1", {migraphx::shape::float_type, {1}});
     auto l2  = mm->add_parameter("2", {migraphx::shape::int8_type, {1}});
     auto l1_mbcast =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {5}}}), l1);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {5}}}), l1);
     auto l2_mbcast =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {5}}}), l2);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {5}}}), l2);
     l2_mbcast = mm->add_instruction(
         migraphx::make_op("convert",
                           {{"target_type", migraphx::to_value(migraphx::shape::float_type)}}),
@@ -971,9 +971,9 @@ migraphx::program make_dequantizelinear_axis_prog()
     auto l1       = mm->add_parameter("1", {migraphx::shape::float_type, {5}});
     auto l2       = mm->add_parameter("2", {migraphx::shape::int8_type, {5}});
     auto l1_bcast = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", axis}, {"dims", input_lens}}), l1);
+        migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", input_lens}}), l1);
     auto l2_bcast = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", axis}, {"dims", input_lens}}), l2);
+        migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", input_lens}}), l2);
     l2_bcast = mm->add_instruction(
         migraphx::make_op("convert",
                           {{"target_type", migraphx::to_value(migraphx::shape::float_type)}}),
@@ -1129,7 +1129,7 @@ TEST_CASE(expand_test)
     auto param = mm->add_parameter("x", s);
     migraphx::shape ss(migraphx::shape::int32_type, {4});
     mm->add_literal(migraphx::literal(ss, {2, 3, 4, 5}));
-    mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {2, 3, 4, 5}}}),
+    mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}),
                         param);
 
     auto prog = optimize_onnx("expand_test.onnx");
@@ -1150,7 +1150,7 @@ migraphx::program create_external_data_prog()
     auto conv    = mm->add_instruction(
         migraphx::make_op("convolution", {{"padding", {0, 0, 0, 0}}}), param, weights);
     auto bias_bcast = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {1, 10, 214, 214}}}), bias);
+        migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {1, 10, 214, 214}}}), bias);
     mm->add_instruction(migraphx::make_op("add"), conv, bias_bcast);
     return p;
 }
@@ -1240,7 +1240,7 @@ TEST_CASE(gather_elements_axis0_test)
 
     auto rsp_data    = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {12}}}), data);
     auto lbst_stride = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", ind_s.lens()}}), l_stride);
+        migraphx::make_op("multibroadcast", {{"out_lens", ind_s.lens()}}), l_stride);
     auto axis_delta = mm->add_instruction(migraphx::make_op("sub"), indices, l_ind_axis_indices);
     auto mul_delta  = mm->add_instruction(migraphx::make_op("mul"), axis_delta, lbst_stride);
     auto ind        = mm->add_instruction(migraphx::make_op("add"), l_data_indices, mul_delta);
@@ -1269,7 +1269,7 @@ TEST_CASE(gather_elements_axis1_test)
 
     auto rsp_data    = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {12}}}), data);
     auto lbst_stride = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", ind_s.lens()}}), l_stride);
+        migraphx::make_op("multibroadcast", {{"out_lens", ind_s.lens()}}), l_stride);
     auto axis_delta = mm->add_instruction(migraphx::make_op("sub"), indices, l_ind_axis_indices);
     auto mul_delta  = mm->add_instruction(migraphx::make_op("mul"), axis_delta, lbst_stride);
     auto ind        = mm->add_instruction(migraphx::make_op("add"), l_data_indices, mul_delta);
@@ -1299,9 +1299,9 @@ TEST_CASE(gemm_test)
         mm->add_instruction(migraphx::make_op("dot", {{"alpha", 1.0f}, {"beta", 0.0f}}), t_a, t1);
     auto b_l = mm->add_literal(beta);
     auto l2_b =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {7, 11}}}), l2);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {7, 11}}}), l2);
     auto b_b = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", l2_b->get_shape().lens()}}), b_l);
+        migraphx::make_op("multibroadcast", {{"out_lens", l2_b->get_shape().lens()}}), b_l);
     auto l2_bb = mm->add_instruction(migraphx::make_op("mul"), l2_b, b_b);
     mm->add_instruction(migraphx::make_op("add"), dot, l2_bb);
 
@@ -1326,7 +1326,7 @@ TEST_CASE(gemm_ex_test)
         mm->add_instruction(migraphx::make_op("dot", {{"alpha", 1.0f}, {"beta", 0.0f}}), t_a, l1);
     auto b_l = mm->add_literal(beta);
     auto b_b = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", l2->get_shape().lens()}}), b_l);
+        migraphx::make_op("multibroadcast", {{"out_lens", l2->get_shape().lens()}}), b_l);
     auto l2_b = mm->add_instruction(migraphx::make_op("mul"), l2, b_b);
     mm->add_instruction(migraphx::make_op("add"), dot, l2_b);
 
@@ -1352,9 +1352,9 @@ TEST_CASE(gemm_ex_brcst_test)
         mm->add_instruction(migraphx::make_op("dot", {{"alpha", 1.0f}, {"beta", 0.0f}}), t_a, l1);
     auto b_l = mm->add_literal(beta);
     auto l2_b =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", out_lens}}), l2);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", out_lens}}), l2);
     auto b_b = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", l2_b->get_shape().lens()}}), b_l);
+        migraphx::make_op("multibroadcast", {{"out_lens", l2_b->get_shape().lens()}}), b_l);
     auto l2_bb = mm->add_instruction(migraphx::make_op("mul"), l2_b, b_b);
     mm->add_instruction(migraphx::make_op("add"), dot, l2_bb);
 
@@ -1379,12 +1379,12 @@ TEST_CASE(gemm_half_test)
     std::vector<std::size_t> lens = {1, 1, 6, 7};
     auto dot =
         mm->add_instruction(migraphx::make_op("dot", {{"alpha", 1.0f}, {"beta", 0.0f}}), t_a, l1);
-    l2 = mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", lens}}), l2);
+    l2 = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), l2);
     l2 = mm->add_instruction(
         migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), l2);
     auto b_l = mm->add_literal(beta);
     auto b_b =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", lens}}), b_l);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), b_l);
     auto l2_b = mm->add_instruction(migraphx::make_op("mul"), l2, b_b);
     l2_b      = mm->add_instruction(
         migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}), l2_b);
@@ -1671,19 +1671,19 @@ TEST_CASE(if_tuple_test)
 
     auto* then_mod = p.create_module("If_6_if");
     auto m1        = then_mod->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {1, 4}}}), l1);
+        migraphx::make_op("multibroadcast", {{"out_lens", {1, 4}}}), l1);
     auto add0 = then_mod->add_instruction(migraphx::make_op("add"), x, m1);
     auto m2   = then_mod->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {3, 4}}}), l2);
+        migraphx::make_op("multibroadcast", {{"out_lens", {3, 4}}}), l2);
     auto mul0 = then_mod->add_instruction(migraphx::make_op("mul"), y, m2);
     then_mod->add_return({add0, mul0});
 
     auto* else_mod = p.create_module("If_6_else");
     auto me1       = else_mod->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {1, 4}}}), l3);
+        migraphx::make_op("multibroadcast", {{"out_lens", {1, 4}}}), l3);
     auto mul1 = else_mod->add_instruction(migraphx::make_op("mul"), x, me1);
     auto me2  = else_mod->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {3, 4}}}), l3);
+        migraphx::make_op("multibroadcast", {{"out_lens", {3, 4}}}), l3);
     auto add1 = else_mod->add_instruction(migraphx::make_op("add"), y, me2);
     else_mod->add_return({mul1, add1});
 
@@ -1709,7 +1709,7 @@ TEST_CASE(imagescaler_test)
         migraphx::make_op("scalar", {{"scalar_bcst_dims", s.lens()}}), scale_val);
     auto img_scaled = mm->add_instruction(migraphx::make_op("mul"), l0, scaled_tensor);
     auto bias_bcast = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", 1}, {"dims", s.lens()}}), bias_vals);
+        migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", s.lens()}}), bias_vals);
     mm->add_instruction(migraphx::make_op("add"), img_scaled, bias_bcast);
 
     auto prog = optimize_onnx("imagescaler_test.onnx");
@@ -1731,7 +1731,7 @@ TEST_CASE(imagescaler_half_test)
         migraphx::make_op("scalar", {{"scalar_bcst_dims", s.lens()}}), scale_val);
     auto img_scaled = mm->add_instruction(migraphx::make_op("mul"), l0, scaled_tensor);
     auto bias_bcast = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", 1}, {"dims", s.lens()}}), bias_vals);
+        migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", s.lens()}}), bias_vals);
     mm->add_instruction(migraphx::make_op("add"), img_scaled, bias_bcast);
 
     auto prog = optimize_onnx("imagescaler_half_test.onnx");
@@ -1746,7 +1746,7 @@ TEST_CASE(implicit_add_bcast_test)
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3, 4, 5}});
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {3, 4, 1}});
     auto l3  = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {2, 3, 4, 5}}}), l1);
+        migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}), l1);
     mm->add_instruction(migraphx::make_op("add"), l0, l3);
 
     auto prog = optimize_onnx("implicit_add_bcast_test.onnx");
@@ -1761,7 +1761,7 @@ TEST_CASE(implicit_add_bcast_user_input_shape_test)
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {3, 4, 5, 6}});
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {4, 5, 1}});
     auto l3  = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {3, 4, 5, 6}}}), l1);
+        migraphx::make_op("multibroadcast", {{"out_lens", {3, 4, 5, 6}}}), l1);
     auto r = mm->add_instruction(migraphx::make_op("add"), l0, l3);
     mm->add_return({r});
 
@@ -1780,7 +1780,7 @@ TEST_CASE(implicit_pow_bcast_test)
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3, 4, 5}});
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {3, 4, 1}});
     auto l3  = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {2, 3, 4, 5}}}), l1);
+        migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}), l1);
     mm->add_instruction(migraphx::make_op("pow"), l0, l3);
 
     auto prog = optimize_onnx("implicit_pow_bcast_test.onnx");
@@ -1795,7 +1795,7 @@ TEST_CASE(implicit_sub_bcast_test)
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::uint64_type, {2, 3, 4, 5}});
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::uint64_type, {4, 5}});
     auto l3  = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {2, 3, 4, 5}}}), l1);
+        migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}), l1);
     mm->add_instruction(migraphx::make_op("sub"), l0, l3);
 
     auto prog = optimize_onnx("implicit_sub_bcast_test.onnx");
@@ -1831,22 +1831,22 @@ TEST_CASE(instance_norm_test)
 
     auto mean = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2, 3}}}), x);
     auto mean_bcast =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", dims}}), mean);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", dims}}), mean);
     auto l0       = mm->add_instruction(migraphx::make_op("sqdiff"), x, mean_bcast);
     auto variance = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2, 3}}}), l0);
     auto l1       = mm->add_instruction(migraphx::make_op("sub"), x, mean_bcast);
     auto epsilon_literal = mm->add_literal(1e-5f);
     auto epsilon_bcast   = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", dims}}), epsilon_literal);
+        migraphx::make_op("multibroadcast", {{"out_lens", dims}}), epsilon_literal);
     auto variance_bcast =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", dims}}), variance);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", dims}}), variance);
     auto l2 = mm->add_instruction(migraphx::make_op("add"), variance_bcast, epsilon_bcast);
     auto l3 = mm->add_instruction(migraphx::make_op("rsqrt"), l2);
     auto l4 = mm->add_instruction(migraphx::make_op("mul"), l1, l3);
     auto scale_bcast =
-        mm->add_instruction(migraphx::make_op("broadcast", {{"axis", 1}, {"dims", dims}}), scale);
+        mm->add_instruction(migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", dims}}), scale);
     auto bias_bcast =
-        mm->add_instruction(migraphx::make_op("broadcast", {{"axis", 1}, {"dims", dims}}), bias);
+        mm->add_instruction(migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", dims}}), bias);
     auto l5 = mm->add_instruction(migraphx::make_op("mul"), l4, scale_bcast);
     mm->add_instruction(migraphx::make_op("add"), l5, bias_bcast);
 
@@ -1944,7 +1944,7 @@ TEST_CASE(logical_and_bcast_test)
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::bool_type, {2, 3, 4, 5}});
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::bool_type, {4, 5}});
     auto l2  = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", l0->get_shape().lens()}}), l1);
+        migraphx::make_op("multibroadcast", {{"out_lens", l0->get_shape().lens()}}), l1);
     auto ret = mm->add_instruction(migraphx::make_op("logical_and"), l0, l2);
     mm->add_return({ret});
 
@@ -1974,7 +1974,7 @@ TEST_CASE(logical_xor_bcast_test)
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::bool_type, {2, 3, 4, 5}});
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::bool_type, {4, 1}});
     auto l2  = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", l0->get_shape().lens()}}), l1);
+        migraphx::make_op("multibroadcast", {{"out_lens", l0->get_shape().lens()}}), l1);
     auto ret = mm->add_instruction(migraphx::make_op("logical_xor"), l0, l2);
     mm->add_return({ret});
 
@@ -2033,9 +2033,9 @@ TEST_CASE(matmul_bmbm_test)
     auto l0  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {3, 6, 7}});
     auto l1 = mm->add_parameter("2", migraphx::shape{migraphx::shape::float_type, {5, 2, 1, 7, 8}});
     auto bl0 = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {5, 2, 3, 6, 7}}}), l0);
+        migraphx::make_op("multibroadcast", {{"out_lens", {5, 2, 3, 6, 7}}}), l0);
     auto bl1 = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {5, 2, 3, 7, 8}}}), l1);
+        migraphx::make_op("multibroadcast", {{"out_lens", {5, 2, 3, 7, 8}}}), l1);
     mm->add_instruction(migraphx::make_op("dot", {{"alpha", 1.0f}, {"beta", 0.0f}}), bl0, bl1);
 
     auto prog = optimize_onnx("matmul_bmbm_test.onnx");
@@ -2051,7 +2051,7 @@ TEST_CASE(matmul_bmv_test)
     auto l1  = mm->add_parameter("2", migraphx::shape{migraphx::shape::float_type, {7}});
     auto sl1 = mm->add_instruction(migraphx::make_op("unsqueeze", {{"axes", {1}}}), l1);
     auto bsl1 =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {3, 7, 1}}}), sl1);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 7, 1}}}), sl1);
     auto res =
         mm->add_instruction(migraphx::make_op("dot", {{"alpha", 1.0f}, {"beta", 0.0f}}), l0, bsl1);
     mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {2}}}), res);
@@ -2085,7 +2085,7 @@ TEST_CASE(matmul_vbm_test)
     auto l1  = mm->add_parameter("2", migraphx::shape{migraphx::shape::float_type, {5, 7, 8}});
     auto sl0 = mm->add_instruction(migraphx::make_op("unsqueeze", {{"axes", {0}}}), l0);
     auto bsl0 =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {5, 1, 7}}}), sl0);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {5, 1, 7}}}), sl0);
     auto res =
         mm->add_instruction(migraphx::make_op("dot", {{"alpha", 1.0f}, {"beta", 0.0f}}), bsl0, l1);
     mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {1}}}), res);
@@ -2306,9 +2306,9 @@ TEST_CASE(onehot_test)
         migraphx::make_op("slice", {{"axes", {0}}, {"starts", {1}}, {"ends", {2}}}), l_val);
     auto diff       = mm->add_instruction(migraphx::make_op("sub"), on_val, off_val);
     auto mb_off_val = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {3, 5, 2}}}), off_val);
+        migraphx::make_op("multibroadcast", {{"out_lens", {3, 5, 2}}}), off_val);
     auto mb_diff = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {3, 5, 2}}}), diff);
+        migraphx::make_op("multibroadcast", {{"out_lens", {3, 5, 2}}}), diff);
     auto mul = mm->add_instruction(migraphx::make_op("mul"), tr_out, mb_diff);
     auto r   = mm->add_instruction(migraphx::make_op("add"), mul, mb_off_val);
     mm->add_return({r});
@@ -2457,7 +2457,7 @@ TEST_CASE(prelu_brcst_test)
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3, 4, 5}});
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {4, 5}});
     auto bl1 = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", l0->get_shape().lens()}}), l1);
+        migraphx::make_op("multibroadcast", {{"out_lens", l0->get_shape().lens()}}), l1);
     auto ret = mm->add_instruction(migraphx::make_op("prelu"), l0, bl1);
     mm->add_return({ret});
 
@@ -2473,7 +2473,7 @@ TEST_CASE(quantizelinear_test)
     auto l0  = mm->add_parameter("0", {migraphx::shape::float_type, {5}});
     auto l1  = mm->add_parameter("1", {migraphx::shape::float_type, {1}});
     auto l1_mbcast =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {5}}}), l1);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {5}}}), l1);
     auto div   = mm->add_instruction(migraphx::make_op("div"), l0, l1_mbcast);
     auto round = mm->add_instruction(migraphx::make_op("round"), div);
     auto s     = round->get_shape();
@@ -2498,7 +2498,7 @@ TEST_CASE(quantizelinear_int32_test)
     auto l0  = mm->add_parameter("0", {migraphx::shape::int32_type, {5}});
     auto l1  = mm->add_parameter("1", {migraphx::shape::float_type, {1}});
     auto l1_mbcast =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {5}}}), l1);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {5}}}), l1);
     l0 = mm->add_instruction(
         migraphx::make_op("convert",
                           {{"target_type", migraphx::to_value(migraphx::shape::float_type)}}),
@@ -2528,11 +2528,11 @@ TEST_CASE(quantizelinear_zero_point_test)
     auto l1  = mm->add_parameter("1", {migraphx::shape::float_type, {1}});
     auto l2  = mm->add_parameter("2", {migraphx::shape::int8_type, {1}});
     auto l1_mbcast =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {5}}}), l1);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {5}}}), l1);
     auto div   = mm->add_instruction(migraphx::make_op("div"), l0, l1_mbcast);
     auto round = mm->add_instruction(migraphx::make_op("round"), div);
     auto l2_mbcast =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {5}}}), l2);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {5}}}), l2);
     l2_mbcast = mm->add_instruction(
         migraphx::make_op("convert",
                           {{"target_type", migraphx::to_value(migraphx::shape::float_type)}}),
@@ -2564,12 +2564,12 @@ migraphx::program make_quantizelinear_axis_prog()
     auto l1       = mm->add_parameter("1", {migraphx::shape::float_type, {5}});
     auto l2       = mm->add_parameter("2", {migraphx::shape::int8_type, {5}});
     auto l1_bcast = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", axis}, {"dims", input_lens}}), l1);
+        migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", input_lens}}), l1);
 
     auto div      = mm->add_instruction(migraphx::make_op("div"), l0, l1_bcast);
     auto round    = mm->add_instruction(migraphx::make_op("round"), div);
     auto l2_bcast = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", axis}, {"dims", input_lens}}), l2);
+        migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", input_lens}}), l2);
     l2_bcast = mm->add_instruction(
         migraphx::make_op("convert",
                           {{"target_type", migraphx::to_value(migraphx::shape::float_type)}}),
@@ -3322,9 +3322,9 @@ TEST_CASE(selu_test)
     auto la = mm->add_literal({ls, {0.3}});
     auto lg = mm->add_literal({ls, {0.25}});
     auto mbla =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", lens}}), la);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), la);
     auto mblg =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", lens}}), lg);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), lg);
 
     auto sign_x = mm->add_instruction(migraphx::make_op("sign"), x);
     auto exp_x  = mm->add_instruction(migraphx::make_op("exp"), x);
@@ -3651,7 +3651,7 @@ TEST_CASE(sub_bcast_test)
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3, 4, 5}});
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {3, 4}});
     auto l2  = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", 1}, {"dims", l0->get_shape().lens()}}), l1);
+        migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", l0->get_shape().lens()}}), l1);
     mm->add_instruction(migraphx::make_op("sub"), l0, l2);
 
     auto prog = optimize_onnx("sub_bcast_test.onnx");
@@ -3666,7 +3666,7 @@ TEST_CASE(sub_scalar_test)
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3, 4, 5}});
     auto l1 = mm->add_literal(migraphx::literal{migraphx::shape{migraphx::shape::float_type}, {1}});
     auto m1 = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {2, 3, 4, 5}}}), l1);
+        migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}), l1);
     mm->add_instruction(migraphx::make_op("sub"), l0, m1);
     auto prog = optimize_onnx("sub_scalar_test.onnx");
 
@@ -3973,11 +3973,11 @@ TEST_CASE(where_test)
                           {{"target_type", migraphx::to_value(migraphx::shape::int32_type)}}),
         lc);
     auto lccm = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {2, 2, 2, 2}}}), int_c);
+        migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 2, 2}}}), int_c);
     auto lxm = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {2, 2, 2, 2}}}), lx);
+        migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 2, 2}}}), lx);
     auto lym = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {2, 2, 2, 2}}}), ly);
+        migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 2, 2}}}), ly);
 
     auto concat_data = mm->add_instruction(migraphx::make_op("concat", {{"axis", 0}}), lym, lxm);
     auto rsp_data =

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -102,8 +102,8 @@ TEST_CASE(add_scalar_test)
     auto* mm = p.get_main_module();
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::uint8_type, {2, 3, 4, 5}});
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::uint8_type});
-    auto m1  = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}), l1);
+    auto m1 =
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}), l1);
     auto r = mm->add_instruction(migraphx::make_op("add"), l0, m1);
     mm->add_return({r});
     auto prog = migraphx::parse_onnx("add_scalar_test.onnx");
@@ -725,7 +725,8 @@ TEST_CASE(conv_relu_maxpool_x2_test)
     auto l10 =
         mm->add_instruction(migraphx::make_op("convolution", {{"padding", {0, 0, 0, 0}}}), l7, l8);
     auto l11 = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", l10->get_shape().lens()}}), l9);
+        migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", l10->get_shape().lens()}}),
+        l9);
     auto l12 = mm->add_instruction(migraphx::make_op("add"), l10, l11);
     auto l13 = mm->add_instruction(migraphx::make_op("relu"), l12);
     mm->add_instruction(
@@ -1129,8 +1130,7 @@ TEST_CASE(expand_test)
     auto param = mm->add_parameter("x", s);
     migraphx::shape ss(migraphx::shape::int32_type, {4});
     mm->add_literal(migraphx::literal(ss, {2, 3, 4, 5}));
-    mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}),
-                        param);
+    mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}), param);
 
     auto prog = optimize_onnx("expand_test.onnx");
     EXPECT(p == prog);
@@ -1238,7 +1238,7 @@ TEST_CASE(gather_elements_axis0_test)
         mm->add_literal(migraphx::literal{ind_s, ind_axis_indices.begin(), ind_axis_indices.end()});
     auto l_stride = mm->add_literal(migraphx::literal{{migraphx::shape::int32_type, {1}}, {4}});
 
-    auto rsp_data    = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {12}}}), data);
+    auto rsp_data    = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {12}}}), data);
     auto lbst_stride = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"out_lens", ind_s.lens()}}), l_stride);
     auto axis_delta = mm->add_instruction(migraphx::make_op("sub"), indices, l_ind_axis_indices);
@@ -1267,7 +1267,7 @@ TEST_CASE(gather_elements_axis1_test)
         mm->add_literal(migraphx::literal{ind_s, ind_axis_indices.begin(), ind_axis_indices.end()});
     auto l_stride = mm->add_literal(migraphx::literal{{migraphx::shape::int32_type, {1}}, {1}});
 
-    auto rsp_data    = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {12}}}), data);
+    auto rsp_data    = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {12}}}), data);
     auto lbst_stride = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"out_lens", ind_s.lens()}}), l_stride);
     auto axis_delta = mm->add_instruction(migraphx::make_op("sub"), indices, l_ind_axis_indices);
@@ -1382,9 +1382,8 @@ TEST_CASE(gemm_half_test)
     l2 = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), l2);
     l2 = mm->add_instruction(
         migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), l2);
-    auto b_l = mm->add_literal(beta);
-    auto b_b =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), b_l);
+    auto b_l  = mm->add_literal(beta);
+    auto b_b  = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), b_l);
     auto l2_b = mm->add_instruction(migraphx::make_op("mul"), l2, b_b);
     l2_b      = mm->add_instruction(
         migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}), l2_b);
@@ -1670,20 +1669,20 @@ TEST_CASE(if_tuple_test)
     auto y    = mm->add_parameter("y", sy);
 
     auto* then_mod = p.create_module("If_6_if");
-    auto m1        = then_mod->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", {1, 4}}}), l1);
+    auto m1 =
+        then_mod->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {1, 4}}}), l1);
     auto add0 = then_mod->add_instruction(migraphx::make_op("add"), x, m1);
-    auto m2   = then_mod->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", {3, 4}}}), l2);
+    auto m2 =
+        then_mod->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 4}}}), l2);
     auto mul0 = then_mod->add_instruction(migraphx::make_op("mul"), y, m2);
     then_mod->add_return({add0, mul0});
 
     auto* else_mod = p.create_module("If_6_else");
-    auto me1       = else_mod->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", {1, 4}}}), l3);
+    auto me1 =
+        else_mod->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {1, 4}}}), l3);
     auto mul1 = else_mod->add_instruction(migraphx::make_op("mul"), x, me1);
-    auto me2  = else_mod->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", {3, 4}}}), l3);
+    auto me2 =
+        else_mod->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 4}}}), l3);
     auto add1 = else_mod->add_instruction(migraphx::make_op("add"), y, me2);
     else_mod->add_return({mul1, add1});
 
@@ -1745,8 +1744,8 @@ TEST_CASE(implicit_add_bcast_test)
     auto* mm = p.get_main_module();
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3, 4, 5}});
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {3, 4, 1}});
-    auto l3  = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}), l1);
+    auto l3 =
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}), l1);
     mm->add_instruction(migraphx::make_op("add"), l0, l3);
 
     auto prog = optimize_onnx("implicit_add_bcast_test.onnx");
@@ -1760,8 +1759,8 @@ TEST_CASE(implicit_add_bcast_user_input_shape_test)
     auto* mm = p.get_main_module();
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {3, 4, 5, 6}});
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {4, 5, 1}});
-    auto l3  = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", {3, 4, 5, 6}}}), l1);
+    auto l3 =
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 4, 5, 6}}}), l1);
     auto r = mm->add_instruction(migraphx::make_op("add"), l0, l3);
     mm->add_return({r});
 
@@ -1779,8 +1778,8 @@ TEST_CASE(implicit_pow_bcast_test)
     auto* mm = p.get_main_module();
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3, 4, 5}});
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {3, 4, 1}});
-    auto l3  = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}), l1);
+    auto l3 =
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}), l1);
     mm->add_instruction(migraphx::make_op("pow"), l0, l3);
 
     auto prog = optimize_onnx("implicit_pow_bcast_test.onnx");
@@ -1794,8 +1793,8 @@ TEST_CASE(implicit_sub_bcast_test)
     auto* mm = p.get_main_module();
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::uint64_type, {2, 3, 4, 5}});
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::uint64_type, {4, 5}});
-    auto l3  = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}), l1);
+    auto l3 =
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}), l1);
     mm->add_instruction(migraphx::make_op("sub"), l0, l3);
 
     auto prog = optimize_onnx("implicit_sub_bcast_test.onnx");
@@ -1840,13 +1839,13 @@ TEST_CASE(instance_norm_test)
         migraphx::make_op("multibroadcast", {{"out_lens", dims}}), epsilon_literal);
     auto variance_bcast =
         mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", dims}}), variance);
-    auto l2 = mm->add_instruction(migraphx::make_op("add"), variance_bcast, epsilon_bcast);
-    auto l3 = mm->add_instruction(migraphx::make_op("rsqrt"), l2);
-    auto l4 = mm->add_instruction(migraphx::make_op("mul"), l1, l3);
-    auto scale_bcast =
-        mm->add_instruction(migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", dims}}), scale);
-    auto bias_bcast =
-        mm->add_instruction(migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", dims}}), bias);
+    auto l2          = mm->add_instruction(migraphx::make_op("add"), variance_bcast, epsilon_bcast);
+    auto l3          = mm->add_instruction(migraphx::make_op("rsqrt"), l2);
+    auto l4          = mm->add_instruction(migraphx::make_op("mul"), l1, l3);
+    auto scale_bcast = mm->add_instruction(
+        migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", dims}}), scale);
+    auto bias_bcast = mm->add_instruction(
+        migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", dims}}), bias);
     auto l5 = mm->add_instruction(migraphx::make_op("mul"), l4, scale_bcast);
     mm->add_instruction(migraphx::make_op("add"), l5, bias_bcast);
 
@@ -2307,8 +2306,8 @@ TEST_CASE(onehot_test)
     auto diff       = mm->add_instruction(migraphx::make_op("sub"), on_val, off_val);
     auto mb_off_val = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"out_lens", {3, 5, 2}}}), off_val);
-    auto mb_diff = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", {3, 5, 2}}}), diff);
+    auto mb_diff =
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 5, 2}}}), diff);
     auto mul = mm->add_instruction(migraphx::make_op("mul"), tr_out, mb_diff);
     auto r   = mm->add_instruction(migraphx::make_op("add"), mul, mb_off_val);
     mm->add_return({r});
@@ -2855,7 +2854,7 @@ TEST_CASE(reshape_non_standard_test)
     auto x      = mm->add_parameter("x", s);
     auto tran_x = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 1}}}), x);
     auto cont_x = mm->add_instruction(migraphx::make_op("contiguous"), tran_x);
-    mm->add_instruction(migraphx::make_op("reshape", {{"dims", {4, 3, 2}}}), cont_x);
+    mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4, 3, 2}}}), cont_x);
     auto prog = optimize_onnx("reshape_non_standard_test.onnx");
 
     EXPECT(p == prog);
@@ -2879,7 +2878,7 @@ TEST_CASE(resize_downsample_c_test)
     std::vector<int> ind = {0, 2};
     auto li              = mm->add_literal(migraphx::literal(si, ind));
 
-    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {8}}}), inx);
+    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {8}}}), inx);
     auto r    = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
     mm->add_return({r});
 
@@ -2905,7 +2904,7 @@ TEST_CASE(resize_downsample_f_test)
     std::vector<int> ind = {0, 3};
     auto li              = mm->add_literal(migraphx::literal(si, ind));
 
-    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {8}}}), inx);
+    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {8}}}), inx);
     auto r    = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
     mm->add_return({r});
 
@@ -2946,7 +2945,7 @@ TEST_CASE(resize_downsample_linear_test)
     auto l1 = mm->add_literal(migraphx::literal(s1, d1));
 
     mm->add_instruction(migraphx::make_op("undefined"));
-    auto rsp   = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {8}}}), x);
+    auto rsp   = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {8}}}), x);
     auto data  = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), rsp, l_ind);
     auto slc80 = mm->add_instruction(
         migraphx::make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", {8}}}), data);
@@ -3000,7 +2999,7 @@ TEST_CASE(resize_outsize_test)
     std::vector<int> ind = {0, 0, 1, 1, 1, 1, 2, 2, 3, 3, 3, 3, 2, 2, 3, 3, 3, 3, 2, 2, 3, 3, 3, 3};
     auto li              = mm->add_literal(migraphx::literal(si, ind));
 
-    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), inx);
+    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4}}}), inx);
     auto r    = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
     mm->add_return({r});
 
@@ -3029,7 +3028,7 @@ TEST_CASE(resize_nonstd_input_test)
     mm->add_instruction(migraphx::make_op("undefined"));
     auto tx_cont = mm->add_instruction(migraphx::make_op("contiguous"), tx);
 
-    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {8}}}), tx_cont);
+    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {8}}}), tx_cont);
     auto r    = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
     mm->add_return({r});
 
@@ -3097,7 +3096,7 @@ TEST_CASE(resize_upsample_linear_ac_test)
     auto l1 = mm->add_literal(migraphx::literal(s1, d1));
 
     mm->add_instruction(migraphx::make_op("undefined"));
-    auto rsp   = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), x);
+    auto rsp   = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4}}}), x);
     auto data  = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), rsp, l_ind);
     auto slc80 = mm->add_instruction(
         migraphx::make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", {8}}}), data);
@@ -3192,7 +3191,7 @@ TEST_CASE(resize_upsample_linear_test)
     auto l1 = mm->add_literal(migraphx::literal(s1, d1));
 
     mm->add_instruction(migraphx::make_op("undefined"));
-    auto rsp   = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), x);
+    auto rsp   = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4}}}), x);
     auto data  = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), rsp, l_ind);
     auto slc80 = mm->add_instruction(
         migraphx::make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", {8}}}), data);
@@ -3246,7 +3245,7 @@ TEST_CASE(resize_upsample_pc_test)
     std::vector<int> ind = {0, 1, 1, 2, 3, 3, 0, 1, 1, 2, 3, 3, 4, 5, 5, 6, 7, 7, 4, 5, 5, 6, 7, 7};
     auto li              = mm->add_literal(migraphx::literal(si, ind));
 
-    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {8}}}), inx);
+    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {8}}}), inx);
     auto r    = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
     mm->add_return({r});
 
@@ -3273,7 +3272,7 @@ TEST_CASE(resize_upsample_pf_test)
     std::vector<int> ind = {0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 2, 2, 2, 3, 3, 3};
     auto li              = mm->add_literal(migraphx::literal(si, ind));
 
-    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), inx);
+    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4}}}), inx);
     auto r    = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
     mm->add_return({r});
 
@@ -3319,12 +3318,10 @@ TEST_CASE(selu_test)
     auto x = mm->add_parameter("x", s);
 
     migraphx::shape ls{migraphx::shape::double_type, {1}};
-    auto la = mm->add_literal({ls, {0.3}});
-    auto lg = mm->add_literal({ls, {0.25}});
-    auto mbla =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), la);
-    auto mblg =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), lg);
+    auto la   = mm->add_literal({ls, {0.3}});
+    auto lg   = mm->add_literal({ls, {0.25}});
+    auto mbla = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), la);
+    auto mblg = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), lg);
 
     auto sign_x = mm->add_instruction(migraphx::make_op("sign"), x);
     auto exp_x  = mm->add_instruction(migraphx::make_op("exp"), x);
@@ -3665,8 +3662,8 @@ TEST_CASE(sub_scalar_test)
     auto* mm = p.get_main_module();
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3, 4, 5}});
     auto l1 = mm->add_literal(migraphx::literal{migraphx::shape{migraphx::shape::float_type}, {1}});
-    auto m1 = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}), l1);
+    auto m1 =
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4, 5}}}), l1);
     mm->add_instruction(migraphx::make_op("sub"), l0, m1);
     auto prog = optimize_onnx("sub_scalar_test.onnx");
 
@@ -3905,7 +3902,7 @@ TEST_CASE(upsample_test)
     std::vector<int> ind = {0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 2, 2, 2, 3, 3, 3};
 
     auto li  = mm->add_literal(migraphx::literal(si, ind));
-    auto rsp = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), ix);
+    auto rsp = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4}}}), ix);
     auto r   = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), rsp, li);
     mm->add_return({r});
 
@@ -3974,14 +3971,14 @@ TEST_CASE(where_test)
         lc);
     auto lccm = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 2, 2}}}), int_c);
-    auto lxm = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 2, 2}}}), lx);
-    auto lym = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 2, 2}}}), ly);
+    auto lxm =
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 2, 2}}}), lx);
+    auto lym =
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 2, 2}}}), ly);
 
     auto concat_data = mm->add_instruction(migraphx::make_op("concat", {{"axis", 0}}), lym, lxm);
     auto rsp_data =
-        mm->add_instruction(migraphx::make_op("reshape", {{"dims", {32}}}), concat_data);
+        mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {32}}}), concat_data);
 
     std::vector<int> offset(16, 16);
     std::vector<int> ind(16);

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -1239,7 +1239,7 @@ TEST_CASE(gather_elements_axis0_test)
         mm->add_literal(migraphx::literal{ind_s, ind_axis_indices.begin(), ind_axis_indices.end()});
     auto l_stride = mm->add_literal(migraphx::literal{{migraphx::shape::int32_type, {1}}, {4}});
 
-    auto rsp_data = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {12}}}), data);
+    auto rsp_data    = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {12}}}), data);
     auto lbst_stride = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"out_lens", ind_s.lens()}}), l_stride);
     auto axis_delta = mm->add_instruction(migraphx::make_op("sub"), indices, l_ind_axis_indices);
@@ -1268,7 +1268,7 @@ TEST_CASE(gather_elements_axis1_test)
         mm->add_literal(migraphx::literal{ind_s, ind_axis_indices.begin(), ind_axis_indices.end()});
     auto l_stride = mm->add_literal(migraphx::literal{{migraphx::shape::int32_type, {1}}, {1}});
 
-    auto rsp_data = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {12}}}), data);
+    auto rsp_data    = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {12}}}), data);
     auto lbst_stride = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"out_lens", ind_s.lens()}}), l_stride);
     auto axis_delta = mm->add_instruction(migraphx::make_op("sub"), indices, l_ind_axis_indices);
@@ -2856,7 +2856,7 @@ TEST_CASE(reshape_non_standard_test)
     auto tran_x =
         mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 1}}}), x);
     auto cont_x = mm->add_instruction(migraphx::make_op("contiguous"), tran_x);
-    mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4, 3, 2}}}), cont_x);
+    mm->add_instruction(migraphx::make_op("reshape", {{"dims", {4, 3, 2}}}), cont_x);
     auto prog = optimize_onnx("reshape_non_standard_test.onnx");
 
     EXPECT(p == prog);
@@ -2880,7 +2880,7 @@ TEST_CASE(resize_downsample_c_test)
     std::vector<int> ind = {0, 2};
     auto li              = mm->add_literal(migraphx::literal(si, ind));
 
-    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {8}}}), inx);
+    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {8}}}), inx);
     auto r    = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
     mm->add_return({r});
 
@@ -2906,7 +2906,7 @@ TEST_CASE(resize_downsample_f_test)
     std::vector<int> ind = {0, 3};
     auto li              = mm->add_literal(migraphx::literal(si, ind));
 
-    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {8}}}), inx);
+    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {8}}}), inx);
     auto r    = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
     mm->add_return({r});
 
@@ -2947,7 +2947,7 @@ TEST_CASE(resize_downsample_linear_test)
     auto l1 = mm->add_literal(migraphx::literal(s1, d1));
 
     mm->add_instruction(migraphx::make_op("undefined"));
-    auto rsp   = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {8}}}), x);
+    auto rsp   = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {8}}}), x);
     auto data  = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), rsp, l_ind);
     auto slc80 = mm->add_instruction(
         migraphx::make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", {8}}}), data);
@@ -3001,7 +3001,7 @@ TEST_CASE(resize_outsize_test)
     std::vector<int> ind = {0, 0, 1, 1, 1, 1, 2, 2, 3, 3, 3, 3, 2, 2, 3, 3, 3, 3, 2, 2, 3, 3, 3, 3};
     auto li              = mm->add_literal(migraphx::literal(si, ind));
 
-    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4}}}), inx);
+    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), inx);
     auto r    = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
     mm->add_return({r});
 
@@ -3031,7 +3031,7 @@ TEST_CASE(resize_nonstd_input_test)
     mm->add_instruction(migraphx::make_op("undefined"));
     auto tx_cont = mm->add_instruction(migraphx::make_op("contiguous"), tx);
 
-    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {8}}}), tx_cont);
+    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {8}}}), tx_cont);
     auto r    = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
     mm->add_return({r});
 
@@ -3099,7 +3099,7 @@ TEST_CASE(resize_upsample_linear_ac_test)
     auto l1 = mm->add_literal(migraphx::literal(s1, d1));
 
     mm->add_instruction(migraphx::make_op("undefined"));
-    auto rsp   = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4}}}), x);
+    auto rsp   = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), x);
     auto data  = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), rsp, l_ind);
     auto slc80 = mm->add_instruction(
         migraphx::make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", {8}}}), data);
@@ -3194,7 +3194,7 @@ TEST_CASE(resize_upsample_linear_test)
     auto l1 = mm->add_literal(migraphx::literal(s1, d1));
 
     mm->add_instruction(migraphx::make_op("undefined"));
-    auto rsp   = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4}}}), x);
+    auto rsp   = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), x);
     auto data  = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), rsp, l_ind);
     auto slc80 = mm->add_instruction(
         migraphx::make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", {8}}}), data);
@@ -3248,7 +3248,7 @@ TEST_CASE(resize_upsample_pc_test)
     std::vector<int> ind = {0, 1, 1, 2, 3, 3, 0, 1, 1, 2, 3, 3, 4, 5, 5, 6, 7, 7, 4, 5, 5, 6, 7, 7};
     auto li              = mm->add_literal(migraphx::literal(si, ind));
 
-    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {8}}}), inx);
+    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {8}}}), inx);
     auto r    = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
     mm->add_return({r});
 
@@ -3275,7 +3275,7 @@ TEST_CASE(resize_upsample_pf_test)
     std::vector<int> ind = {0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 2, 2, 2, 3, 3, 3};
     auto li              = mm->add_literal(migraphx::literal(si, ind));
 
-    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4}}}), inx);
+    auto lrsp = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), inx);
     auto r    = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
     mm->add_return({r});
 
@@ -3905,7 +3905,7 @@ TEST_CASE(upsample_test)
     std::vector<int> ind = {0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 2, 2, 2, 3, 3, 3};
 
     auto li  = mm->add_literal(migraphx::literal(si, ind));
-    auto rsp = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4}}}), ix);
+    auto rsp = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), ix);
     auto r   = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), rsp, li);
     mm->add_return({r});
 
@@ -3981,7 +3981,7 @@ TEST_CASE(where_test)
 
     auto concat_data = mm->add_instruction(migraphx::make_op("concat", {{"axis", 0}}), lym, lxm);
     auto rsp_data =
-        mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {32}}}), concat_data);
+        mm->add_instruction(migraphx::make_op("reshape", {{"dims", {32}}}), concat_data);
 
     std::vector<int> offset(16, 16);
     std::vector<int> ind(16);

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -1188,7 +1188,7 @@ TEST_CASE(flatten_nonstd_test)
     migraphx::program p;
     auto* mm = p.get_main_module();
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3, 5, 4}});
-    auto l1  = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l0);
+    auto l1  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l0);
     auto l2  = mm->add_instruction(migraphx::make_op("contiguous"), l1);
     mm->add_instruction(migraphx::make_op("flatten", {{"axis", 2}}), l2);
     auto l3 = mm->add_instruction(migraphx::make_op("contiguous"), l1);
@@ -1238,7 +1238,7 @@ TEST_CASE(gather_elements_axis0_test)
         mm->add_literal(migraphx::literal{ind_s, ind_axis_indices.begin(), ind_axis_indices.end()});
     auto l_stride = mm->add_literal(migraphx::literal{{migraphx::shape::int32_type, {1}}, {4}});
 
-    auto rsp_data    = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {12}}}), data);
+    auto rsp_data = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {12}}}), data);
     auto lbst_stride = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"out_lens", ind_s.lens()}}), l_stride);
     auto axis_delta = mm->add_instruction(migraphx::make_op("sub"), indices, l_ind_axis_indices);
@@ -1267,7 +1267,7 @@ TEST_CASE(gather_elements_axis1_test)
         mm->add_literal(migraphx::literal{ind_s, ind_axis_indices.begin(), ind_axis_indices.end()});
     auto l_stride = mm->add_literal(migraphx::literal{{migraphx::shape::int32_type, {1}}, {1}});
 
-    auto rsp_data    = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {12}}}), data);
+    auto rsp_data = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {12}}}), data);
     auto lbst_stride = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"out_lens", ind_s.lens()}}), l_stride);
     auto axis_delta = mm->add_instruction(migraphx::make_op("sub"), indices, l_ind_axis_indices);
@@ -1292,8 +1292,8 @@ TEST_CASE(gemm_test)
     auto beta  = 2.0f;
     auto a_l   = mm->add_literal(alpha);
     auto t_a   = add_common_op(*mm, migraphx::make_op("mul"), {a_l, l0});
-    t_a        = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), t_a);
-    auto t1    = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l1);
+    t_a        = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), t_a);
+    auto t1    = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
 
     auto dot =
         mm->add_instruction(migraphx::make_op("dot", {{"alpha", 1.0f}, {"beta", 0.0f}}), t_a, t1);
@@ -1320,7 +1320,7 @@ TEST_CASE(gemm_ex_test)
     auto beta  = 0.8f;
     auto a_l   = mm->add_literal(alpha);
     auto t_a   = add_common_op(*mm, migraphx::make_op("mul"), {a_l, l0});
-    t_a        = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), t_a);
+    t_a        = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), t_a);
 
     auto dot =
         mm->add_instruction(migraphx::make_op("dot", {{"alpha", 1.0f}, {"beta", 0.0f}}), t_a, l1);
@@ -1346,7 +1346,7 @@ TEST_CASE(gemm_ex_brcst_test)
     auto beta  = 0.8f;
     auto a_l   = mm->add_literal(alpha);
     auto t_a   = add_common_op(*mm, migraphx::make_op("mul"), {a_l, l0});
-    t_a        = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), t_a);
+    t_a        = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), t_a);
 
     auto dot =
         mm->add_instruction(migraphx::make_op("dot", {{"alpha", 1.0f}, {"beta", 0.0f}}), t_a, l1);
@@ -1375,7 +1375,7 @@ TEST_CASE(gemm_half_test)
     auto t_a   = add_common_op(*mm, migraphx::make_op("mul"), {a_l, l0});
     t_a        = mm->add_instruction(
         migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}), t_a);
-    t_a = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), t_a);
+    t_a = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), t_a);
     std::vector<std::size_t> lens = {1, 1, 6, 7};
     auto dot =
         mm->add_instruction(migraphx::make_op("dot", {{"alpha", 1.0f}, {"beta", 0.0f}}), t_a, l1);
@@ -2298,7 +2298,7 @@ TEST_CASE(onehot_test)
     auto l_dep      = mm->add_literal(migraphx::literal(s_dep, data_dep));
     auto gather_out = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), l_dep, l_ind);
     auto tr_out =
-        mm->add_instruction(migraphx::make_op("transpose", {{"dims", {2, 0, 1}}}), gather_out);
+        mm->add_instruction(migraphx::make_op("transpose", {{"perm", {2, 0, 1}}}), gather_out);
     auto off_val = mm->add_instruction(
         migraphx::make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", {1}}}), l_val);
     auto on_val = mm->add_instruction(
@@ -2852,7 +2852,7 @@ TEST_CASE(reshape_non_standard_test)
     std::vector<int64_t> reshape_dims{4, 3, 2};
     migraphx::shape s{migraphx::shape::float_type, {2, 3, 4}};
     auto x      = mm->add_parameter("x", s);
-    auto tran_x = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 1}}}), x);
+    auto tran_x = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 1}}}), x);
     auto cont_x = mm->add_instruction(migraphx::make_op("contiguous"), tran_x);
     mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4, 3, 2}}}), cont_x);
     auto prog = optimize_onnx("reshape_non_standard_test.onnx");
@@ -3024,7 +3024,7 @@ TEST_CASE(resize_nonstd_input_test)
     std::vector<int> ind = {0, 4};
     auto li              = mm->add_literal(migraphx::literal(si, ind));
 
-    auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), inx);
+    auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), inx);
     mm->add_instruction(migraphx::make_op("undefined"));
     auto tx_cont = mm->add_instruction(migraphx::make_op("contiguous"), tx);
 
@@ -3813,7 +3813,7 @@ TEST_CASE(transpose_test)
     auto* mm   = p.get_main_module();
     auto input = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {1, 2, 2, 3}});
     std::vector<int64_t> perm{0, 3, 1, 2};
-    mm->add_instruction(migraphx::make_op("transpose", {{"dims", perm}}), input);
+    mm->add_instruction(migraphx::make_op("transpose", {{"perm", perm}}), input);
 
     auto prog = optimize_onnx("transpose_test.onnx");
 
@@ -3838,9 +3838,9 @@ TEST_CASE(transpose_gather_test)
     auto ind =
         mm->add_parameter("indices", migraphx::shape{migraphx::shape::int32_type, {2, 4, 3, 5}});
     auto tr_data =
-        mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 1, 3}}}), data);
+        mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 1, 3}}}), data);
     auto tr_ind =
-        mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 1, 3}}}), ind);
+        mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 1, 3}}}), ind);
     int axis = 1;
     mm->add_instruction(migraphx::make_op("gather", {{"axis", axis}}),
                         make_contiguous(tr_data),

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -1188,8 +1188,9 @@ TEST_CASE(flatten_nonstd_test)
     migraphx::program p;
     auto* mm = p.get_main_module();
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3, 5, 4}});
-    auto l1  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l0);
-    auto l2  = mm->add_instruction(migraphx::make_op("contiguous"), l1);
+    auto l1 =
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), l0);
+    auto l2 = mm->add_instruction(migraphx::make_op("contiguous"), l1);
     mm->add_instruction(migraphx::make_op("flatten", {{"axis", 2}}), l2);
     auto l3 = mm->add_instruction(migraphx::make_op("contiguous"), l1);
     mm->add_instruction(migraphx::make_op("flatten", {{"axis", 1}}), l3);
@@ -1292,8 +1293,8 @@ TEST_CASE(gemm_test)
     auto beta  = 2.0f;
     auto a_l   = mm->add_literal(alpha);
     auto t_a   = add_common_op(*mm, migraphx::make_op("mul"), {a_l, l0});
-    t_a        = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), t_a);
-    auto t1    = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
+    t_a     = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), t_a);
+    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l1);
 
     auto dot =
         mm->add_instruction(migraphx::make_op("dot", {{"alpha", 1.0f}, {"beta", 0.0f}}), t_a, t1);
@@ -1320,7 +1321,7 @@ TEST_CASE(gemm_ex_test)
     auto beta  = 0.8f;
     auto a_l   = mm->add_literal(alpha);
     auto t_a   = add_common_op(*mm, migraphx::make_op("mul"), {a_l, l0});
-    t_a        = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), t_a);
+    t_a = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), t_a);
 
     auto dot =
         mm->add_instruction(migraphx::make_op("dot", {{"alpha", 1.0f}, {"beta", 0.0f}}), t_a, l1);
@@ -1346,7 +1347,7 @@ TEST_CASE(gemm_ex_brcst_test)
     auto beta  = 0.8f;
     auto a_l   = mm->add_literal(alpha);
     auto t_a   = add_common_op(*mm, migraphx::make_op("mul"), {a_l, l0});
-    t_a        = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), t_a);
+    t_a = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), t_a);
 
     auto dot =
         mm->add_instruction(migraphx::make_op("dot", {{"alpha", 1.0f}, {"beta", 0.0f}}), t_a, l1);
@@ -1375,7 +1376,7 @@ TEST_CASE(gemm_half_test)
     auto t_a   = add_common_op(*mm, migraphx::make_op("mul"), {a_l, l0});
     t_a        = mm->add_instruction(
         migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}), t_a);
-    t_a = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), t_a);
+    t_a = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), t_a);
     std::vector<std::size_t> lens = {1, 1, 6, 7};
     auto dot =
         mm->add_instruction(migraphx::make_op("dot", {{"alpha", 1.0f}, {"beta", 0.0f}}), t_a, l1);
@@ -2297,8 +2298,8 @@ TEST_CASE(onehot_test)
     std::vector<float> data_dep{1, 0, 0, 0, 1, 0, 0, 0, 1};
     auto l_dep      = mm->add_literal(migraphx::literal(s_dep, data_dep));
     auto gather_out = mm->add_instruction(migraphx::make_op("gather", {{"axis", 0}}), l_dep, l_ind);
-    auto tr_out =
-        mm->add_instruction(migraphx::make_op("transpose", {{"perm", {2, 0, 1}}}), gather_out);
+    auto tr_out  = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {2, 0, 1}}}),
+                                      gather_out);
     auto off_val = mm->add_instruction(
         migraphx::make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", {1}}}), l_val);
     auto on_val = mm->add_instruction(
@@ -2851,8 +2852,9 @@ TEST_CASE(reshape_non_standard_test)
     migraphx::op::reshape op;
     std::vector<int64_t> reshape_dims{4, 3, 2};
     migraphx::shape s{migraphx::shape::float_type, {2, 3, 4}};
-    auto x      = mm->add_parameter("x", s);
-    auto tran_x = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 1}}}), x);
+    auto x = mm->add_parameter("x", s);
+    auto tran_x =
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 1}}}), x);
     auto cont_x = mm->add_instruction(migraphx::make_op("contiguous"), tran_x);
     mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4, 3, 2}}}), cont_x);
     auto prog = optimize_onnx("reshape_non_standard_test.onnx");
@@ -3024,7 +3026,8 @@ TEST_CASE(resize_nonstd_input_test)
     std::vector<int> ind = {0, 4};
     auto li              = mm->add_literal(migraphx::literal(si, ind));
 
-    auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), inx);
+    auto tx =
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), inx);
     mm->add_instruction(migraphx::make_op("undefined"));
     auto tx_cont = mm->add_instruction(migraphx::make_op("contiguous"), tx);
 
@@ -3813,7 +3816,7 @@ TEST_CASE(transpose_test)
     auto* mm   = p.get_main_module();
     auto input = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {1, 2, 2, 3}});
     std::vector<int64_t> perm{0, 3, 1, 2};
-    mm->add_instruction(migraphx::make_op("transpose", {{"perm", perm}}), input);
+    mm->add_instruction(migraphx::make_op("transpose", {{"permutation", perm}}), input);
 
     auto prog = optimize_onnx("transpose_test.onnx");
 
@@ -3838,9 +3841,9 @@ TEST_CASE(transpose_gather_test)
     auto ind =
         mm->add_parameter("indices", migraphx::shape{migraphx::shape::int32_type, {2, 4, 3, 5}});
     auto tr_data =
-        mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 1, 3}}}), data);
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 1, 3}}}), data);
     auto tr_ind =
-        mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 1, 3}}}), ind);
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 1, 3}}}), ind);
     int axis = 1;
     mm->add_instruction(migraphx::make_op("gather", {{"axis", axis}}),
                         make_contiguous(tr_data),

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -74,7 +74,7 @@ TEST_CASE(broadcast)
         std::vector<std::size_t> lens{1, 1};
         migraphx::shape input{migraphx::shape::float_type, {1}, {0}};
         expect_shape(migraphx::shape{migraphx::shape::float_type, {1, 1}, {0, 0}},
-                     migraphx::make_op("broadcast", {{"axis", 0}, {"dims", lens}}),
+                     migraphx::make_op("broadcast", {{"axis", 0}, {"out_lens", lens}}),
                      input);
     }
 
@@ -94,14 +94,14 @@ TEST_CASE(broadcast)
         std::vector<std::size_t> lens{3, 2, 4, 3};
         migraphx::shape input{migraphx::shape::float_type, {4, 3}};
         expect_shape(migraphx::shape{migraphx::shape::float_type, {3, 2, 4, 3}, {0, 0, 3, 1}},
-                     migraphx::make_op("broadcast", {{"axis", 2}, {"dims", lens}}),
+                     migraphx::make_op("broadcast", {{"axis", 2}, {"out_lens", lens}}),
                      input);
     }
 
     {
         std::vector<std::size_t> lens{3, 2, 4, 3};
         migraphx::shape input{migraphx::shape::float_type, {4, 4}};
-        throws_shape(migraphx::make_op("broadcast", {{"axis", 2}, {"dims", lens}}), input);
+        throws_shape(migraphx::make_op("broadcast", {{"axis", 2}, {"out_lens", lens}}), input);
     }
 }
 
@@ -953,70 +953,70 @@ TEST_CASE(multibroadcast)
         std::vector<std::size_t> lens{4, 2, 5, 3};
         migraphx::shape input{migraphx::shape::float_type, {2, 1, 3}};
         expect_shape(migraphx::shape{migraphx::shape::float_type, lens, {0, 3, 0, 1}},
-                     migraphx::make_op("multibroadcast", {{"output_lens", lens}}),
+                     migraphx::make_op("multibroadcast", {{"out_lens", lens}}),
                      input);
     }
     {
         std::vector<std::size_t> lens{4, 2, 5, 3};
         migraphx::shape input{migraphx::shape::float_type, {2, 1, 1}};
         expect_shape(migraphx::shape{migraphx::shape::float_type, lens, {0, 1, 0, 0}},
-                     migraphx::make_op("multibroadcast", {{"output_lens", lens}}),
+                     migraphx::make_op("multibroadcast", {{"out_lens", lens}}),
                      input);
     }
     {
         std::vector<std::size_t> lens{4, 2, 5, 3};
         migraphx::shape input{migraphx::shape::float_type, {5, 1}};
         expect_shape(migraphx::shape{migraphx::shape::float_type, lens, {0, 0, 1, 0}},
-                     migraphx::make_op("multibroadcast", {{"output_lens", lens}}),
+                     migraphx::make_op("multibroadcast", {{"out_lens", lens}}),
                      input);
     }
     {
         std::vector<std::size_t> lens{4, 2, 5, 3};
         migraphx::shape input{migraphx::shape::float_type, {4, 1, 1, 1}};
         expect_shape(migraphx::shape{migraphx::shape::float_type, lens, {1, 0, 0, 0}},
-                     migraphx::make_op("multibroadcast", {{"output_lens", lens}}),
+                     migraphx::make_op("multibroadcast", {{"out_lens", lens}}),
                      input);
     }
     {
         std::vector<std::size_t> lens{4, 2, 5, 3};
         migraphx::shape input{migraphx::shape::float_type, {3}};
         expect_shape(migraphx::shape{migraphx::shape::float_type, lens, {0, 0, 0, 1}},
-                     migraphx::make_op("multibroadcast", {{"output_lens", lens}}),
+                     migraphx::make_op("multibroadcast", {{"out_lens", lens}}),
                      input);
     }
     {
         std::vector<std::size_t> lens{4, 4, 1, 3};
         migraphx::shape input{migraphx::shape::float_type, {4, 1, 3}};
         expect_shape(migraphx::shape{migraphx::shape::float_type, lens, {0, 3, 3, 1}},
-                     migraphx::make_op("multibroadcast", {{"output_lens", lens}}),
+                     migraphx::make_op("multibroadcast", {{"out_lens", lens}}),
                      input);
     }
     {
         std::vector<std::size_t> lens{4, 1, 1, 3};
         migraphx::shape input{migraphx::shape::float_type, {4, 1, 1, 1}};
         expect_shape(migraphx::shape{migraphx::shape::float_type, lens, {1, 1, 1, 0}},
-                     migraphx::make_op("multibroadcast", {{"output_lens", lens}}),
+                     migraphx::make_op("multibroadcast", {{"out_lens", lens}}),
                      input);
     }
     {
         std::vector<std::size_t> lens{4, 1, 3};
         migraphx::shape input{migraphx::shape::float_type, {4, 1, 1, 1}};
-        throws_shape(migraphx::make_op("multibroadcast", {{"output_lens", lens}}), input);
+        throws_shape(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), input);
     }
     {
         std::vector<std::size_t> lens{4, 1, 3};
         migraphx::shape input{migraphx::shape::float_type, {}};
-        throws_shape(migraphx::make_op("multibroadcast", {{"output_lens", lens}}), input);
+        throws_shape(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), input);
     }
     {
         std::vector<std::size_t> lens{2, 3, 4, 5};
         migraphx::shape input{migraphx::shape::float_type, {3, 4}};
-        throws_shape(migraphx::make_op("multibroadcast", {{"output_lens", lens}}), input);
+        throws_shape(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), input);
     }
     {
         std::vector<std::size_t> lens{2, 3, 4, 5};
         migraphx::shape input{migraphx::shape::float_type, {2, 3, 4}};
-        throws_shape(migraphx::make_op("multibroadcast", {{"output_lens", lens}}), input);
+        throws_shape(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), input);
     }
 }
 

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -1183,13 +1183,13 @@ TEST_CASE(reshape_shape)
         std::vector<std::size_t> lens(new_shape.size());
         std::copy(new_shape.begin(), new_shape.end(), lens.begin());
         migraphx::shape output{migraphx::shape::float_type, lens};
-        expect_shape(output, migraphx::make_op("reshape", {{"out_lens", new_shape}}), input);
+        expect_shape(output, migraphx::make_op("reshape", {{"dims", new_shape}}), input);
     }
 
     for(auto&& new_shape :
         std::vector<std::vector<int64_t>>{{8, 3, 2, 2}, {1, 3, -1, -1}, {3, 0, 0}, {3, 2, 0}})
     {
-        throws_shape(migraphx::make_op("reshape", {{"out_lens", new_shape}}), input);
+        throws_shape(migraphx::make_op("reshape", {{"dims", new_shape}}), input);
     }
 
     std::vector<std::pair<std::vector<int64_t>, migraphx::shape>> minus1_tests{
@@ -1205,7 +1205,7 @@ TEST_CASE(reshape_shape)
 
     for(auto& it : minus1_tests)
     {
-        expect_shape(it.second, migraphx::make_op("reshape", {{"out_lens", it.first}}), input);
+        expect_shape(it.second, migraphx::make_op("reshape", {{"dims", it.first}}), input);
     }
 }
 

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -1558,10 +1558,10 @@ TEST_CASE(transpose_shape)
 {
     migraphx::shape input{migraphx::shape::float_type, {2, 2}};
     migraphx::shape output{migraphx::shape::float_type, {2, 2}, {1, 2}};
-    expect_shape(input, migraphx::make_op("transpose", {{"perm", {0, 1}}}), input);
-    expect_shape(output, migraphx::make_op("transpose", {{"perm", {1, 0}}}), input);
+    expect_shape(input, migraphx::make_op("transpose", {{"permutation", {0, 1}}}), input);
+    expect_shape(output, migraphx::make_op("transpose", {{"permutation", {1, 0}}}), input);
     expect_shape(output, migraphx::make_op("transpose"), input);
-    throws_shape(migraphx::make_op("transpose", {{"perm", {1, 2}}}), input);
+    throws_shape(migraphx::make_op("transpose", {{"permutation", {1, 2}}}), input);
 }
 
 TEST_CASE(step_test)

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -1558,10 +1558,10 @@ TEST_CASE(transpose_shape)
 {
     migraphx::shape input{migraphx::shape::float_type, {2, 2}};
     migraphx::shape output{migraphx::shape::float_type, {2, 2}, {1, 2}};
-    expect_shape(input, migraphx::make_op("transpose", {{"dims", {0, 1}}}), input);
-    expect_shape(output, migraphx::make_op("transpose", {{"dims", {1, 0}}}), input);
+    expect_shape(input, migraphx::make_op("transpose", {{"perm", {0, 1}}}), input);
+    expect_shape(output, migraphx::make_op("transpose", {{"perm", {1, 0}}}), input);
     expect_shape(output, migraphx::make_op("transpose"), input);
-    throws_shape(migraphx::make_op("transpose", {{"dims", {1, 2}}}), input);
+    throws_shape(migraphx::make_op("transpose", {{"perm", {1, 2}}}), input);
 }
 
 TEST_CASE(step_test)

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -1183,13 +1183,13 @@ TEST_CASE(reshape_shape)
         std::vector<std::size_t> lens(new_shape.size());
         std::copy(new_shape.begin(), new_shape.end(), lens.begin());
         migraphx::shape output{migraphx::shape::float_type, lens};
-        expect_shape(output, migraphx::make_op("reshape", {{"dims", new_shape}}), input);
+        expect_shape(output, migraphx::make_op("reshape", {{"out_lens", new_shape}}), input);
     }
 
     for(auto&& new_shape :
         std::vector<std::vector<int64_t>>{{8, 3, 2, 2}, {1, 3, -1, -1}, {3, 0, 0}, {3, 2, 0}})
     {
-        throws_shape(migraphx::make_op("reshape", {{"dims", new_shape}}), input);
+        throws_shape(migraphx::make_op("reshape", {{"out_lens", new_shape}}), input);
     }
 
     std::vector<std::pair<std::vector<int64_t>, migraphx::shape>> minus1_tests{
@@ -1205,7 +1205,7 @@ TEST_CASE(reshape_shape)
 
     for(auto& it : minus1_tests)
     {
-        expect_shape(it.second, migraphx::make_op("reshape", {{"dims", it.first}}), input);
+        expect_shape(it.second, migraphx::make_op("reshape", {{"out_lens", it.first}}), input);
     }
 }
 

--- a/test/quantization.cpp
+++ b/test/quantization.cpp
@@ -25,10 +25,10 @@ create_clip_op(migraphx::program& p, float max, float min, migraphx::instruction
     auto input_lens = input->get_shape().lens();
     auto max_val    = mm->add_literal(max);
     auto min_val    = mm->add_literal(min);
-    max_val         = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), max_val);
-    min_val = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), min_val);
+    max_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}),
+                                  max_val);
+    min_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}),
+                                  min_val);
     return mm->add_instruction(migraphx::make_op("clip"), input, min_val, max_val);
 }
 

--- a/test/quantization.cpp
+++ b/test/quantization.cpp
@@ -26,9 +26,9 @@ create_clip_op(migraphx::program& p, float max, float min, migraphx::instruction
     auto max_val    = mm->add_literal(max);
     auto min_val    = mm->add_literal(min);
     max_val         = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), max_val);
+        migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), max_val);
     min_val = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), min_val);
+        migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), min_val);
     return mm->add_instruction(migraphx::make_op("clip"), input, min_val, max_val);
 }
 
@@ -43,9 +43,9 @@ migraphx::instruction_ref create_clip_op(migraphx::instruction_ref insert_loc,
     auto max_val    = mm->add_literal(max);
     auto min_val    = mm->add_literal(min);
     max_val         = mm->insert_instruction(
-        insert_loc, migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), max_val);
+        insert_loc, migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), max_val);
     min_val = mm->insert_instruction(
-        insert_loc, migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), min_val);
+        insert_loc, migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), min_val);
     return mm->insert_instruction(insert_loc, migraphx::make_op("clip"), input, min_val, max_val);
 }
 

--- a/test/ref_dot_op_test.cpp
+++ b/test/ref_dot_op_test.cpp
@@ -668,7 +668,7 @@ TEST_CASE(matmul_vm)
         auto al   = mm->add_literal(migraphx::literal{a_shape, a});
         auto ual  = mm->add_instruction(migraphx::make_op("unsqueeze", {{"axes", {0}}}), al);
         auto bual = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {3, 1, 6}}}), ual);
+            migraphx::make_op("multibroadcast", {{"out_lens", {3, 1, 6}}}), ual);
         migraphx::shape b_shape{migraphx::shape::float_type, {3, 6, 4}};
         auto bl = mm->add_literal(migraphx::literal{b_shape, b});
         mm->add_instruction(migraphx::make_op("dot"), bual, bl);
@@ -715,7 +715,7 @@ TEST_CASE(matmul_vm)
         auto al   = mm->add_literal(migraphx::literal{a_shape, a});
         auto ual  = mm->add_instruction(migraphx::make_op("unsqueeze", {{"axes", {0}}}), al);
         auto bual = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {3, 1, 6}}}), ual);
+            migraphx::make_op("multibroadcast", {{"out_lens", {3, 1, 6}}}), ual);
         migraphx::shape b_shape{migraphx::shape::float_type, {3, 6, 4}};
         auto bl = mm->add_literal(migraphx::literal{b_shape, b});
         mm->add_instruction(migraphx::make_op("dot", {{"alpha", 0.21f}}), bual, bl);
@@ -837,7 +837,7 @@ TEST_CASE(matmul_mv)
         auto bl   = mm->add_literal(migraphx::literal{b_shape, b});
         auto ubl  = mm->add_instruction(migraphx::make_op("unsqueeze", {{"axes", {1}}}), bl);
         auto bubl = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 2, 5, 1}}}), ubl);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 5, 1}}}), ubl);
         mm->add_instruction(migraphx::make_op("dot"), al, bubl);
         std::vector<float> gold = {-0.792717,
                                    6.33595,
@@ -897,7 +897,7 @@ TEST_CASE(matmul_mm1)
         migraphx::shape b_shape{migraphx::shape::float_type, {5, 3}};
         auto bl  = mm->add_literal(migraphx::literal{b_shape, b});
         auto bbl = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 2, 5, 3}}}), bl);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 5, 3}}}), bl);
         mm->add_instruction(migraphx::make_op("dot"), al, bbl);
         std::vector<float> gold = {-0.386828, 0.187735,  -0.22822, -0.148057, 2.015,    -2.56938,
                                    -0.782212, 1.9459,    0.927426, -2.44907,  2.40531,  2.30232,
@@ -946,7 +946,7 @@ TEST_CASE(matmul_mm1)
         migraphx::shape a_shape{migraphx::shape::float_type, {3, 4}};
         auto al  = mm->add_literal(migraphx::literal{a_shape, a});
         auto bal = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 3, 3, 4}}}), al);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 3, 4}}}), al);
         migraphx::shape b_shape{migraphx::shape::float_type, {2, 3, 4, 3}};
         auto bl = mm->add_literal(migraphx::literal{b_shape, b});
         mm->add_instruction(migraphx::make_op("dot"), bal, bl);
@@ -994,7 +994,7 @@ TEST_CASE(matmul_mm2)
         migraphx::shape b_shape{migraphx::shape::float_type, {2, 1, 5, 3}};
         auto bl  = mm->add_literal(migraphx::literal{b_shape, b});
         auto bbl = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 2, 5, 3}}}), bl);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 5, 3}}}), bl);
         std::vector<float> gold = {
             0.70574512,  -2.80915314, -1.57644969, 1.75415381,  -3.13303087, -1.00150259,
             -0.18675123, -0.23349122, -0.12357225, 0.82911538,  1.37473744,  -1.11709934,
@@ -1030,11 +1030,11 @@ TEST_CASE(matmul_mm2)
         migraphx::shape a_shape{migraphx::shape::float_type, {1, 2, 3, 5}};
         auto al  = mm->add_literal(migraphx::literal{a_shape, a});
         auto bal = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 2, 3, 5}}}), al);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 3, 5}}}), al);
         migraphx::shape b_shape{migraphx::shape::float_type, {2, 1, 5, 3}};
         auto bl  = mm->add_literal(migraphx::literal{b_shape, b});
         auto bbl = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 2, 5, 3}}}), bl);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 5, 3}}}), bl);
         mm->add_instruction(migraphx::make_op("dot"), bal, bbl);
         std::vector<float> gold = {
             1.64924590e+00,  2.84575831e+00,  1.07340773e+00,  2.19817080e-01,  -1.87873283e+00,
@@ -1132,7 +1132,7 @@ TEST_CASE(matmul_mm2)
         migraphx::shape b_shape{migraphx::shape::float_type, {2, 4, 5}};
         auto bl  = mm->add_literal(migraphx::literal{b_shape, b});
         auto bbl = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 2, 4, 5}}}), bl);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 4, 5}}}), bl);
         mm->add_instruction(migraphx::make_op("dot"), al, bbl);
         std::vector<float> gold = {
             -1.08585245, 0.39575611,  0.33947977,  -0.86339678, 1.50710753,  0.05646156,

--- a/test/ref_dot_op_test.cpp
+++ b/test/ref_dot_op_test.cpp
@@ -1193,7 +1193,7 @@ TEST_CASE(quant_dot_2args_multi4)
         std::iota(data2.begin(), data2.end(), 0);
 
         auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l1);
+        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
         auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
         mm->add_instruction(migraphx::make_op("quant_dot"), tl1, l2);
 
@@ -1221,7 +1221,7 @@ TEST_CASE(quant_dot_2args_multi4)
 
         auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
         auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l2);
+        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
         mm->add_instruction(migraphx::make_op("quant_dot"), l1, tl2);
 
         std::vector<int> gold = {14,  38,   62,  86,  110, 134, 158, 182,  38,   126, 214,
@@ -1247,9 +1247,9 @@ TEST_CASE(quant_dot_2args_multi4)
         std::iota(data2.begin(), data2.end(), 0);
 
         auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l1);
+        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
         auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l2);
+        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
         mm->add_instruction(migraphx::make_op("quant_dot"), tl1, tl2);
 
         std::vector<int> gold = {56,  152, 248, 344, 440, 536, 632, 728, 62,  174, 286,
@@ -1303,7 +1303,7 @@ TEST_CASE(quant_dot_2args_general)
         std::iota(data2.begin(), data2.end(), 0);
 
         auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l1);
+        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
         auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
         mm->add_instruction(migraphx::make_op("quant_dot"), tl1, l2);
 
@@ -1330,7 +1330,7 @@ TEST_CASE(quant_dot_2args_general)
 
         auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
         auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l2);
+        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
         mm->add_instruction(migraphx::make_op("quant_dot", {{"alpha", 2}}), l1, tl2);
 
         std::vector<int> gold = {
@@ -1355,9 +1355,9 @@ TEST_CASE(quant_dot_2args_general)
         std::iota(data2.begin(), data2.end(), 0);
 
         auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l1);
+        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
         auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l2);
+        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
         mm->add_instruction(migraphx::make_op("quant_dot", {{"alpha", 3}, {"beta", 2}}), tl1, tl2);
 
         std::vector<int> gold = {
@@ -1447,7 +1447,7 @@ TEST_CASE(quant_dot_3args_general)
         std::iota(data3.begin(), data3.end(), 2);
 
         auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l1);
+        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
         auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
         auto l3  = mm->add_literal(migraphx::literal{m3_shape, data3});
         mm->add_instruction(
@@ -1479,7 +1479,7 @@ TEST_CASE(quant_dot_3args_general)
 
         auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
         auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l2);
+        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
         auto l3  = mm->add_literal(migraphx::literal{m3_shape, data3});
         mm->add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 2}, {"beta", 3}}), l1, tl2, l3);
@@ -1509,9 +1509,9 @@ TEST_CASE(quant_dot_3args_general)
         std::iota(data3.begin(), data3.end(), 2);
 
         auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l1);
+        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
         auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l2);
+        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
         auto l3  = mm->add_literal(migraphx::literal{m3_shape, data3});
         mm->add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 3}, {"beta", 2}}), tl1, tl2, l3);
@@ -1579,10 +1579,10 @@ TEST_CASE(quant_dot_3args_batch)
 
         auto l1 = mm->add_literal(migraphx::literal{m1_shape, data1});
         auto tl1 =
-            mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l1);
+            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l1);
         auto l2 = mm->add_literal(migraphx::literal{m2_shape, data2});
         auto tl2 =
-            mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l2);
+            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l2);
         auto l3 = mm->add_literal(migraphx::literal{m3_shape, data3});
         mm->add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 2}, {"beta", 3}}), tl1, tl2, l3);

--- a/test/ref_dot_op_test.cpp
+++ b/test/ref_dot_op_test.cpp
@@ -1192,9 +1192,10 @@ TEST_CASE(quant_dot_2args_multi4)
         std::iota(data1.begin(), data1.end(), 0);
         std::iota(data2.begin(), data2.end(), 0);
 
-        auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
-        auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
+        auto l1 = mm->add_literal(migraphx::literal{m1_shape, data1});
+        auto tl1 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l1);
+        auto l2 = mm->add_literal(migraphx::literal{m2_shape, data2});
         mm->add_instruction(migraphx::make_op("quant_dot"), tl1, l2);
 
         std::vector<int> gold = {448, 472, 496, 520, 544, 568, 592, 616, 496, 524, 552,
@@ -1219,9 +1220,10 @@ TEST_CASE(quant_dot_2args_multi4)
         std::iota(data1.begin(), data1.end(), 0);
         std::iota(data2.begin(), data2.end(), 0);
 
-        auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
-        auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
+        auto l1 = mm->add_literal(migraphx::literal{m1_shape, data1});
+        auto l2 = mm->add_literal(migraphx::literal{m2_shape, data2});
+        auto tl2 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l2);
         mm->add_instruction(migraphx::make_op("quant_dot"), l1, tl2);
 
         std::vector<int> gold = {14,  38,   62,  86,  110, 134, 158, 182,  38,   126, 214,
@@ -1246,10 +1248,12 @@ TEST_CASE(quant_dot_2args_multi4)
         std::iota(data1.begin(), data1.end(), 0);
         std::iota(data2.begin(), data2.end(), 0);
 
-        auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
-        auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
+        auto l1 = mm->add_literal(migraphx::literal{m1_shape, data1});
+        auto tl1 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l1);
+        auto l2 = mm->add_literal(migraphx::literal{m2_shape, data2});
+        auto tl2 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l2);
         mm->add_instruction(migraphx::make_op("quant_dot"), tl1, tl2);
 
         std::vector<int> gold = {56,  152, 248, 344, 440, 536, 632, 728, 62,  174, 286,
@@ -1302,9 +1306,10 @@ TEST_CASE(quant_dot_2args_general)
         std::iota(data1.begin(), data1.end(), 0);
         std::iota(data2.begin(), data2.end(), 0);
 
-        auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
-        auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
+        auto l1 = mm->add_literal(migraphx::literal{m1_shape, data1});
+        auto tl1 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l1);
+        auto l2 = mm->add_literal(migraphx::literal{m2_shape, data2});
         mm->add_instruction(migraphx::make_op("quant_dot"), tl1, l2);
 
         std::vector<int> gold = {
@@ -1328,9 +1333,10 @@ TEST_CASE(quant_dot_2args_general)
         std::iota(data1.begin(), data1.end(), 0);
         std::iota(data2.begin(), data2.end(), 0);
 
-        auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
-        auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
+        auto l1 = mm->add_literal(migraphx::literal{m1_shape, data1});
+        auto l2 = mm->add_literal(migraphx::literal{m2_shape, data2});
+        auto tl2 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l2);
         mm->add_instruction(migraphx::make_op("quant_dot", {{"alpha", 2}}), l1, tl2);
 
         std::vector<int> gold = {
@@ -1354,10 +1360,12 @@ TEST_CASE(quant_dot_2args_general)
         std::iota(data1.begin(), data1.end(), 0);
         std::iota(data2.begin(), data2.end(), 0);
 
-        auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
-        auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
+        auto l1 = mm->add_literal(migraphx::literal{m1_shape, data1});
+        auto tl1 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l1);
+        auto l2 = mm->add_literal(migraphx::literal{m2_shape, data2});
+        auto tl2 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l2);
         mm->add_instruction(migraphx::make_op("quant_dot", {{"alpha", 3}, {"beta", 2}}), tl1, tl2);
 
         std::vector<int> gold = {
@@ -1446,10 +1454,11 @@ TEST_CASE(quant_dot_3args_general)
         std::iota(data2.begin(), data2.end(), 0);
         std::iota(data3.begin(), data3.end(), 2);
 
-        auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
-        auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
-        auto l3  = mm->add_literal(migraphx::literal{m3_shape, data3});
+        auto l1 = mm->add_literal(migraphx::literal{m1_shape, data1});
+        auto tl1 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l1);
+        auto l2 = mm->add_literal(migraphx::literal{m2_shape, data2});
+        auto l3 = mm->add_literal(migraphx::literal{m3_shape, data3});
         mm->add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 1}, {"beta", 3}}), tl1, l2, l3);
 
@@ -1477,10 +1486,11 @@ TEST_CASE(quant_dot_3args_general)
         std::iota(data2.begin(), data2.end(), 0);
         std::iota(data3.begin(), data3.end(), 2);
 
-        auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
-        auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
-        auto l3  = mm->add_literal(migraphx::literal{m3_shape, data3});
+        auto l1 = mm->add_literal(migraphx::literal{m1_shape, data1});
+        auto l2 = mm->add_literal(migraphx::literal{m2_shape, data2});
+        auto tl2 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l2);
+        auto l3 = mm->add_literal(migraphx::literal{m3_shape, data3});
         mm->add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 2}, {"beta", 3}}), l1, tl2, l3);
 
@@ -1508,11 +1518,13 @@ TEST_CASE(quant_dot_3args_general)
         std::iota(data2.begin(), data2.end(), 0);
         std::iota(data3.begin(), data3.end(), 2);
 
-        auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
-        auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
-        auto l3  = mm->add_literal(migraphx::literal{m3_shape, data3});
+        auto l1 = mm->add_literal(migraphx::literal{m1_shape, data1});
+        auto tl1 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l1);
+        auto l2 = mm->add_literal(migraphx::literal{m2_shape, data2});
+        auto tl2 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l2);
+        auto l3 = mm->add_literal(migraphx::literal{m3_shape, data3});
         mm->add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 3}, {"beta", 2}}), tl1, tl2, l3);
 
@@ -1577,12 +1589,12 @@ TEST_CASE(quant_dot_3args_batch)
         std::iota(data2.begin(), data2.end(), 0);
         std::iota(data3.begin(), data3.end(), 2);
 
-        auto l1 = mm->add_literal(migraphx::literal{m1_shape, data1});
-        auto tl1 =
-            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l1);
-        auto l2 = mm->add_literal(migraphx::literal{m2_shape, data2});
-        auto tl2 =
-            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l2);
+        auto l1  = mm->add_literal(migraphx::literal{m1_shape, data1});
+        auto tl1 = mm->add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), l1);
+        auto l2  = mm->add_literal(migraphx::literal{m2_shape, data2});
+        auto tl2 = mm->add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), l2);
         auto l3 = mm->add_literal(migraphx::literal{m3_shape, data3});
         mm->add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 2}, {"beta", 3}}), tl1, tl2, l3);

--- a/test/ref_ops_test.cpp
+++ b/test/ref_ops_test.cpp
@@ -86,7 +86,7 @@ TEST_CASE(add_broadcast_test)
         auto l1       = mm->add_literal(migraphx::literal{a_shape, a_data});
         auto l2       = mm->add_literal(migraphx::literal{b_shape, b_data});
         auto l3       = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", axis}, {"dims", l1->get_shape().lens()}}), l2);
+            migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", l1->get_shape().lens()}}), l2);
         mm->add_instruction(migraphx::make_op("add"), l1, l3);
         p.compile(migraphx::ref::target{});
         auto result = p.eval({}).back();
@@ -106,9 +106,9 @@ TEST_CASE(add_broadcast_test)
         auto l1 = mm->add_literal(migraphx::literal{a_shape, a_data});
         auto l2 = mm->add_literal(migraphx::literal{b_shape, b_data});
         auto l3 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 2, 3}}}), l1);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 3}}}), l1);
         auto l4 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 2, 3}}}), l2);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 3}}}), l2);
         mm->add_instruction(migraphx::make_op("add"), l3, l4);
         p.compile(migraphx::ref::target{});
         auto result = p.eval({}).back();
@@ -675,7 +675,7 @@ TEST_CASE(broadcast_test)
     auto l1       = mm->add_literal(migraphx::literal{a_shape, a_data});
     auto l2       = mm->add_literal(migraphx::literal{b_shape, b_data});
     mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", axis}, {"dims", l1->get_shape().lens()}}), l2);
+        migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", l1->get_shape().lens()}}), l2);
     p.compile(migraphx::ref::target{});
     auto result = p.eval({}).back();
     auto output = result.get<int32_t>();
@@ -712,9 +712,9 @@ TEST_CASE(clip_test)
     auto min_val = mm->add_literal(0.0f);
     auto max_val = mm->add_literal(6.0f);
     min_val =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {3}}}), min_val);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3}}}), min_val);
     max_val =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {3}}}), max_val);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3}}}), max_val);
     mm->add_instruction(migraphx::make_op("clip"), l, min_val, max_val);
     p.compile(migraphx::ref::target{});
     auto result = p.eval({}).back();
@@ -1330,7 +1330,7 @@ TEST_CASE(equal_brcst_test)
     migraphx::shape s1{migraphx::shape::float_type, {3, 1}};
     auto l1 = mm->add_literal(migraphx::literal{s1, {1.1, -1.5, 0.0}});
     auto bl1 =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {3, 3}}}), l1);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 3}}}), l1);
     auto eq = mm->add_instruction(migraphx::make_op("equal"), l0, bl1);
     auto r  = mm->add_instruction(
         migraphx::make_op("convert",
@@ -1677,7 +1677,7 @@ TEST_CASE(greater_brcst_test)
     migraphx::shape s1{migraphx::shape::float_type, {3, 1}};
     auto l1 = mm->add_literal(migraphx::literal{s1, {1.1, -1.5, 0.0}});
     auto bl1 =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {3, 3}}}), l1);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 3}}}), l1);
     auto gr = mm->add_instruction(migraphx::make_op("greater"), l0, bl1);
     auto r  = mm->add_instruction(
         migraphx::make_op("convert",
@@ -2129,7 +2129,7 @@ TEST_CASE(imagescaler_test)
     auto bias_vals  = mm->add_literal(
         migraphx::literal{migraphx::shape{migraphx::shape::float_type, {3}}, {0.01, 0.02, 0.03}});
     auto bias_bcast = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", 1}, {"dims", s.lens()}}), bias_vals);
+        migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", s.lens()}}), bias_vals);
     mm->add_instruction(migraphx::make_op("add"), img_scaled, bias_bcast);
     p.compile(migraphx::ref::target{});
     auto result = p.eval({}).back();
@@ -2177,7 +2177,7 @@ TEST_CASE(less_brcst_test)
     migraphx::shape s1{migraphx::shape::float_type, {3, 1}};
     auto l1 = mm->add_literal(migraphx::literal{s1, {1.1, -1.5, 0.0}});
     auto bl1 =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {3, 3}}}), l1);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 3}}}), l1);
     auto le = mm->add_instruction(migraphx::make_op("less"), l0, bl1);
     auto r  = mm->add_instruction(
         migraphx::make_op("convert",

--- a/test/ref_ops_test.cpp
+++ b/test/ref_ops_test.cpp
@@ -4196,7 +4196,7 @@ TEST_CASE(step_test)
         std::iota(data.begin(), data.end(), 2);
         migraphx::shape s1{migraphx::shape::float_type, {2, 1, 4, 6}};
         auto l0 = mm->add_literal(migraphx::literal{s1, data});
-        auto tl = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), l0);
+        auto tl = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l0);
         auto r  = mm->add_instruction(
             migraphx::make_op("step", {{"axes", {0, 1, 2}}, {"steps", {2, 2, 3}}}), tl);
         mm->add_return({r});
@@ -4270,7 +4270,7 @@ TEST_CASE(transpose_test)
         auto* mm                  = p.get_main_module();
         auto l                    = mm->add_literal(migraphx::literal{a_shape, data});
         std::vector<int64_t> perm = {0, 3, 1, 2};
-        mm->add_instruction(migraphx::make_op("transpose", {{"dims", perm}}), l);
+        mm->add_instruction(migraphx::make_op("transpose", {{"perm", perm}}), l);
         p.compile(migraphx::ref::target{});
         auto result = p.eval({}).back();
 
@@ -4284,7 +4284,7 @@ TEST_CASE(transpose_test)
         auto* mm                  = p.get_main_module();
         auto l                    = mm->add_literal(migraphx::literal{a_shape, data});
         std::vector<int64_t> perm = {0, 3, 1, 2};
-        auto result = mm->add_instruction(migraphx::make_op("transpose", {{"dims", perm}}), l);
+        auto result = mm->add_instruction(migraphx::make_op("transpose", {{"perm", perm}}), l);
         mm->add_instruction(migraphx::make_op("contiguous"), result);
         p.compile(migraphx::ref::target{});
         auto result2 = p.eval({}).back();

--- a/test/ref_ops_test.cpp
+++ b/test/ref_ops_test.cpp
@@ -86,7 +86,8 @@ TEST_CASE(add_broadcast_test)
         auto l1       = mm->add_literal(migraphx::literal{a_shape, a_data});
         auto l2       = mm->add_literal(migraphx::literal{b_shape, b_data});
         auto l3       = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", l1->get_shape().lens()}}), l2);
+            migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", l1->get_shape().lens()}}),
+            l2);
         mm->add_instruction(migraphx::make_op("add"), l1, l3);
         p.compile(migraphx::ref::target{});
         auto result = p.eval({}).back();
@@ -105,10 +106,10 @@ TEST_CASE(add_broadcast_test)
         std::vector<float> b_data{0, -1, -2, -3};
         auto l1 = mm->add_literal(migraphx::literal{a_shape, a_data});
         auto l2 = mm->add_literal(migraphx::literal{b_shape, b_data});
-        auto l3 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 3}}}), l1);
-        auto l4 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 3}}}), l2);
+        auto l3 =
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 3}}}), l1);
+        auto l4 =
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 3}}}), l2);
         mm->add_instruction(migraphx::make_op("add"), l3, l4);
         p.compile(migraphx::ref::target{});
         auto result = p.eval({}).back();
@@ -1328,11 +1329,10 @@ TEST_CASE(equal_brcst_test)
     auto l0 =
         mm->add_literal(migraphx::literal{s0, {1.1, 1.5, 0.1, -1.1, -1.5, -0.6, 0.0, 2.0, -2.0}});
     migraphx::shape s1{migraphx::shape::float_type, {3, 1}};
-    auto l1 = mm->add_literal(migraphx::literal{s1, {1.1, -1.5, 0.0}});
-    auto bl1 =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 3}}}), l1);
-    auto eq = mm->add_instruction(migraphx::make_op("equal"), l0, bl1);
-    auto r  = mm->add_instruction(
+    auto l1  = mm->add_literal(migraphx::literal{s1, {1.1, -1.5, 0.0}});
+    auto bl1 = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 3}}}), l1);
+    auto eq  = mm->add_instruction(migraphx::make_op("equal"), l0, bl1);
+    auto r   = mm->add_instruction(
         migraphx::make_op("convert",
                           {{"target_type", migraphx::to_value(migraphx::shape::bool_type)}}),
         eq);
@@ -1675,11 +1675,10 @@ TEST_CASE(greater_brcst_test)
     auto l0 =
         mm->add_literal(migraphx::literal{s0, {1.1, 1.5, 0.1, -1.1, -1.5, -0.6, 0.0, 2.0, -2.0}});
     migraphx::shape s1{migraphx::shape::float_type, {3, 1}};
-    auto l1 = mm->add_literal(migraphx::literal{s1, {1.1, -1.5, 0.0}});
-    auto bl1 =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 3}}}), l1);
-    auto gr = mm->add_instruction(migraphx::make_op("greater"), l0, bl1);
-    auto r  = mm->add_instruction(
+    auto l1  = mm->add_literal(migraphx::literal{s1, {1.1, -1.5, 0.0}});
+    auto bl1 = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 3}}}), l1);
+    auto gr  = mm->add_instruction(migraphx::make_op("greater"), l0, bl1);
+    auto r   = mm->add_instruction(
         migraphx::make_op("convert",
                           {{"target_type", migraphx::to_value(migraphx::shape::bool_type)}}),
         gr);
@@ -2175,11 +2174,10 @@ TEST_CASE(less_brcst_test)
     auto l0 =
         mm->add_literal(migraphx::literal{s0, {1.1, 1.5, 0.1, -1.1, -1.5, -0.6, 0.0, 2.0, -2.0}});
     migraphx::shape s1{migraphx::shape::float_type, {3, 1}};
-    auto l1 = mm->add_literal(migraphx::literal{s1, {1.1, -1.5, 0.0}});
-    auto bl1 =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 3}}}), l1);
-    auto le = mm->add_instruction(migraphx::make_op("less"), l0, bl1);
-    auto r  = mm->add_instruction(
+    auto l1  = mm->add_literal(migraphx::literal{s1, {1.1, -1.5, 0.0}});
+    auto bl1 = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 3}}}), l1);
+    auto le  = mm->add_instruction(migraphx::make_op("less"), l0, bl1);
+    auto r   = mm->add_instruction(
         migraphx::make_op("convert",
                           {{"target_type", migraphx::to_value(migraphx::shape::bool_type)}}),
         le);
@@ -3707,7 +3705,7 @@ TEST_CASE(reshape_test)
         auto* mm                       = p.get_main_module();
         auto l                         = mm->add_literal(migraphx::literal{a_shape, data});
         std::vector<int64_t> new_shape = {8, 3, 1, 1};
-        mm->add_instruction(migraphx::make_op("reshape", {{"dims", new_shape}}), l);
+        mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", new_shape}}), l);
         p.compile(migraphx::ref::target{});
         auto result = p.eval({}).back();
         std::vector<float> results_vector(3);
@@ -3719,7 +3717,7 @@ TEST_CASE(reshape_test)
         auto* mm                       = p.get_main_module();
         auto l                         = mm->add_literal(migraphx::literal{a_shape, data});
         std::vector<int64_t> new_shape = {1, 3, 4, 2};
-        mm->add_instruction(migraphx::make_op("reshape", {{"dims", new_shape}}), l);
+        mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", new_shape}}), l);
         p.compile(migraphx::ref::target{});
         auto result = p.eval({}).back();
         std::vector<float> results_vector(3);
@@ -3731,7 +3729,7 @@ TEST_CASE(reshape_test)
         auto* mm                       = p.get_main_module();
         auto l                         = mm->add_literal(migraphx::literal{a_shape, data});
         std::vector<int64_t> new_shape = {1, 3, 4, 2};
-        mm->add_instruction(migraphx::make_op("reshape", {{"dims", new_shape}}), l);
+        mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", new_shape}}), l);
         p.compile(migraphx::ref::target{});
         auto result = p.eval({}).back();
         std::vector<float> results_vector(3);

--- a/test/ref_ops_test.cpp
+++ b/test/ref_ops_test.cpp
@@ -3705,7 +3705,7 @@ TEST_CASE(reshape_test)
         auto* mm                       = p.get_main_module();
         auto l                         = mm->add_literal(migraphx::literal{a_shape, data});
         std::vector<int64_t> new_shape = {8, 3, 1, 1};
-        mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", new_shape}}), l);
+        mm->add_instruction(migraphx::make_op("reshape", {{"dims", new_shape}}), l);
         p.compile(migraphx::ref::target{});
         auto result = p.eval({}).back();
         std::vector<float> results_vector(3);
@@ -3717,7 +3717,7 @@ TEST_CASE(reshape_test)
         auto* mm                       = p.get_main_module();
         auto l                         = mm->add_literal(migraphx::literal{a_shape, data});
         std::vector<int64_t> new_shape = {1, 3, 4, 2};
-        mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", new_shape}}), l);
+        mm->add_instruction(migraphx::make_op("reshape", {{"dims", new_shape}}), l);
         p.compile(migraphx::ref::target{});
         auto result = p.eval({}).back();
         std::vector<float> results_vector(3);
@@ -3729,7 +3729,7 @@ TEST_CASE(reshape_test)
         auto* mm                       = p.get_main_module();
         auto l                         = mm->add_literal(migraphx::literal{a_shape, data});
         std::vector<int64_t> new_shape = {1, 3, 4, 2};
-        mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", new_shape}}), l);
+        mm->add_instruction(migraphx::make_op("reshape", {{"dims", new_shape}}), l);
         p.compile(migraphx::ref::target{});
         auto result = p.eval({}).back();
         std::vector<float> results_vector(3);

--- a/test/ref_ops_test.cpp
+++ b/test/ref_ops_test.cpp
@@ -4196,8 +4196,9 @@ TEST_CASE(step_test)
         std::iota(data.begin(), data.end(), 2);
         migraphx::shape s1{migraphx::shape::float_type, {2, 1, 4, 6}};
         auto l0 = mm->add_literal(migraphx::literal{s1, data});
-        auto tl = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l0);
-        auto r  = mm->add_instruction(
+        auto tl = mm->add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), l0);
+        auto r = mm->add_instruction(
             migraphx::make_op("step", {{"axes", {0, 1, 2}}, {"steps", {2, 2, 3}}}), tl);
         mm->add_return({r});
         p.compile(migraphx::ref::target{});
@@ -4270,7 +4271,7 @@ TEST_CASE(transpose_test)
         auto* mm                  = p.get_main_module();
         auto l                    = mm->add_literal(migraphx::literal{a_shape, data});
         std::vector<int64_t> perm = {0, 3, 1, 2};
-        mm->add_instruction(migraphx::make_op("transpose", {{"perm", perm}}), l);
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", perm}}), l);
         p.compile(migraphx::ref::target{});
         auto result = p.eval({}).back();
 
@@ -4284,7 +4285,8 @@ TEST_CASE(transpose_test)
         auto* mm                  = p.get_main_module();
         auto l                    = mm->add_literal(migraphx::literal{a_shape, data});
         std::vector<int64_t> perm = {0, 3, 1, 2};
-        auto result = mm->add_instruction(migraphx::make_op("transpose", {{"perm", perm}}), l);
+        auto result =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", perm}}), l);
         mm->add_instruction(migraphx::make_op("contiguous"), result);
         p.compile(migraphx::ref::target{});
         auto result2 = p.eval({}).back();

--- a/test/rewrite_pooling_test.cpp
+++ b/test/rewrite_pooling_test.cpp
@@ -38,10 +38,10 @@ TEST_CASE(rewrite_pooling_test)
     auto opt_program = [&](const migraphx::operation& reduce_op) {
         migraphx::module m;
         auto input = m.add_parameter("x", s);
-        auto rsp   = m.add_instruction(migraphx::make_op("reshape", {{"dims", {4, -1}}}), input);
+        auto rsp   = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {4, -1}}}), input);
         auto rdm   = m.add_instruction(reduce_op, rsp);
         auto ret =
-            m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2, 1, 1, 1}}}), rdm);
+            m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2, 1, 1, 1}}}), rdm);
         m.add_return({ret});
         return m;
     };
@@ -154,10 +154,10 @@ TEST_CASE(literal_rewrite_pooling_test)
         migraphx::program p;
         auto* mm   = p.get_main_module();
         auto input = mm->add_literal(migraphx::literal(s, data));
-        auto rsp   = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {4, -1}}}), input);
+        auto rsp   = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4, -1}}}), input);
         auto rdm   = mm->add_instruction(op, rsp);
         auto ret =
-            mm->add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2, 1, 1, 1}}}), rdm);
+            mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2, 1, 1, 1}}}), rdm);
         mm->add_return({ret});
 
         return p;

--- a/test/rewrite_pooling_test.cpp
+++ b/test/rewrite_pooling_test.cpp
@@ -38,8 +38,8 @@ TEST_CASE(rewrite_pooling_test)
     auto opt_program = [&](const migraphx::operation& reduce_op) {
         migraphx::module m;
         auto input = m.add_parameter("x", s);
-        auto rsp   = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {4, -1}}}), input);
-        auto rdm   = m.add_instruction(reduce_op, rsp);
+        auto rsp = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {4, -1}}}), input);
+        auto rdm = m.add_instruction(reduce_op, rsp);
         auto ret =
             m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2, 1, 1, 1}}}), rdm);
         m.add_return({ret});
@@ -154,8 +154,9 @@ TEST_CASE(literal_rewrite_pooling_test)
         migraphx::program p;
         auto* mm   = p.get_main_module();
         auto input = mm->add_literal(migraphx::literal(s, data));
-        auto rsp   = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4, -1}}}), input);
-        auto rdm   = mm->add_instruction(op, rsp);
+        auto rsp =
+            mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4, -1}}}), input);
+        auto rdm = mm->add_instruction(op, rsp);
         auto ret =
             mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2, 1, 1, 1}}}), rdm);
         mm->add_return({ret});

--- a/test/rewrite_pooling_test.cpp
+++ b/test/rewrite_pooling_test.cpp
@@ -38,10 +38,10 @@ TEST_CASE(rewrite_pooling_test)
     auto opt_program = [&](const migraphx::operation& reduce_op) {
         migraphx::module m;
         auto input = m.add_parameter("x", s);
-        auto rsp = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {4, -1}}}), input);
-        auto rdm = m.add_instruction(reduce_op, rsp);
+        auto rsp   = m.add_instruction(migraphx::make_op("reshape", {{"dims", {4, -1}}}), input);
+        auto rdm   = m.add_instruction(reduce_op, rsp);
         auto ret =
-            m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2, 1, 1, 1}}}), rdm);
+            m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2, 1, 1, 1}}}), rdm);
         m.add_return({ret});
         return m;
     };
@@ -154,11 +154,10 @@ TEST_CASE(literal_rewrite_pooling_test)
         migraphx::program p;
         auto* mm   = p.get_main_module();
         auto input = mm->add_literal(migraphx::literal(s, data));
-        auto rsp =
-            mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {4, -1}}}), input);
-        auto rdm = mm->add_instruction(op, rsp);
+        auto rsp   = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {4, -1}}}), input);
+        auto rdm   = mm->add_instruction(op, rsp);
         auto ret =
-            mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2, 1, 1, 1}}}), rdm);
+            mm->add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2, 1, 1, 1}}}), rdm);
         mm->add_return({ret});
 
         return p;

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -1062,7 +1062,7 @@ TEST_CASE(simplify_split_add_relu_reshape)
         auto concatb = m2.add_instruction(b, concat);
         auto sum     = m2.add_instruction(migraphx::make_op("add"), input, concatb);
         auto relu    = m2.add_instruction(migraphx::make_op("relu"), sum);
-        auto rsp     = m2.add_instruction(migraphx::make_op("reshape", {{"dims", {3, 8}}}), relu);
+        auto rsp     = m2.add_instruction(migraphx::make_op("reshape", {{"out_lens", {3, 8}}}), relu);
         auto slc1    = m2.add_instruction(
             migraphx::make_op("slice", {{"axes", {1}}, {"starts", {0}}, {"ends", {4}}}), rsp);
         auto slc2 = m2.add_instruction(
@@ -1781,9 +1781,9 @@ TEST_CASE(reorder_reshape_slice)
         auto c2 = m1.add_instruction(migraphx::make_op("contiguous"), slc2);
 
         std::vector<int64_t> lens = {static_cast<int64_t>(batch_size), 128, 10, 64};
-        auto r0 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c0);
-        auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c1);
-        auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c2);
+        auto r0 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c0);
+        auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c1);
+        auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c2);
 
         auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"dims", perm0}}), r0);
         auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"dims", perm0}}), r1);
@@ -1801,7 +1801,7 @@ TEST_CASE(reorder_reshape_slice)
         auto s     = migraphx::shape{migraphx::shape::float_type, {batch_size, 128, 1920}};
         auto input = m2.add_parameter("input", s);
         std::vector<int64_t> lens = {static_cast<int64_t>(batch_size), 128, 30, 64};
-        auto r = m2.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), input);
+        auto r = m2.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), input);
 
         auto slc0 = m2.add_instruction(
             migraphx::make_op("slice", {{"axes", {2}}, {"starts", {0}}, {"ends", {10}}}), r);
@@ -1853,13 +1853,13 @@ TEST_CASE(reorder_reshape_slice_move_axis1)
         auto c2 = m1.add_instruction(migraphx::make_op("contiguous"), slc2);
 
         std::vector<int64_t> lens = {static_cast<int64_t>(batch_size), 64, 4, 32};
-        auto r0 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c0);
-        auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c1);
-        auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c2);
+        auto r0 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c0);
+        auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c1);
+        auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c2);
 
-        auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"dims", perm0}}), r0);
-        auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"dims", perm0}}), r1);
-        auto t2 = m1.add_instruction(migraphx::make_op("transpose", {{"dims", perm1}}), r2);
+        auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"out_lens", perm0}}), r0);
+        auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"out_lens", perm0}}), r1);
+        auto t2 = m1.add_instruction(migraphx::make_op("transpose", {{"out_lens", perm1}}), r2);
 
         auto sum = m1.add_instruction(migraphx::make_op("add"), t0, t1);
         auto ret = m1.add_instruction(migraphx::make_op("dot"), sum, t2);
@@ -1875,7 +1875,7 @@ TEST_CASE(reorder_reshape_slice_move_axis1)
         std::vector<int64_t> perm1 = {0, 2, 3, 1};
         auto input                 = m.add_parameter("input", s);
         std::vector<int64_t> lens  = {static_cast<int64_t>(batch_size), 64, 4, 96};
-        auto rsp  = m.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), input);
+        auto rsp  = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), input);
         auto slc0 = m.add_instruction(
             migraphx::make_op("slice", {{"axes", {3}}, {"starts", {0}}, {"ends", {32}}}), rsp);
         auto t0   = m.add_instruction(migraphx::make_op("transpose", {{"dims", perm0}}), slc0);
@@ -1922,9 +1922,9 @@ TEST_CASE(reorder_reshape_slice_move_axis2)
         auto c2 = m1.add_instruction(migraphx::make_op("contiguous"), slc2);
 
         std::vector<int64_t> lens = {1, 16, 8, 32};
-        auto r0 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c0);
-        auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c1);
-        auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c2);
+        auto r0 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c0);
+        auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c1);
+        auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c2);
 
         auto sum = m1.add_instruction(migraphx::make_op("add"), r0, r1);
         auto ret = m1.add_instruction(migraphx::make_op("mul"), sum, r2);
@@ -1938,7 +1938,7 @@ TEST_CASE(reorder_reshape_slice_move_axis2)
         auto s                    = migraphx::shape{migraphx::shape::float_type, {128, 96}};
         auto input                = m.add_parameter("input", s);
         std::vector<int64_t> lens = {1, 16, 8, 96};
-        auto rsp  = m.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), input);
+        auto rsp  = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), input);
         auto slc0 = m.add_instruction(
             migraphx::make_op("slice", {{"axes", {3}}, {"starts", {0}}, {"ends", {32}}}), rsp);
         auto slc1 = m.add_instruction(
@@ -1977,9 +1977,9 @@ TEST_CASE(reorder_reshape_slice_not_apply)
         auto c2 = m.add_instruction(migraphx::make_op("contiguous"), slc2);
 
         std::vector<int64_t> lens = {1, 16, 16, 16};
-        auto r0 = m.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c0);
-        auto r1 = m.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c1);
-        auto r2 = m.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c2);
+        auto r0 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c0);
+        auto r1 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c1);
+        auto r2 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c2);
 
         auto sum = m.add_instruction(migraphx::make_op("add"), r0, r1);
         auto ret = m.add_instruction(migraphx::make_op("mul"), sum, r2);
@@ -2015,9 +2015,9 @@ TEST_CASE(reorder_reshape_slice_diff_dims)
 
         std::vector<int64_t> lens  = {static_cast<int64_t>(batch_size), 32, 3, 32};
         std::vector<int64_t> lens1 = {static_cast<int64_t>(batch_size), 48, 2, 32};
-        auto r0 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c0);
-        auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c1);
-        auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens1}}), c2);
+        auto r0 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c0);
+        auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c1);
+        auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens1}}), c2);
 
         m1.add_return({r0, r1, r2});
 

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -1062,8 +1062,8 @@ TEST_CASE(simplify_split_add_relu_reshape)
         auto concatb = m2.add_instruction(b, concat);
         auto sum     = m2.add_instruction(migraphx::make_op("add"), input, concatb);
         auto relu    = m2.add_instruction(migraphx::make_op("relu"), sum);
-        auto rsp     = m2.add_instruction(migraphx::make_op("reshape", {{"out_lens", {3, 8}}}), relu);
-        auto slc1    = m2.add_instruction(
+        auto rsp  = m2.add_instruction(migraphx::make_op("reshape", {{"out_lens", {3, 8}}}), relu);
+        auto slc1 = m2.add_instruction(
             migraphx::make_op("slice", {{"axes", {1}}, {"starts", {0}}, {"ends", {4}}}), rsp);
         auto slc2 = m2.add_instruction(
             migraphx::make_op("slice", {{"axes", {1}}, {"starts", {4}}, {"ends", {8}}}), rsp);
@@ -1785,9 +1785,9 @@ TEST_CASE(reorder_reshape_slice)
         auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c1);
         auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c2);
 
-        auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"dims", perm0}}), r0);
-        auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"dims", perm0}}), r1);
-        auto t2 = m1.add_instruction(migraphx::make_op("transpose", {{"dims", perm1}}), r2);
+        auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), r0);
+        auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), r1);
+        auto t2 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm1}}), r2);
 
         auto sum = m1.add_instruction(migraphx::make_op("add"), t0, t1);
         auto ret = m1.add_instruction(migraphx::make_op("dot"), sum, t2);
@@ -1810,9 +1810,9 @@ TEST_CASE(reorder_reshape_slice)
         auto slc2 = m2.add_instruction(
             migraphx::make_op("slice", {{"axes", {2}}, {"starts", {20}}, {"ends", {30}}}), r);
 
-        auto t0 = m2.add_instruction(migraphx::make_op("transpose", {{"dims", perm0}}), slc0);
-        auto t1 = m2.add_instruction(migraphx::make_op("transpose", {{"dims", perm0}}), slc1);
-        auto t2 = m2.add_instruction(migraphx::make_op("transpose", {{"dims", perm1}}), slc2);
+        auto t0 = m2.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), slc0);
+        auto t1 = m2.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), slc1);
+        auto t2 = m2.add_instruction(migraphx::make_op("transpose", {{"perm", perm1}}), slc2);
 
         auto sum = m2.add_instruction(migraphx::make_op("add"), t0, t1);
         auto ret = m2.add_instruction(migraphx::make_op("dot"), sum, t2);
@@ -1857,9 +1857,9 @@ TEST_CASE(reorder_reshape_slice_move_axis1)
         auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c1);
         auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c2);
 
-        auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"out_lens", perm0}}), r0);
-        auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"out_lens", perm0}}), r1);
-        auto t2 = m1.add_instruction(migraphx::make_op("transpose", {{"out_lens", perm1}}), r2);
+        auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), r0);
+        auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), r1);
+        auto t2 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm1}}), r2);
 
         auto sum = m1.add_instruction(migraphx::make_op("add"), t0, t1);
         auto ret = m1.add_instruction(migraphx::make_op("dot"), sum, t2);
@@ -1878,13 +1878,13 @@ TEST_CASE(reorder_reshape_slice_move_axis1)
         auto rsp  = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), input);
         auto slc0 = m.add_instruction(
             migraphx::make_op("slice", {{"axes", {3}}, {"starts", {0}}, {"ends", {32}}}), rsp);
-        auto t0   = m.add_instruction(migraphx::make_op("transpose", {{"dims", perm0}}), slc0);
+        auto t0   = m.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), slc0);
         auto slc1 = m.add_instruction(
             migraphx::make_op("slice", {{"axes", {3}}, {"starts", {32}}, {"ends", {64}}}), rsp);
-        auto t1   = m.add_instruction(migraphx::make_op("transpose", {{"dims", perm0}}), slc1);
+        auto t1   = m.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), slc1);
         auto slc2 = m.add_instruction(
             migraphx::make_op("slice", {{"axes", {3}}, {"starts", {64}}, {"ends", {96}}}), rsp);
-        auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"dims", perm1}}), slc2);
+        auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", perm1}}), slc2);
 
         auto sum = m.add_instruction(migraphx::make_op("add"), t0, t1);
         auto ret = m.add_instruction(migraphx::make_op("dot"), sum, t2);
@@ -2051,9 +2051,9 @@ TEST_CASE(reorder_slice_trans)
             migraphx::make_op("slice", {{"axes", {2}}, {"starts", {1280}}, {"ends", {1920}}}),
             input);
 
-        auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"dims", perm}}), slc0);
-        auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"dims", perm}}), slc1);
-        auto t2 = m1.add_instruction(migraphx::make_op("transpose", {{"dims", perm}}), slc2);
+        auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm}}), slc0);
+        auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm}}), slc1);
+        auto t2 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm}}), slc2);
 
         auto sum = m1.add_instruction(migraphx::make_op("add"), t0, t1);
         auto ret = m1.add_instruction(migraphx::make_op("mul"), sum, t2);
@@ -2066,7 +2066,7 @@ TEST_CASE(reorder_slice_trans)
         migraphx::module m2;
         auto s     = migraphx::shape{migraphx::shape::float_type, {batch_size, 128, 1920}};
         auto input = m2.add_parameter("input", s);
-        auto r     = m2.add_instruction(migraphx::make_op("transpose", {{"dims", perm}}), input);
+        auto r     = m2.add_instruction(migraphx::make_op("transpose", {{"perm", perm}}), input);
 
         auto slc0 = m2.add_instruction(
             migraphx::make_op("slice", {{"axes", {1}}, {"starts", {0}}, {"ends", {640}}}), r);
@@ -2110,9 +2110,9 @@ TEST_CASE(reorder_slice_trans_diff_perm)
             migraphx::make_op("slice", {{"axes", {2}}, {"starts", {1280}}, {"ends", {1920}}}),
             input);
 
-        auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"dims", perm0}}), slc0);
-        auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"dims", perm0}}), slc1);
-        auto t2 = m1.add_instruction(migraphx::make_op("transpose", {{"dims", perm1}}), slc2);
+        auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), slc0);
+        auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), slc1);
+        auto t2 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm1}}), slc2);
 
         auto sum = m1.add_instruction(migraphx::make_op("add"), t0, t1);
         auto ret = m1.add_instruction(migraphx::make_op("dot"), sum, t2);

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -1785,9 +1785,9 @@ TEST_CASE(reorder_reshape_slice)
         auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c1);
         auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c2);
 
-        auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), r0);
-        auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), r1);
-        auto t2 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm1}}), r2);
+        auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"permutation", perm0}}), r0);
+        auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"permutation", perm0}}), r1);
+        auto t2 = m1.add_instruction(migraphx::make_op("transpose", {{"permutation", perm1}}), r2);
 
         auto sum = m1.add_instruction(migraphx::make_op("add"), t0, t1);
         auto ret = m1.add_instruction(migraphx::make_op("dot"), sum, t2);
@@ -1810,9 +1810,12 @@ TEST_CASE(reorder_reshape_slice)
         auto slc2 = m2.add_instruction(
             migraphx::make_op("slice", {{"axes", {2}}, {"starts", {20}}, {"ends", {30}}}), r);
 
-        auto t0 = m2.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), slc0);
-        auto t1 = m2.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), slc1);
-        auto t2 = m2.add_instruction(migraphx::make_op("transpose", {{"perm", perm1}}), slc2);
+        auto t0 =
+            m2.add_instruction(migraphx::make_op("transpose", {{"permutation", perm0}}), slc0);
+        auto t1 =
+            m2.add_instruction(migraphx::make_op("transpose", {{"permutation", perm0}}), slc1);
+        auto t2 =
+            m2.add_instruction(migraphx::make_op("transpose", {{"permutation", perm1}}), slc2);
 
         auto sum = m2.add_instruction(migraphx::make_op("add"), t0, t1);
         auto ret = m2.add_instruction(migraphx::make_op("dot"), sum, t2);
@@ -1857,9 +1860,9 @@ TEST_CASE(reorder_reshape_slice_move_axis1)
         auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c1);
         auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c2);
 
-        auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), r0);
-        auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), r1);
-        auto t2 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm1}}), r2);
+        auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"permutation", perm0}}), r0);
+        auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"permutation", perm0}}), r1);
+        auto t2 = m1.add_instruction(migraphx::make_op("transpose", {{"permutation", perm1}}), r2);
 
         auto sum = m1.add_instruction(migraphx::make_op("add"), t0, t1);
         auto ret = m1.add_instruction(migraphx::make_op("dot"), sum, t2);
@@ -1878,13 +1881,13 @@ TEST_CASE(reorder_reshape_slice_move_axis1)
         auto rsp  = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), input);
         auto slc0 = m.add_instruction(
             migraphx::make_op("slice", {{"axes", {3}}, {"starts", {0}}, {"ends", {32}}}), rsp);
-        auto t0   = m.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), slc0);
+        auto t0 = m.add_instruction(migraphx::make_op("transpose", {{"permutation", perm0}}), slc0);
         auto slc1 = m.add_instruction(
             migraphx::make_op("slice", {{"axes", {3}}, {"starts", {32}}, {"ends", {64}}}), rsp);
-        auto t1   = m.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), slc1);
+        auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"permutation", perm0}}), slc1);
         auto slc2 = m.add_instruction(
             migraphx::make_op("slice", {{"axes", {3}}, {"starts", {64}}, {"ends", {96}}}), rsp);
-        auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", perm1}}), slc2);
+        auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"permutation", perm1}}), slc2);
 
         auto sum = m.add_instruction(migraphx::make_op("add"), t0, t1);
         auto ret = m.add_instruction(migraphx::make_op("dot"), sum, t2);
@@ -2051,9 +2054,9 @@ TEST_CASE(reorder_slice_trans)
             migraphx::make_op("slice", {{"axes", {2}}, {"starts", {1280}}, {"ends", {1920}}}),
             input);
 
-        auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm}}), slc0);
-        auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm}}), slc1);
-        auto t2 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm}}), slc2);
+        auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"permutation", perm}}), slc0);
+        auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"permutation", perm}}), slc1);
+        auto t2 = m1.add_instruction(migraphx::make_op("transpose", {{"permutation", perm}}), slc2);
 
         auto sum = m1.add_instruction(migraphx::make_op("add"), t0, t1);
         auto ret = m1.add_instruction(migraphx::make_op("mul"), sum, t2);
@@ -2066,7 +2069,7 @@ TEST_CASE(reorder_slice_trans)
         migraphx::module m2;
         auto s     = migraphx::shape{migraphx::shape::float_type, {batch_size, 128, 1920}};
         auto input = m2.add_parameter("input", s);
-        auto r     = m2.add_instruction(migraphx::make_op("transpose", {{"perm", perm}}), input);
+        auto r = m2.add_instruction(migraphx::make_op("transpose", {{"permutation", perm}}), input);
 
         auto slc0 = m2.add_instruction(
             migraphx::make_op("slice", {{"axes", {1}}, {"starts", {0}}, {"ends", {640}}}), r);
@@ -2110,9 +2113,12 @@ TEST_CASE(reorder_slice_trans_diff_perm)
             migraphx::make_op("slice", {{"axes", {2}}, {"starts", {1280}}, {"ends", {1920}}}),
             input);
 
-        auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), slc0);
-        auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm0}}), slc1);
-        auto t2 = m1.add_instruction(migraphx::make_op("transpose", {{"perm", perm1}}), slc2);
+        auto t0 =
+            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", perm0}}), slc0);
+        auto t1 =
+            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", perm0}}), slc1);
+        auto t2 =
+            m1.add_instruction(migraphx::make_op("transpose", {{"permutation", perm1}}), slc2);
 
         auto sum = m1.add_instruction(migraphx::make_op("add"), t0, t1);
         auto ret = m1.add_instruction(migraphx::make_op("dot"), sum, t2);

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -1062,8 +1062,8 @@ TEST_CASE(simplify_split_add_relu_reshape)
         auto concatb = m2.add_instruction(b, concat);
         auto sum     = m2.add_instruction(migraphx::make_op("add"), input, concatb);
         auto relu    = m2.add_instruction(migraphx::make_op("relu"), sum);
-        auto rsp  = m2.add_instruction(migraphx::make_op("reshape", {{"out_lens", {3, 8}}}), relu);
-        auto slc1 = m2.add_instruction(
+        auto rsp     = m2.add_instruction(migraphx::make_op("reshape", {{"dims", {3, 8}}}), relu);
+        auto slc1    = m2.add_instruction(
             migraphx::make_op("slice", {{"axes", {1}}, {"starts", {0}}, {"ends", {4}}}), rsp);
         auto slc2 = m2.add_instruction(
             migraphx::make_op("slice", {{"axes", {1}}, {"starts", {4}}, {"ends", {8}}}), rsp);
@@ -1781,9 +1781,9 @@ TEST_CASE(reorder_reshape_slice)
         auto c2 = m1.add_instruction(migraphx::make_op("contiguous"), slc2);
 
         std::vector<int64_t> lens = {static_cast<int64_t>(batch_size), 128, 10, 64};
-        auto r0 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c0);
-        auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c1);
-        auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c2);
+        auto r0 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c0);
+        auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c1);
+        auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c2);
 
         auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"permutation", perm0}}), r0);
         auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"permutation", perm0}}), r1);
@@ -1801,7 +1801,7 @@ TEST_CASE(reorder_reshape_slice)
         auto s     = migraphx::shape{migraphx::shape::float_type, {batch_size, 128, 1920}};
         auto input = m2.add_parameter("input", s);
         std::vector<int64_t> lens = {static_cast<int64_t>(batch_size), 128, 30, 64};
-        auto r = m2.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), input);
+        auto r = m2.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), input);
 
         auto slc0 = m2.add_instruction(
             migraphx::make_op("slice", {{"axes", {2}}, {"starts", {0}}, {"ends", {10}}}), r);
@@ -1856,9 +1856,9 @@ TEST_CASE(reorder_reshape_slice_move_axis1)
         auto c2 = m1.add_instruction(migraphx::make_op("contiguous"), slc2);
 
         std::vector<int64_t> lens = {static_cast<int64_t>(batch_size), 64, 4, 32};
-        auto r0 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c0);
-        auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c1);
-        auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c2);
+        auto r0 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c0);
+        auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c1);
+        auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c2);
 
         auto t0 = m1.add_instruction(migraphx::make_op("transpose", {{"permutation", perm0}}), r0);
         auto t1 = m1.add_instruction(migraphx::make_op("transpose", {{"permutation", perm0}}), r1);
@@ -1878,7 +1878,7 @@ TEST_CASE(reorder_reshape_slice_move_axis1)
         std::vector<int64_t> perm1 = {0, 2, 3, 1};
         auto input                 = m.add_parameter("input", s);
         std::vector<int64_t> lens  = {static_cast<int64_t>(batch_size), 64, 4, 96};
-        auto rsp  = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), input);
+        auto rsp  = m.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), input);
         auto slc0 = m.add_instruction(
             migraphx::make_op("slice", {{"axes", {3}}, {"starts", {0}}, {"ends", {32}}}), rsp);
         auto t0 = m.add_instruction(migraphx::make_op("transpose", {{"permutation", perm0}}), slc0);
@@ -1925,9 +1925,9 @@ TEST_CASE(reorder_reshape_slice_move_axis2)
         auto c2 = m1.add_instruction(migraphx::make_op("contiguous"), slc2);
 
         std::vector<int64_t> lens = {1, 16, 8, 32};
-        auto r0 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c0);
-        auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c1);
-        auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c2);
+        auto r0 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c0);
+        auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c1);
+        auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c2);
 
         auto sum = m1.add_instruction(migraphx::make_op("add"), r0, r1);
         auto ret = m1.add_instruction(migraphx::make_op("mul"), sum, r2);
@@ -1941,7 +1941,7 @@ TEST_CASE(reorder_reshape_slice_move_axis2)
         auto s                    = migraphx::shape{migraphx::shape::float_type, {128, 96}};
         auto input                = m.add_parameter("input", s);
         std::vector<int64_t> lens = {1, 16, 8, 96};
-        auto rsp  = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), input);
+        auto rsp  = m.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), input);
         auto slc0 = m.add_instruction(
             migraphx::make_op("slice", {{"axes", {3}}, {"starts", {0}}, {"ends", {32}}}), rsp);
         auto slc1 = m.add_instruction(
@@ -1980,9 +1980,9 @@ TEST_CASE(reorder_reshape_slice_not_apply)
         auto c2 = m.add_instruction(migraphx::make_op("contiguous"), slc2);
 
         std::vector<int64_t> lens = {1, 16, 16, 16};
-        auto r0 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c0);
-        auto r1 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c1);
-        auto r2 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c2);
+        auto r0 = m.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c0);
+        auto r1 = m.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c1);
+        auto r2 = m.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c2);
 
         auto sum = m.add_instruction(migraphx::make_op("add"), r0, r1);
         auto ret = m.add_instruction(migraphx::make_op("mul"), sum, r2);
@@ -2018,9 +2018,9 @@ TEST_CASE(reorder_reshape_slice_diff_dims)
 
         std::vector<int64_t> lens  = {static_cast<int64_t>(batch_size), 32, 3, 32};
         std::vector<int64_t> lens1 = {static_cast<int64_t>(batch_size), 48, 2, 32};
-        auto r0 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c0);
-        auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens}}), c1);
-        auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"out_lens", lens1}}), c2);
+        auto r0 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c0);
+        auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c1);
+        auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens1}}), c2);
 
         m1.add_return({r0, r1, r2});
 

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -204,7 +204,7 @@ TEST_CASE(simplify_mul_conv1)
         w);
     auto a = m.add_literal(migraphx::generate_literal({migraphx::shape::int32_type, {256}}));
     auto b = m.add_instruction(
-        migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {1, 256, 14, 14}}}), a);
+        migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {1, 256, 14, 14}}}), a);
     auto mul = m.add_instruction(migraphx::make_op("mul"), conv, b);
     m.add_instruction(pass_op{}, mul);
     EXPECT(conv->outputs().front()->name() == "mul");
@@ -226,7 +226,7 @@ TEST_CASE(simplify_mul_slice_conv1)
             migraphx::make_op("slice", {{"axes", {1}}, {"starts", {0}}, {"ends", {384}}}), conv);
         auto a = m1.add_literal(migraphx::generate_literal({migraphx::shape::int32_type, {384}}));
         auto b = m1.add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {1, 384, 17, 17}}}), a);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {1, 384, 17, 17}}}), a);
         auto mul    = m1.add_instruction(migraphx::make_op("mul"), slice1, b);
         auto slice2 = m1.add_instruction(
             migraphx::make_op("slice", {{"axes", {1}}, {"starts", {384}}, {"ends", {768}}}), conv);
@@ -244,7 +244,7 @@ TEST_CASE(simplify_mul_slice_conv1)
             migraphx::make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", {384}}}), w);
         auto a = m2.add_literal(migraphx::generate_literal({migraphx::shape::int32_type, {384}}));
         auto b = m2.add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 0}, {"dims", {384, 1024, 1, 1}}}), a);
+            migraphx::make_op("broadcast", {{"axis", 0}, {"out_lens", {384, 1024, 1, 1}}}), a);
         auto mul     = m2.add_instruction(migraphx::make_op("mul"), b, wslice1);
         auto wslice2 = m2.add_instruction(
             migraphx::make_op("slice", {{"axes", {0}}, {"starts", {384}}, {"ends", {768}}}), w);
@@ -272,7 +272,7 @@ TEST_CASE(simplify_mul_slice_conv_overlapping_slice)
             migraphx::make_op("slice", {{"axes", {1}}, {"starts", {0}}, {"ends", {384}}}), conv);
         auto a = m1.add_literal(migraphx::generate_literal({migraphx::shape::int32_type, {384}}));
         auto b = m1.add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {1, 384, 17, 17}}}), a);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {1, 384, 17, 17}}}), a);
         auto mul    = m1.add_instruction(migraphx::make_op("mul"), slice1, b);
         auto slice2 = m1.add_instruction(
             migraphx::make_op("slice", {{"axes", {1}}, {"starts", {383}}, {"ends", {767}}}), conv);
@@ -296,7 +296,7 @@ TEST_CASE(simplify_mul_slice_conv_not_all_slice)
             migraphx::make_op("slice", {{"axes", {1}}, {"starts", {0}}, {"ends", {384}}}), conv);
         auto a = m1.add_literal(migraphx::generate_literal({migraphx::shape::int32_type, {384}}));
         auto b = m1.add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {1, 384, 17, 17}}}), a);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {1, 384, 17, 17}}}), a);
         auto mul = m1.add_instruction(migraphx::make_op("mul"), slice1, b);
         auto c   = m1.add_literal(
             migraphx::generate_literal({migraphx::shape::int32_type, {1, 768, 17, 17}}));
@@ -1086,10 +1086,10 @@ TEST_CASE(simplify_slice_different_axis)
             migraphx::make_op("slice", {{"axes", {3}}, {"starts", {0}}, {"ends", {1}}}), input);
         auto one  = m1.add_literal(1);
         auto oneb = m1.add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {3, 1, 4, 2}}}), one);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {3, 1, 4, 2}}}), one);
         auto two  = m1.add_literal(2);
         auto twob = m1.add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 3}, {"dims", {3, 2, 4, 1}}}), two);
+            migraphx::make_op("broadcast", {{"axis", 3}, {"out_lens", {3, 2, 4, 1}}}), two);
         auto sum1     = m1.add_instruction(migraphx::make_op("add"), x, oneb);
         auto relu1    = m1.add_instruction(migraphx::make_op("relu"), sum1);
         auto reshape1 = m1.add_instruction(r, relu1);
@@ -1709,17 +1709,17 @@ TEST_CASE(simplify_mul_slice_conv_horiz_fusion)
         auto a1 =
             m1.add_literal(migraphx::generate_literal({migraphx::shape::int32_type, {384}}, 1));
         auto b1 = m1.add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {1, 384, 17, 17}}}), a1);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {1, 384, 17, 17}}}), a1);
         auto mul = m1.add_instruction(migraphx::make_op("mul"), slice1, b1);
         auto a2 =
             m1.add_literal(migraphx::generate_literal({migraphx::shape::int32_type, {384}}, 2));
         auto b2 = m1.add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {1, 384, 17, 17}}}), a2);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {1, 384, 17, 17}}}), a2);
         auto add1 = m1.add_instruction(migraphx::make_op("add"), mul, b2);
         auto a3 =
             m1.add_literal(migraphx::generate_literal({migraphx::shape::int32_type, {384}}, 3));
         auto b3 = m1.add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {1, 384, 17, 17}}}), a3);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {1, 384, 17, 17}}}), a3);
         auto slice2 = m1.add_instruction(
             migraphx::make_op("slice", {{"axes", {1}}, {"starts", {384}}, {"ends", {768}}}), conv);
         auto add2 = m1.add_instruction(migraphx::make_op("add"), slice2, b3);
@@ -1737,7 +1737,7 @@ TEST_CASE(simplify_mul_slice_conv_horiz_fusion)
         auto a1 =
             m2.add_literal(migraphx::generate_literal({migraphx::shape::int32_type, {384}}, 1));
         auto b1 = m2.add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 0}, {"dims", {384, 1024, 1, 1}}}), a1);
+            migraphx::make_op("broadcast", {{"axis", 0}, {"out_lens", {384, 1024, 1, 1}}}), a1);
         auto mul     = m2.add_instruction(migraphx::make_op("mul"), b1, wslice1);
         auto wslice2 = m2.add_instruction(
             migraphx::make_op("slice", {{"axes", {0}}, {"starts", {384}}, {"ends", {768}}}), w);
@@ -1749,7 +1749,7 @@ TEST_CASE(simplify_mul_slice_conv_horiz_fusion)
             m2.add_literal(migraphx::generate_literal({migraphx::shape::int32_type, {384}}, 3));
         auto concat2 = m2.add_instruction(migraphx::make_op("concat"), a2, a3);
         auto b4      = m2.add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {1, 768, 17, 17}}}), concat2);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {1, 768, 17, 17}}}), concat2);
         auto add    = m2.add_instruction(migraphx::make_op("add"), conv, b4);
         auto slice1 = m2.add_instruction(
             migraphx::make_op("slice", {{"axes", {1}}, {"starts", {0}}, {"ends", {384}}}), add);

--- a/test/simplify_qdq_test.cpp
+++ b/test/simplify_qdq_test.cpp
@@ -587,7 +587,7 @@ TEST_CASE(mobilenet_snippet)
                                      d6);
         auto q3 = add_quantize_op(mm, "quantizelinear", ap, scale, zero);
         auto d7 = add_quantize_op(mm, "dequantizelinear", q3, scale, zero);
-        auto rs = mm.add_instruction(migraphx::make_op("reshape", {{"out_lens", {1, -1}}}), d7);
+        auto rs = mm.add_instruction(migraphx::make_op("reshape", {{"dims", {1, -1}}}), d7);
         auto q4 = add_quantize_op(mm, "quantizelinear", rs, scale, zero);
         auto d8 = add_quantize_op(mm, "dequantizelinear", q4, scale, zero);
         auto dot =

--- a/test/simplify_qdq_test.cpp
+++ b/test/simplify_qdq_test.cpp
@@ -32,8 +32,8 @@ migraphx::instruction_ref add_quantize_op(migraphx::module& m,
         scale_mb =
             m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), scale);
     else
-        scale_mb =
-            m.add_instruction(migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", lens}}), scale);
+        scale_mb = m.add_instruction(
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", lens}}), scale);
     auto shift_mb =
         m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), shift);
     return m.add_instruction(migraphx::make_op(name), x, scale_mb, shift_mb);
@@ -50,8 +50,8 @@ migraphx::instruction_ref add_quantize_op(migraphx::module& m,
         scale_mb =
             m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), scale);
     else
-        scale_mb =
-            m.add_instruction(migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", lens}}), scale);
+        scale_mb = m.add_instruction(
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", lens}}), scale);
     return m.add_instruction(migraphx::make_op(name), x, scale_mb);
 }
 
@@ -484,10 +484,10 @@ TEST_CASE(conv_pooling_dot)
         auto d8 = add_quantize_op(m1, "dequantizelinear", q4, scale, zero);
         auto dot =
             m1.add_instruction(migraphx::make_op("dot", {{"alpha", 1}, {"beta", 0}}), d8, d4);
-        auto q5  = add_quantize_op(m1, "quantizelinear", dot, scale, zero);
-        auto d9  = add_quantize_op(m1, "dequantizelinear", q5, scale, zero);
-        auto mb1 = m1.add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {1, 1000}}}), d3);
+        auto q5 = add_quantize_op(m1, "quantizelinear", dot, scale, zero);
+        auto d9 = add_quantize_op(m1, "dequantizelinear", q5, scale, zero);
+        auto mb1 =
+            m1.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {1, 1000}}}), d3);
         auto a2 = m1.add_instruction(migraphx::make_op("add"), d9, mb1);
         m1.add_return({a2});
     }
@@ -530,9 +530,9 @@ TEST_CASE(conv_pooling_dot)
         auto q4 = add_quantize_op(m2, "quantizelinear", fl, scale, zero);
         auto dot =
             m2.add_instruction(migraphx::make_op("quant_dot", {{"alpha", 1}, {"beta", 0}}), q4, db);
-        auto d9  = add_quantize_op(m2, "dequantizelinear", dot, scale2);
-        auto mb1 = m2.add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {1, 1000}}}), d3);
+        auto d9 = add_quantize_op(m2, "dequantizelinear", dot, scale2);
+        auto mb1 =
+            m2.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {1, 1000}}}), d3);
         auto a2 = m2.add_instruction(migraphx::make_op("add"), d9, mb1);
         m2.add_return({a2});
     }
@@ -587,15 +587,15 @@ TEST_CASE(mobilenet_snippet)
                                      d6);
         auto q3 = add_quantize_op(mm, "quantizelinear", ap, scale, zero);
         auto d7 = add_quantize_op(mm, "dequantizelinear", q3, scale, zero);
-        auto rs = mm.add_instruction(migraphx::make_op("reshape", {{"dims", {1, -1}}}), d7);
+        auto rs = mm.add_instruction(migraphx::make_op("reshape", {{"out_lens", {1, -1}}}), d7);
         auto q4 = add_quantize_op(mm, "quantizelinear", rs, scale, zero);
         auto d8 = add_quantize_op(mm, "dequantizelinear", q4, scale, zero);
         auto dot =
             mm.add_instruction(migraphx::make_op("dot", {{"alpha", 1}, {"beta", 0}}), d8, d4);
-        auto q5  = add_quantize_op(mm, "quantizelinear", dot, scale, zero);
-        auto d9  = add_quantize_op(mm, "dequantizelinear", q5, scale, zero);
-        auto mb1 = mm.add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {1, 1000}}}), d3);
+        auto q5 = add_quantize_op(mm, "quantizelinear", dot, scale, zero);
+        auto d9 = add_quantize_op(mm, "dequantizelinear", q5, scale, zero);
+        auto mb1 =
+            mm.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {1, 1000}}}), d3);
         auto a2 = mm.add_instruction(migraphx::make_op("add"), d9, mb1);
         mm.add_return({a2});
 

--- a/test/simplify_qdq_test.cpp
+++ b/test/simplify_qdq_test.cpp
@@ -30,12 +30,12 @@ migraphx::instruction_ref add_quantize_op(migraphx::module& m,
     migraphx::instruction_ref scale_mb;
     if(scale->get_shape().lens().front() == 1)
         scale_mb =
-            m.add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", lens}}), scale);
+            m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), scale);
     else
         scale_mb =
-            m.add_instruction(migraphx::make_op("broadcast", {{"axis", 1}, {"dims", lens}}), scale);
+            m.add_instruction(migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", lens}}), scale);
     auto shift_mb =
-        m.add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", lens}}), shift);
+        m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), shift);
     return m.add_instruction(migraphx::make_op(name), x, scale_mb, shift_mb);
 }
 
@@ -48,10 +48,10 @@ migraphx::instruction_ref add_quantize_op(migraphx::module& m,
     migraphx::instruction_ref scale_mb;
     if(scale->get_shape().lens().front() == 1)
         scale_mb =
-            m.add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", lens}}), scale);
+            m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", lens}}), scale);
     else
         scale_mb =
-            m.add_instruction(migraphx::make_op("broadcast", {{"axis", 1}, {"dims", lens}}), scale);
+            m.add_instruction(migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", lens}}), scale);
     return m.add_instruction(migraphx::make_op(name), x, scale_mb);
 }
 
@@ -402,7 +402,7 @@ TEST_CASE(conv_bias_add)
                                      d5,
                                      d1);
         auto b1 = m1.add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {1, 1280, 7, 7}}}), d2);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {1, 1280, 7, 7}}}), d2);
         auto a1 = m1.add_instruction(migraphx::make_op("add"), c1, b1);
         m1.add_return({a1});
     }
@@ -428,7 +428,7 @@ TEST_CASE(conv_bias_add)
                                      weights);
         auto d6 = add_quantize_op(m2, "dequantizelinear", c1, scale1);
         auto b1 = m2.add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {1, 1280, 7, 7}}}), d2);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {1, 1280, 7, 7}}}), d2);
         auto a1 = m2.add_instruction(migraphx::make_op("add"), d6, b1);
         m2.add_return({a1});
     }
@@ -470,7 +470,7 @@ TEST_CASE(conv_pooling_dot)
                                      d5,
                                      d1);
         auto bc1 = m1.add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {1, 1280, 7, 7}}}), d2);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {1, 1280, 7, 7}}}), d2);
         auto a1 = m1.add_instruction(migraphx::make_op("add"), c1, bc1);
         auto ap = m1.add_instruction(migraphx::make_op("pooling",
                                                        {{"mode", "average"},
@@ -487,7 +487,7 @@ TEST_CASE(conv_pooling_dot)
         auto q5  = add_quantize_op(m1, "quantizelinear", dot, scale, zero);
         auto d9  = add_quantize_op(m1, "dequantizelinear", q5, scale, zero);
         auto mb1 = m1.add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {1, 1000}}}), d3);
+            migraphx::make_op("multibroadcast", {{"out_lens", {1, 1000}}}), d3);
         auto a2 = m1.add_instruction(migraphx::make_op("add"), d9, mb1);
         m1.add_return({a2});
     }
@@ -517,7 +517,7 @@ TEST_CASE(conv_pooling_dot)
                                      weights);
         auto d5  = add_quantize_op(m2, "dequantizelinear", c1, scale1);
         auto bc1 = m2.add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {1, 1280, 7, 7}}}), d2);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {1, 1280, 7, 7}}}), d2);
         auto a1 = m2.add_instruction(migraphx::make_op("add"), d5, bc1);
         auto ap = m2.add_instruction(migraphx::make_op("pooling",
                                                        {{"mode", "average"},
@@ -532,7 +532,7 @@ TEST_CASE(conv_pooling_dot)
             m2.add_instruction(migraphx::make_op("quant_dot", {{"alpha", 1}, {"beta", 0}}), q4, db);
         auto d9  = add_quantize_op(m2, "dequantizelinear", dot, scale2);
         auto mb1 = m2.add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {1, 1000}}}), d3);
+            migraphx::make_op("multibroadcast", {{"out_lens", {1, 1000}}}), d3);
         auto a2 = m2.add_instruction(migraphx::make_op("add"), d9, mb1);
         m2.add_return({a2});
     }
@@ -574,7 +574,7 @@ TEST_CASE(mobilenet_snippet)
                                      d5,
                                      d1);
         auto bc1 = mm.add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {1, 1280, 7, 7}}}), d2);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {1, 1280, 7, 7}}}), d2);
         auto a1 = mm.add_instruction(migraphx::make_op("add"), c1, bc1);
         auto q2 = add_quantize_op(mm, "quantizelinear", a1, scale, zero);
         auto d6 = add_quantize_op(mm, "dequantizelinear", q2, scale, zero);
@@ -595,7 +595,7 @@ TEST_CASE(mobilenet_snippet)
         auto q5  = add_quantize_op(mm, "quantizelinear", dot, scale, zero);
         auto d9  = add_quantize_op(mm, "dequantizelinear", q5, scale, zero);
         auto mb1 = mm.add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {1, 1000}}}), d3);
+            migraphx::make_op("multibroadcast", {{"out_lens", {1, 1000}}}), d3);
         auto a2 = mm.add_instruction(migraphx::make_op("add"), d9, mb1);
         mm.add_return({a2});
 

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -134,14 +134,13 @@ TEST_CASE(reshape_transpose)
 {
     migraphx::module m;
 
-    auto s = migraphx::shape{migraphx::shape::float_type, {1, 112, 56, 56}};
-    auto x = m.add_parameter("x", s);
-    auto r1 =
-        m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {1, 4, 28, 56, 56}}}), x);
+    auto s  = migraphx::shape{migraphx::shape::float_type, {1, 112, 56, 56}};
+    auto x  = m.add_parameter("x", s);
+    auto r1 = m.add_instruction(migraphx::make_op("reshape", {{"dims", {1, 4, 28, 56, 56}}}), x);
     auto t =
         m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 1, 3, 4}}}), r1);
     auto ct = m.add_instruction(migraphx::make_op("contiguous"), t);
-    auto r2 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {1, 112, 56, 56}}}), ct);
+    auto r2 = m.add_instruction(migraphx::make_op("reshape", {{"dims", {1, 112, 56, 56}}}), ct);
     m.add_return({r2});
     EXPECT(m.get_output_shapes().back() == s);
     auto n = std::distance(m.begin(), m.end());
@@ -538,7 +537,7 @@ TEST_CASE(optimize_resize)
                                 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 2, 2, 2, 3, 3, 3};
         auto li              = m.add_literal(migraphx::literal(si, ind));
 
-        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {4}}}), inx);
+        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), inx);
         auto gr   = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
         auto r    = m.add_instruction(migraphx::make_op("softmax", {{"axis", 1}}), gr);
         m.add_return({r});
@@ -553,15 +552,14 @@ TEST_CASE(optimize_resize)
         migraphx::module m;
         auto inx                  = m.add_parameter("X", sx);
         std::vector<int64_t> dims = {1, 1, 2, 1, 2, 1};
-        auto rspx = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", dims}}), inx);
+        auto rspx = m.add_instruction(migraphx::make_op("reshape", {{"dims", dims}}), inx);
         std::vector<int64_t> mb_dims = {1, 2, 2, 2, 2, 3};
         auto mbx =
             m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_dims}}), rspx);
         auto std_mb                    = m.add_instruction(migraphx::make_op("contiguous"), mbx);
         std::vector<int64_t> orig_dims = {1, 2, 4, 6};
-        auto rmb =
-            m.add_instruction(migraphx::make_op("reshape", {{"out_lens", orig_dims}}), std_mb);
-        auto r = m.add_instruction(migraphx::make_op("softmax", {{"axis", 1}}), rmb);
+        auto rmb = m.add_instruction(migraphx::make_op("reshape", {{"dims", orig_dims}}), std_mb);
+        auto r   = m.add_instruction(migraphx::make_op("softmax", {{"axis", 1}}), rmb);
         m.add_return({r});
 
         return m;
@@ -583,7 +581,7 @@ TEST_CASE(optimize_resize_ind_not_apply)
                                 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 2, 2, 2, 3, 3, 3};
         auto li              = m.add_literal(migraphx::literal(si, ind));
 
-        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {4}}}), inx);
+        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), inx);
         auto gr   = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
         auto r    = m.add_instruction(migraphx::make_op("softmax", {{"axis", 1}}), gr);
         m.add_return({r});
@@ -608,7 +606,7 @@ TEST_CASE(optimize_resize_rsp_dim_1)
                                 2, 2, 2, 3, 3, 3, 2, 2, 2, 3, 3, 3};
         auto li              = m.add_literal(migraphx::literal(si, ind));
 
-        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2}}}), inx);
+        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2}}}), inx);
         auto r    = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
         m.add_return({r});
 
@@ -634,7 +632,7 @@ TEST_CASE(optimize_resize_ndims_unequal)
                                 2, 2, 2, 3, 3, 3, 2, 2, 2, 3, 3, 3};
         auto li              = m.add_literal(migraphx::literal(si, ind));
 
-        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {4}}}), inx);
+        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), inx);
         auto gr   = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
         auto r    = m.add_instruction(migraphx::make_op("sub"), iny, gr);
         m.add_return({r});
@@ -661,7 +659,7 @@ TEST_CASE(optimize_resize_ind_non_brcst)
                                 2, 2, 2, 3, 3, 3, 2, 2, 2, 3, 3, 3};
         auto li              = m.add_literal(migraphx::literal(si, ind));
 
-        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {6}}}), inx);
+        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"dims", {6}}}), inx);
         auto gr   = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
         auto r    = m.add_instruction(migraphx::make_op("sub"), iny, gr);
         m.add_return({r});
@@ -685,7 +683,7 @@ TEST_CASE(optimize_resize_ind_non_const)
 
         migraphx::shape si{migraphx::shape::int32_type, {1, 1, 4, 6}};
         auto li   = m.add_parameter("ind", si);
-        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {6}}}), inx);
+        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"dims", {6}}}), inx);
         auto gr   = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
         auto r    = m.add_instruction(migraphx::make_op("sub"), iny, gr);
         m.add_return({r});
@@ -710,7 +708,7 @@ TEST_CASE(optimize_where_true)
         std::vector<char> idata(si.elements(), static_cast<char>(cond));
         auto li     = m.add_literal(migraphx::literal(si, idata));
         auto data   = m.add_instruction(migraphx::make_op("concat", {{"axis", 0}}), inx, iny);
-        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {12}}}), data);
+        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"dims", {12}}}), data);
         auto r      = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), data_1, li);
         m.add_return({r});
         return m;
@@ -744,7 +742,7 @@ TEST_CASE(where_different_cond_values)
         std::vector<char> idata = {1, 1, 0, 1, 0, 1};
         auto li                 = m.add_literal(migraphx::literal(si, idata));
         auto data   = m.add_instruction(migraphx::make_op("concat", {{"axis", 0}}), inx, iny);
-        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {12}}}), data);
+        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"dims", {12}}}), data);
         auto r      = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), data_1, li);
         m.add_return({r});
         return m;
@@ -767,7 +765,7 @@ TEST_CASE(where_axis_nonzero)
         std::vector<char> idata(6, 1);
         auto li     = m.add_literal(migraphx::literal(si, idata));
         auto data   = m.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), inx, iny);
-        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {12}}}), data);
+        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"dims", {12}}}), data);
         auto r      = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), data_1, li);
         m.add_return({r});
         return m;
@@ -790,7 +788,7 @@ TEST_CASE(where_three_concat_inputs)
         std::vector<char> idata(6, 1);
         auto li     = m.add_literal(migraphx::literal(si, idata));
         auto data   = m.add_instruction(migraphx::make_op("concat", {{"axis", 0}}), inx, iny, inx);
-        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {18}}}), data);
+        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"dims", {18}}}), data);
         auto r      = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), data_1, li);
         m.add_return({r});
         return m;
@@ -814,7 +812,7 @@ TEST_CASE(where_three_inputs_diff_shapes)
         std::vector<char> idata(6, 1);
         auto li     = m.add_literal(migraphx::literal(si, idata));
         auto data   = m.add_instruction(migraphx::make_op("concat", {{"axis", 0}}), inx, iny);
-        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {18}}}), data);
+        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"dims", {18}}}), data);
         auto r      = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), data_1, li);
         m.add_return({r});
         return m;
@@ -838,7 +836,7 @@ TEST_CASE(where_three_lens_diff)
         std::vector<char> idata(6, 1);
         auto li     = m.add_literal(migraphx::literal(si, idata));
         auto data   = m.add_instruction(migraphx::make_op("concat", {{"axis", 0}}), inx, iny);
-        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {12}}}), data);
+        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"dims", {12}}}), data);
         auto r      = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), data_1, li);
         m.add_return({r});
         return m;
@@ -862,7 +860,7 @@ TEST_CASE(reshape_cont)
             m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 6}}}), inx);
         auto std_inx = m.add_instruction(migraphx::make_op("contiguous"), mb_inx);
         auto rsp =
-            m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2, 2, 6}}}), std_inx);
+            m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2, 2, 6}}}), std_inx);
         auto r = m.add_instruction(migraphx::make_op("add"), rsp, iny);
         m.add_return({r});
 
@@ -881,10 +879,9 @@ TEST_CASE(reshape_cont)
         auto iny = m.add_parameter("y", sy);
         auto mb_inx =
             m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 6}}}), inx);
-        auto rsp_iny =
-            m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 4, 6}}}), iny);
-        auto sum = m.add_instruction(migraphx::make_op("add"), mb_inx, rsp_iny);
-        auto r = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2, 2, 6}}}), sum);
+        auto rsp_iny = m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 4, 6}}}), iny);
+        auto sum     = m.add_instruction(migraphx::make_op("add"), mb_inx, rsp_iny);
+        auto r = m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2, 2, 6}}}), sum);
         m.add_return({r});
 
         return m;
@@ -906,7 +903,7 @@ TEST_CASE(reshape_input_non_std)
             m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 6}}}), inx);
         auto std_inx = m.add_instruction(migraphx::make_op("contiguous"), mb_inx);
         auto rsp =
-            m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2, 2, 6}}}), std_inx);
+            m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2, 2, 6}}}), std_inx);
         auto ty =
             m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), iny);
         auto r = m.add_instruction(migraphx::make_op("add"), rsp, ty);
@@ -934,7 +931,7 @@ TEST_CASE(reshape_cont_nonpw)
             m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 6}}}), inx);
         auto std_inx = m.add_instruction(migraphx::make_op("contiguous"), mb_inx);
         auto rsp =
-            m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2, 2, 6}}}), std_inx);
+            m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2, 2, 6}}}), std_inx);
         auto r = m.add_instruction(migraphx::make_op("convolution"), rsp, iny);
         m.add_return({r});
 

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -438,7 +438,7 @@ TEST_CASE(multibroadcast_simplify)
     std::vector<size_t> s_lens{1, 2, 3, 4};
     auto s = migraphx::shape{migraphx::shape::float_type, s_lens};
     auto x = m.add_parameter("x", s);
-    auto y = m.add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", s_lens}}), x);
+    auto y = m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s_lens}}), x);
     m.add_instruction(migraphx::make_op("mul"), y, y);
     auto n = std::distance(m.begin(), m.end());
     run_pass(m);
@@ -548,7 +548,7 @@ TEST_CASE(optimize_resize)
         auto rspx = m.add_instruction(migraphx::make_op("reshape", {{"dims", dims}}), inx);
         std::vector<int64_t> mb_dims = {1, 2, 2, 2, 2, 3};
         auto mbx                     = m.add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", mb_dims}}), rspx);
+            migraphx::make_op("multibroadcast", {{"out_lens", mb_dims}}), rspx);
         auto std_mb                    = m.add_instruction(migraphx::make_op("contiguous"), mbx);
         std::vector<int64_t> orig_dims = {1, 2, 4, 6};
         auto rmb = m.add_instruction(migraphx::make_op("reshape", {{"dims", orig_dims}}), std_mb);
@@ -850,7 +850,7 @@ TEST_CASE(reshape_cont)
         auto inx    = m.add_parameter("x", sx);
         auto iny    = m.add_parameter("y", sy);
         auto mb_inx = m.add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 4, 6}}}), inx);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 6}}}), inx);
         auto std_inx = m.add_instruction(migraphx::make_op("contiguous"), mb_inx);
         auto rsp =
             m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2, 2, 6}}}), std_inx);
@@ -871,7 +871,7 @@ TEST_CASE(reshape_cont)
         auto inx    = m.add_parameter("x", sx);
         auto iny    = m.add_parameter("y", sy);
         auto mb_inx = m.add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 4, 6}}}), inx);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 6}}}), inx);
         auto rsp_iny = m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 4, 6}}}), iny);
         auto sum     = m.add_instruction(migraphx::make_op("add"), mb_inx, rsp_iny);
         auto r = m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2, 2, 6}}}), sum);
@@ -893,7 +893,7 @@ TEST_CASE(reshape_input_non_std)
         auto inx    = m.add_parameter("x", sx);
         auto iny    = m.add_parameter("y", sy);
         auto mb_inx = m.add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 4, 6}}}), inx);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 6}}}), inx);
         auto std_inx = m.add_instruction(migraphx::make_op("contiguous"), mb_inx);
         auto rsp =
             m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2, 2, 6}}}), std_inx);
@@ -920,7 +920,7 @@ TEST_CASE(reshape_cont_nonpw)
         auto inx    = m.add_parameter("x", sx);
         auto iny    = m.add_parameter("y", sy);
         auto mb_inx = m.add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 4, 6}}}), inx);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 6}}}), inx);
         auto std_inx = m.add_instruction(migraphx::make_op("contiguous"), mb_inx);
         auto rsp =
             m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2, 2, 6}}}), std_inx);

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -136,10 +136,10 @@ TEST_CASE(reshape_transpose)
 
     auto s  = migraphx::shape{migraphx::shape::float_type, {1, 112, 56, 56}};
     auto x  = m.add_parameter("x", s);
-    auto r1 = m.add_instruction(migraphx::make_op("reshape", {{"dims", {1, 4, 28, 56, 56}}}), x);
+    auto r1 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {1, 4, 28, 56, 56}}}), x);
     auto t  = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 1, 3, 4}}}), r1);
     auto ct = m.add_instruction(migraphx::make_op("contiguous"), t);
-    auto r2 = m.add_instruction(migraphx::make_op("reshape", {{"dims", {1, 112, 56, 56}}}), ct);
+    auto r2 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {1, 112, 56, 56}}}), ct);
     m.add_return({r2});
     EXPECT(m.get_output_shapes().back() == s);
     auto n = std::distance(m.begin(), m.end());
@@ -530,7 +530,7 @@ TEST_CASE(optimize_resize)
                                 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 2, 2, 2, 3, 3, 3};
         auto li              = m.add_literal(migraphx::literal(si, ind));
 
-        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), inx);
+        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {4}}}), inx);
         auto gr   = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
         auto r    = m.add_instruction(migraphx::make_op("softmax", {{"axis", 1}}), gr);
         m.add_return({r});
@@ -545,13 +545,13 @@ TEST_CASE(optimize_resize)
         migraphx::module m;
         auto inx                  = m.add_parameter("X", sx);
         std::vector<int64_t> dims = {1, 1, 2, 1, 2, 1};
-        auto rspx = m.add_instruction(migraphx::make_op("reshape", {{"dims", dims}}), inx);
+        auto rspx = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", dims}}), inx);
         std::vector<int64_t> mb_dims = {1, 2, 2, 2, 2, 3};
-        auto mbx                     = m.add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", mb_dims}}), rspx);
+        auto mbx =
+            m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_dims}}), rspx);
         auto std_mb                    = m.add_instruction(migraphx::make_op("contiguous"), mbx);
         std::vector<int64_t> orig_dims = {1, 2, 4, 6};
-        auto rmb = m.add_instruction(migraphx::make_op("reshape", {{"dims", orig_dims}}), std_mb);
+        auto rmb = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", orig_dims}}), std_mb);
         auto r   = m.add_instruction(migraphx::make_op("softmax", {{"axis", 1}}), rmb);
         m.add_return({r});
 
@@ -574,7 +574,7 @@ TEST_CASE(optimize_resize_ind_not_apply)
                                 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 2, 2, 2, 3, 3, 3};
         auto li              = m.add_literal(migraphx::literal(si, ind));
 
-        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), inx);
+        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {4}}}), inx);
         auto gr   = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
         auto r    = m.add_instruction(migraphx::make_op("softmax", {{"axis", 1}}), gr);
         m.add_return({r});
@@ -599,7 +599,7 @@ TEST_CASE(optimize_resize_rsp_dim_1)
                                 2, 2, 2, 3, 3, 3, 2, 2, 2, 3, 3, 3};
         auto li              = m.add_literal(migraphx::literal(si, ind));
 
-        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2}}}), inx);
+        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2}}}), inx);
         auto r    = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
         m.add_return({r});
 
@@ -625,7 +625,7 @@ TEST_CASE(optimize_resize_ndims_unequal)
                                 2, 2, 2, 3, 3, 3, 2, 2, 2, 3, 3, 3};
         auto li              = m.add_literal(migraphx::literal(si, ind));
 
-        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"dims", {4}}}), inx);
+        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {4}}}), inx);
         auto gr   = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
         auto r    = m.add_instruction(migraphx::make_op("sub"), iny, gr);
         m.add_return({r});
@@ -652,7 +652,7 @@ TEST_CASE(optimize_resize_ind_non_brcst)
                                 2, 2, 2, 3, 3, 3, 2, 2, 2, 3, 3, 3};
         auto li              = m.add_literal(migraphx::literal(si, ind));
 
-        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"dims", {6}}}), inx);
+        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {6}}}), inx);
         auto gr   = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
         auto r    = m.add_instruction(migraphx::make_op("sub"), iny, gr);
         m.add_return({r});
@@ -676,7 +676,7 @@ TEST_CASE(optimize_resize_ind_non_const)
 
         migraphx::shape si{migraphx::shape::int32_type, {1, 1, 4, 6}};
         auto li   = m.add_parameter("ind", si);
-        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"dims", {6}}}), inx);
+        auto lrsp = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {6}}}), inx);
         auto gr   = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), lrsp, li);
         auto r    = m.add_instruction(migraphx::make_op("sub"), iny, gr);
         m.add_return({r});
@@ -701,7 +701,7 @@ TEST_CASE(optimize_where_true)
         std::vector<char> idata(si.elements(), static_cast<char>(cond));
         auto li     = m.add_literal(migraphx::literal(si, idata));
         auto data   = m.add_instruction(migraphx::make_op("concat", {{"axis", 0}}), inx, iny);
-        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"dims", {12}}}), data);
+        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {12}}}), data);
         auto r      = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), data_1, li);
         m.add_return({r});
         return m;
@@ -735,7 +735,7 @@ TEST_CASE(where_different_cond_values)
         std::vector<char> idata = {1, 1, 0, 1, 0, 1};
         auto li                 = m.add_literal(migraphx::literal(si, idata));
         auto data   = m.add_instruction(migraphx::make_op("concat", {{"axis", 0}}), inx, iny);
-        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"dims", {12}}}), data);
+        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {12}}}), data);
         auto r      = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), data_1, li);
         m.add_return({r});
         return m;
@@ -758,7 +758,7 @@ TEST_CASE(where_axis_nonzero)
         std::vector<char> idata(6, 1);
         auto li     = m.add_literal(migraphx::literal(si, idata));
         auto data   = m.add_instruction(migraphx::make_op("concat", {{"axis", 1}}), inx, iny);
-        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"dims", {12}}}), data);
+        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {12}}}), data);
         auto r      = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), data_1, li);
         m.add_return({r});
         return m;
@@ -781,7 +781,7 @@ TEST_CASE(where_three_concat_inputs)
         std::vector<char> idata(6, 1);
         auto li     = m.add_literal(migraphx::literal(si, idata));
         auto data   = m.add_instruction(migraphx::make_op("concat", {{"axis", 0}}), inx, iny, inx);
-        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"dims", {18}}}), data);
+        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {18}}}), data);
         auto r      = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), data_1, li);
         m.add_return({r});
         return m;
@@ -805,7 +805,7 @@ TEST_CASE(where_three_inputs_diff_shapes)
         std::vector<char> idata(6, 1);
         auto li     = m.add_literal(migraphx::literal(si, idata));
         auto data   = m.add_instruction(migraphx::make_op("concat", {{"axis", 0}}), inx, iny);
-        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"dims", {18}}}), data);
+        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {18}}}), data);
         auto r      = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), data_1, li);
         m.add_return({r});
         return m;
@@ -829,7 +829,7 @@ TEST_CASE(where_three_lens_diff)
         std::vector<char> idata(6, 1);
         auto li     = m.add_literal(migraphx::literal(si, idata));
         auto data   = m.add_instruction(migraphx::make_op("concat", {{"axis", 0}}), inx, iny);
-        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"dims", {12}}}), data);
+        auto data_1 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {12}}}), data);
         auto r      = m.add_instruction(migraphx::make_op("gather", {{"axis", 0}}), data_1, li);
         m.add_return({r});
         return m;
@@ -847,13 +847,13 @@ TEST_CASE(reshape_cont)
         migraphx::shape sx{migraphx::shape::float_type, {1, 4, 1}};
         migraphx::shape sy{migraphx::shape::float_type, {2, 2, 2, 6}};
 
-        auto inx    = m.add_parameter("x", sx);
-        auto iny    = m.add_parameter("y", sy);
-        auto mb_inx = m.add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 6}}}), inx);
+        auto inx = m.add_parameter("x", sx);
+        auto iny = m.add_parameter("y", sy);
+        auto mb_inx =
+            m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 6}}}), inx);
         auto std_inx = m.add_instruction(migraphx::make_op("contiguous"), mb_inx);
         auto rsp =
-            m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2, 2, 6}}}), std_inx);
+            m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2, 2, 6}}}), std_inx);
         auto r = m.add_instruction(migraphx::make_op("add"), rsp, iny);
         m.add_return({r});
 
@@ -868,13 +868,13 @@ TEST_CASE(reshape_cont)
         migraphx::shape sx{migraphx::shape::float_type, {1, 4, 1}};
         migraphx::shape sy{migraphx::shape::float_type, {2, 2, 2, 6}};
 
-        auto inx    = m.add_parameter("x", sx);
-        auto iny    = m.add_parameter("y", sy);
-        auto mb_inx = m.add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 6}}}), inx);
-        auto rsp_iny = m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 4, 6}}}), iny);
+        auto inx = m.add_parameter("x", sx);
+        auto iny = m.add_parameter("y", sy);
+        auto mb_inx =
+            m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 6}}}), inx);
+        auto rsp_iny = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 4, 6}}}), iny);
         auto sum     = m.add_instruction(migraphx::make_op("add"), mb_inx, rsp_iny);
-        auto r = m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2, 2, 6}}}), sum);
+        auto r = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2, 2, 6}}}), sum);
         m.add_return({r});
 
         return m;
@@ -890,13 +890,13 @@ TEST_CASE(reshape_input_non_std)
         migraphx::shape sx{migraphx::shape::float_type, {1, 4, 1}};
         migraphx::shape sy{migraphx::shape::float_type, {2, 6, 2, 2}};
 
-        auto inx    = m.add_parameter("x", sx);
-        auto iny    = m.add_parameter("y", sy);
-        auto mb_inx = m.add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 6}}}), inx);
+        auto inx = m.add_parameter("x", sx);
+        auto iny = m.add_parameter("y", sy);
+        auto mb_inx =
+            m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 6}}}), inx);
         auto std_inx = m.add_instruction(migraphx::make_op("contiguous"), mb_inx);
         auto rsp =
-            m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2, 2, 6}}}), std_inx);
+            m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2, 2, 6}}}), std_inx);
         auto ty = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), iny);
         auto r  = m.add_instruction(migraphx::make_op("add"), rsp, ty);
         m.add_return({r});
@@ -917,13 +917,13 @@ TEST_CASE(reshape_cont_nonpw)
         migraphx::shape sx{migraphx::shape::float_type, {1, 4, 1}};
         migraphx::shape sy{migraphx::shape::float_type, {2, 2, 2, 6}};
 
-        auto inx    = m.add_parameter("x", sx);
-        auto iny    = m.add_parameter("y", sy);
-        auto mb_inx = m.add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 6}}}), inx);
+        auto inx = m.add_parameter("x", sx);
+        auto iny = m.add_parameter("y", sy);
+        auto mb_inx =
+            m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 6}}}), inx);
         auto std_inx = m.add_instruction(migraphx::make_op("contiguous"), mb_inx);
         auto rsp =
-            m.add_instruction(migraphx::make_op("reshape", {{"dims", {2, 2, 2, 6}}}), std_inx);
+            m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2, 2, 6}}}), std_inx);
         auto r = m.add_instruction(migraphx::make_op("convolution"), rsp, iny);
         m.add_return({r});
 

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -22,7 +22,7 @@ TEST_CASE(double_contig)
     auto* mm = p.get_main_module();
 
     auto l  = mm->add_literal(get_2x2());
-    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l);
+    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
     auto c1 = mm->add_instruction(migraphx::make_op("contiguous"), t1);
     auto c2 = mm->add_instruction(migraphx::make_op("contiguous"), c1);
     mm->add_return({c2});
@@ -42,8 +42,8 @@ TEST_CASE(double_transpose)
     auto* mm = p.get_main_module();
 
     auto l  = mm->add_literal(get_2x2());
-    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l);
-    auto t2 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), t1);
+    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
+    auto t2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), t1);
     mm->add_return({t2});
     EXPECT(mm->get_output_shapes().back().standard());
     EXPECT(not mm->get_output_shapes().back().transposed());
@@ -61,9 +61,9 @@ TEST_CASE(double_transpose_contig)
     auto* mm = p.get_main_module();
 
     auto l  = mm->add_literal(get_2x2());
-    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l);
+    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
     auto c1 = mm->add_instruction(migraphx::make_op("contiguous"), t1);
-    auto t2 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), c1);
+    auto t2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), c1);
     auto c2 = mm->add_instruction(migraphx::make_op("contiguous"), t2);
     mm->add_return({c2});
     EXPECT(mm->get_output_shapes().back().standard());
@@ -82,7 +82,7 @@ TEST_CASE(single_transpose)
     auto* mm = p.get_main_module();
 
     auto l  = mm->add_literal(get_2x2());
-    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l);
+    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
     mm->add_return({t1});
     EXPECT(not mm->get_output_shapes().back().standard());
     EXPECT(mm->get_output_shapes().back().transposed());
@@ -100,8 +100,8 @@ TEST_CASE(double_transpose_sin_pass)
     auto* mm = p.get_main_module();
 
     auto l  = mm->add_literal(get_2x2());
-    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l);
-    mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), t1);
+    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
+    mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), t1);
     EXPECT(mm->get_output_shapes().back().standard());
     EXPECT(not mm->get_output_shapes().back().transposed());
     run_pass(*mm);
@@ -119,7 +119,7 @@ TEST_CASE(single_transpose_sin_pass)
     auto* mm = p.get_main_module();
 
     auto l = mm->add_literal(get_2x2());
-    mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l);
+    mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
     EXPECT(not mm->get_output_shapes().back().standard());
     EXPECT(mm->get_output_shapes().back().transposed());
     run_pass(*mm);
@@ -134,10 +134,11 @@ TEST_CASE(reshape_transpose)
 {
     migraphx::module m;
 
-    auto s  = migraphx::shape{migraphx::shape::float_type, {1, 112, 56, 56}};
-    auto x  = m.add_parameter("x", s);
-    auto r1 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {1, 4, 28, 56, 56}}}), x);
-    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 1, 3, 4}}}), r1);
+    auto s = migraphx::shape{migraphx::shape::float_type, {1, 112, 56, 56}};
+    auto x = m.add_parameter("x", s);
+    auto r1 =
+        m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {1, 4, 28, 56, 56}}}), x);
+    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 1, 3, 4}}}), r1);
     auto ct = m.add_instruction(migraphx::make_op("contiguous"), t);
     auto r2 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {1, 112, 56, 56}}}), ct);
     m.add_return({r2});
@@ -154,7 +155,7 @@ TEST_CASE(transpose_contiguous)
 
     auto s  = migraphx::shape{migraphx::shape::float_type, {4, 4}};
     auto x  = m.add_parameter("x", s);
-    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), x);
+    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), x);
     auto c1 = m.add_instruction(migraphx::make_op("contiguous"), t);
     m.add_return({c1});
     auto out_shape = m.get_output_shapes().back();
@@ -170,7 +171,7 @@ TEST_CASE(transpose_double_contiguous)
 
     auto s  = migraphx::shape{migraphx::shape::float_type, {4, 4}};
     auto x  = m.add_parameter("x", s);
-    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), x);
+    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), x);
     auto c1 = m.add_instruction(migraphx::make_op("contiguous"), t);
     auto c2 = m.add_instruction(migraphx::make_op("contiguous"), c1);
     m.add_return({c2});
@@ -188,8 +189,8 @@ TEST_CASE(transpose_partial1)
 
     auto s  = migraphx::shape{migraphx::shape::float_type, {1, 2, 3}};
     auto x  = m.add_parameter("x", s);
-    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0, 2}}}), x);
-    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 2, 0}}}), t1);
+    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0, 2}}}), x);
+    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 2, 0}}}), t1);
     m.add_return({t2});
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -204,9 +205,9 @@ TEST_CASE(transpose_partial2)
 
     auto s  = migraphx::shape{migraphx::shape::float_type, {1, 2, 3}};
     auto x  = m.add_parameter("x", s);
-    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0, 2}}}), x);
-    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 2, 0}}}), t1);
-    auto t3 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0, 2}}}), t2);
+    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0, 2}}}), x);
+    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 2, 0}}}), t1);
+    auto t3 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0, 2}}}), t2);
     m.add_return({t3});
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -221,10 +222,10 @@ TEST_CASE(transpose_partial3)
 
     auto s  = migraphx::shape{migraphx::shape::float_type, {1, 2, 3}};
     auto x  = m.add_parameter("x", s);
-    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0, 2}}}), x);
-    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 2, 0}}}), t1);
-    auto t3 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0, 2}}}), t2);
-    auto t4 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0, 2}}}), t3);
+    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0, 2}}}), x);
+    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 2, 0}}}), t1);
+    auto t3 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0, 2}}}), t2);
+    auto t4 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0, 2}}}), t3);
     m.add_return({t4});
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -239,7 +240,7 @@ TEST_CASE(nop_transpose1)
 
     auto s = migraphx::shape{migraphx::shape::float_type, {1, 2, 3}};
     auto x = m.add_parameter("x", s);
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 2}}}), x);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 2}}}), x);
     m.add_return({t});
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -254,10 +255,10 @@ TEST_CASE(nop_transpose2)
 
     auto s  = migraphx::shape{migraphx::shape::float_type, {1, 2, 3}};
     auto x  = m.add_parameter("x", s);
-    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 2}}}), x);
-    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 2}}}), t1);
-    auto t3 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 2}}}), t2);
-    auto t4 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 2}}}), t3);
+    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 2}}}), x);
+    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 2}}}), t1);
+    auto t3 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 2}}}), t2);
+    auto t4 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 2}}}), t3);
     m.add_instruction(pass_op{}, t4);
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -274,8 +275,8 @@ TEST_CASE(nop_transpose3)
     auto x      = m.add_parameter("x", s);
     auto y      = m.add_parameter("y", s);
     auto concat = m.add_instruction(migraphx::make_op("concat", {{"axis", 3}}), x, y);
-    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 2, 3}}}), concat);
-    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), t1);
+    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 2, 3}}}), concat);
+    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), t1);
     m.add_return({t2});
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -309,10 +310,10 @@ TEST_CASE(concat_transpose1)
     auto s      = migraphx::shape{migraphx::shape::float_type, {1, 2, 3, 4}};
     auto x      = m.add_parameter("x", s);
     auto y      = m.add_parameter("y", s);
-    auto xt     = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), x);
-    auto yt     = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), y);
+    auto xt     = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), x);
+    auto yt     = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), y);
     auto concat = m.add_instruction(migraphx::make_op("concat", {{"axis", 2}}), xt, yt);
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), concat);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), concat);
     m.add_return({t});
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -332,10 +333,10 @@ TEST_CASE(concat_transpose2)
     auto s      = migraphx::shape{migraphx::shape::float_type, {1, 2, 3, 4}};
     auto x      = m.add_parameter("x", s);
     auto y      = m.add_parameter("y", s);
-    auto xt     = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), x);
-    auto yt     = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), y);
+    auto xt     = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), x);
+    auto yt     = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), y);
     auto concat = m.add_instruction(migraphx::make_op("concat", {{"axis", -1}}), xt, yt);
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), concat);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), concat);
     m.add_return({t});
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -355,10 +356,10 @@ TEST_CASE(concat_transpose3)
     auto s      = migraphx::shape{migraphx::shape::float_type, {1, 2, 3, 4}};
     auto x      = m.add_parameter("x", migraphx::shape{migraphx::shape::float_type, {1, 2, 3, 4}});
     auto y      = m.add_parameter("y", migraphx::shape{migraphx::shape::float_type, {1, 5, 3, 4}});
-    auto xt     = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), x);
-    auto yt     = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), y);
+    auto xt     = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), x);
+    auto yt     = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), y);
     auto concat = m.add_instruction(migraphx::make_op("concat", {{"axis", 3}}), xt, yt);
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), concat);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), concat);
     m.add_return({t});
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -378,10 +379,10 @@ TEST_CASE(concat_transpose4)
     auto sy     = migraphx::shape{migraphx::shape::float_type, {1, 12, 1, 64}};
     auto x      = m.add_parameter("x", sx);
     auto y      = m.add_parameter("y", sy);
-    auto xt     = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), x);
-    auto yt     = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), y);
+    auto xt     = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), x);
+    auto yt     = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), y);
     auto concat = m.add_instruction(migraphx::make_op("concat", {{"axis", 3}}), xt, yt);
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), concat);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), concat);
     m.add_return({t});
 
     migraphx::module m1 = m;
@@ -551,8 +552,9 @@ TEST_CASE(optimize_resize)
             m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", mb_dims}}), rspx);
         auto std_mb                    = m.add_instruction(migraphx::make_op("contiguous"), mbx);
         std::vector<int64_t> orig_dims = {1, 2, 4, 6};
-        auto rmb = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", orig_dims}}), std_mb);
-        auto r   = m.add_instruction(migraphx::make_op("softmax", {{"axis", 1}}), rmb);
+        auto rmb =
+            m.add_instruction(migraphx::make_op("reshape", {{"out_lens", orig_dims}}), std_mb);
+        auto r = m.add_instruction(migraphx::make_op("softmax", {{"axis", 1}}), rmb);
         m.add_return({r});
 
         return m;
@@ -872,8 +874,9 @@ TEST_CASE(reshape_cont)
         auto iny = m.add_parameter("y", sy);
         auto mb_inx =
             m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 4, 6}}}), inx);
-        auto rsp_iny = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 4, 6}}}), iny);
-        auto sum     = m.add_instruction(migraphx::make_op("add"), mb_inx, rsp_iny);
+        auto rsp_iny =
+            m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 4, 6}}}), iny);
+        auto sum = m.add_instruction(migraphx::make_op("add"), mb_inx, rsp_iny);
         auto r = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2, 2, 6}}}), sum);
         m.add_return({r});
 
@@ -897,7 +900,7 @@ TEST_CASE(reshape_input_non_std)
         auto std_inx = m.add_instruction(migraphx::make_op("contiguous"), mb_inx);
         auto rsp =
             m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2, 2, 6}}}), std_inx);
-        auto ty = m.add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), iny);
+        auto ty = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), iny);
         auto r  = m.add_instruction(migraphx::make_op("add"), rsp, ty);
         m.add_return({r});
 

--- a/test/simplify_reshapes_test.cpp
+++ b/test/simplify_reshapes_test.cpp
@@ -22,7 +22,7 @@ TEST_CASE(double_contig)
     auto* mm = p.get_main_module();
 
     auto l  = mm->add_literal(get_2x2());
-    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
+    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l);
     auto c1 = mm->add_instruction(migraphx::make_op("contiguous"), t1);
     auto c2 = mm->add_instruction(migraphx::make_op("contiguous"), c1);
     mm->add_return({c2});
@@ -42,8 +42,8 @@ TEST_CASE(double_transpose)
     auto* mm = p.get_main_module();
 
     auto l  = mm->add_literal(get_2x2());
-    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
-    auto t2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), t1);
+    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l);
+    auto t2 = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), t1);
     mm->add_return({t2});
     EXPECT(mm->get_output_shapes().back().standard());
     EXPECT(not mm->get_output_shapes().back().transposed());
@@ -61,9 +61,9 @@ TEST_CASE(double_transpose_contig)
     auto* mm = p.get_main_module();
 
     auto l  = mm->add_literal(get_2x2());
-    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
+    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l);
     auto c1 = mm->add_instruction(migraphx::make_op("contiguous"), t1);
-    auto t2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), c1);
+    auto t2 = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), c1);
     auto c2 = mm->add_instruction(migraphx::make_op("contiguous"), t2);
     mm->add_return({c2});
     EXPECT(mm->get_output_shapes().back().standard());
@@ -82,7 +82,7 @@ TEST_CASE(single_transpose)
     auto* mm = p.get_main_module();
 
     auto l  = mm->add_literal(get_2x2());
-    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
+    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l);
     mm->add_return({t1});
     EXPECT(not mm->get_output_shapes().back().standard());
     EXPECT(mm->get_output_shapes().back().transposed());
@@ -100,8 +100,8 @@ TEST_CASE(double_transpose_sin_pass)
     auto* mm = p.get_main_module();
 
     auto l  = mm->add_literal(get_2x2());
-    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
-    mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), t1);
+    auto t1 = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l);
+    mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), t1);
     EXPECT(mm->get_output_shapes().back().standard());
     EXPECT(not mm->get_output_shapes().back().transposed());
     run_pass(*mm);
@@ -119,7 +119,7 @@ TEST_CASE(single_transpose_sin_pass)
     auto* mm = p.get_main_module();
 
     auto l = mm->add_literal(get_2x2());
-    mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l);
+    mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l);
     EXPECT(not mm->get_output_shapes().back().standard());
     EXPECT(mm->get_output_shapes().back().transposed());
     run_pass(*mm);
@@ -138,7 +138,8 @@ TEST_CASE(reshape_transpose)
     auto x = m.add_parameter("x", s);
     auto r1 =
         m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {1, 4, 28, 56, 56}}}), x);
-    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 1, 3, 4}}}), r1);
+    auto t =
+        m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 1, 3, 4}}}), r1);
     auto ct = m.add_instruction(migraphx::make_op("contiguous"), t);
     auto r2 = m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {1, 112, 56, 56}}}), ct);
     m.add_return({r2});
@@ -155,7 +156,7 @@ TEST_CASE(transpose_contiguous)
 
     auto s  = migraphx::shape{migraphx::shape::float_type, {4, 4}};
     auto x  = m.add_parameter("x", s);
-    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), x);
+    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), x);
     auto c1 = m.add_instruction(migraphx::make_op("contiguous"), t);
     m.add_return({c1});
     auto out_shape = m.get_output_shapes().back();
@@ -171,7 +172,7 @@ TEST_CASE(transpose_double_contiguous)
 
     auto s  = migraphx::shape{migraphx::shape::float_type, {4, 4}};
     auto x  = m.add_parameter("x", s);
-    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), x);
+    auto t  = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), x);
     auto c1 = m.add_instruction(migraphx::make_op("contiguous"), t);
     auto c2 = m.add_instruction(migraphx::make_op("contiguous"), c1);
     m.add_return({c2});
@@ -189,8 +190,8 @@ TEST_CASE(transpose_partial1)
 
     auto s  = migraphx::shape{migraphx::shape::float_type, {1, 2, 3}};
     auto x  = m.add_parameter("x", s);
-    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0, 2}}}), x);
-    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 2, 0}}}), t1);
+    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0, 2}}}), x);
+    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 2, 0}}}), t1);
     m.add_return({t2});
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -205,9 +206,9 @@ TEST_CASE(transpose_partial2)
 
     auto s  = migraphx::shape{migraphx::shape::float_type, {1, 2, 3}};
     auto x  = m.add_parameter("x", s);
-    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0, 2}}}), x);
-    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 2, 0}}}), t1);
-    auto t3 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0, 2}}}), t2);
+    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0, 2}}}), x);
+    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 2, 0}}}), t1);
+    auto t3 = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0, 2}}}), t2);
     m.add_return({t3});
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -222,10 +223,10 @@ TEST_CASE(transpose_partial3)
 
     auto s  = migraphx::shape{migraphx::shape::float_type, {1, 2, 3}};
     auto x  = m.add_parameter("x", s);
-    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0, 2}}}), x);
-    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 2, 0}}}), t1);
-    auto t3 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0, 2}}}), t2);
-    auto t4 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0, 2}}}), t3);
+    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0, 2}}}), x);
+    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 2, 0}}}), t1);
+    auto t3 = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0, 2}}}), t2);
+    auto t4 = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0, 2}}}), t3);
     m.add_return({t4});
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -240,7 +241,7 @@ TEST_CASE(nop_transpose1)
 
     auto s = migraphx::shape{migraphx::shape::float_type, {1, 2, 3}};
     auto x = m.add_parameter("x", s);
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 2}}}), x);
+    auto t = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 2}}}), x);
     m.add_return({t});
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -255,10 +256,10 @@ TEST_CASE(nop_transpose2)
 
     auto s  = migraphx::shape{migraphx::shape::float_type, {1, 2, 3}};
     auto x  = m.add_parameter("x", s);
-    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 2}}}), x);
-    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 2}}}), t1);
-    auto t3 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 2}}}), t2);
-    auto t4 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 2}}}), t3);
+    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 2}}}), x);
+    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 2}}}), t1);
+    auto t3 = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 2}}}), t2);
+    auto t4 = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 2}}}), t3);
     m.add_instruction(pass_op{}, t4);
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -275,8 +276,10 @@ TEST_CASE(nop_transpose3)
     auto x      = m.add_parameter("x", s);
     auto y      = m.add_parameter("y", s);
     auto concat = m.add_instruction(migraphx::make_op("concat", {{"axis", 3}}), x, y);
-    auto t1 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 2, 3}}}), concat);
-    auto t2 = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), t1);
+    auto t1 =
+        m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 2, 3}}}), concat);
+    auto t2 =
+        m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), t1);
     m.add_return({t2});
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -307,13 +310,14 @@ TEST_CASE(concat_transpose1)
 {
     migraphx::module m;
 
-    auto s      = migraphx::shape{migraphx::shape::float_type, {1, 2, 3, 4}};
-    auto x      = m.add_parameter("x", s);
-    auto y      = m.add_parameter("y", s);
-    auto xt     = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), x);
-    auto yt     = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), y);
+    auto s  = migraphx::shape{migraphx::shape::float_type, {1, 2, 3, 4}};
+    auto x  = m.add_parameter("x", s);
+    auto y  = m.add_parameter("y", s);
+    auto xt = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), x);
+    auto yt = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), y);
     auto concat = m.add_instruction(migraphx::make_op("concat", {{"axis", 2}}), xt, yt);
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), concat);
+    auto t =
+        m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), concat);
     m.add_return({t});
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -330,13 +334,14 @@ TEST_CASE(concat_transpose2)
 {
     migraphx::module m;
 
-    auto s      = migraphx::shape{migraphx::shape::float_type, {1, 2, 3, 4}};
-    auto x      = m.add_parameter("x", s);
-    auto y      = m.add_parameter("y", s);
-    auto xt     = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), x);
-    auto yt     = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), y);
+    auto s  = migraphx::shape{migraphx::shape::float_type, {1, 2, 3, 4}};
+    auto x  = m.add_parameter("x", s);
+    auto y  = m.add_parameter("y", s);
+    auto xt = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), x);
+    auto yt = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), y);
     auto concat = m.add_instruction(migraphx::make_op("concat", {{"axis", -1}}), xt, yt);
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), concat);
+    auto t =
+        m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), concat);
     m.add_return({t});
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -353,13 +358,14 @@ TEST_CASE(concat_transpose3)
 {
     migraphx::module m;
 
-    auto s      = migraphx::shape{migraphx::shape::float_type, {1, 2, 3, 4}};
-    auto x      = m.add_parameter("x", migraphx::shape{migraphx::shape::float_type, {1, 2, 3, 4}});
-    auto y      = m.add_parameter("y", migraphx::shape{migraphx::shape::float_type, {1, 5, 3, 4}});
-    auto xt     = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), x);
-    auto yt     = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), y);
+    auto s  = migraphx::shape{migraphx::shape::float_type, {1, 2, 3, 4}};
+    auto x  = m.add_parameter("x", migraphx::shape{migraphx::shape::float_type, {1, 2, 3, 4}});
+    auto y  = m.add_parameter("y", migraphx::shape{migraphx::shape::float_type, {1, 5, 3, 4}});
+    auto xt = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), x);
+    auto yt = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), y);
     auto concat = m.add_instruction(migraphx::make_op("concat", {{"axis", 3}}), xt, yt);
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), concat);
+    auto t =
+        m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), concat);
     m.add_return({t});
     auto out_shape = m.get_output_shapes().back();
     auto n         = std::distance(m.begin(), m.end());
@@ -375,14 +381,15 @@ TEST_CASE(concat_transpose3)
 TEST_CASE(concat_transpose4)
 {
     migraphx::module m;
-    auto sx     = migraphx::shape{migraphx::shape::float_type, {1, 1, 12, 64}};
-    auto sy     = migraphx::shape{migraphx::shape::float_type, {1, 12, 1, 64}};
-    auto x      = m.add_parameter("x", sx);
-    auto y      = m.add_parameter("y", sy);
-    auto xt     = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), x);
-    auto yt     = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), y);
+    auto sx = migraphx::shape{migraphx::shape::float_type, {1, 1, 12, 64}};
+    auto sy = migraphx::shape{migraphx::shape::float_type, {1, 12, 1, 64}};
+    auto x  = m.add_parameter("x", sx);
+    auto y  = m.add_parameter("y", sy);
+    auto xt = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), x);
+    auto yt = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), y);
     auto concat = m.add_instruction(migraphx::make_op("concat", {{"axis", 3}}), xt, yt);
-    auto t = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), concat);
+    auto t =
+        m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), concat);
     m.add_return({t});
 
     migraphx::module m1 = m;
@@ -900,8 +907,9 @@ TEST_CASE(reshape_input_non_std)
         auto std_inx = m.add_instruction(migraphx::make_op("contiguous"), mb_inx);
         auto rsp =
             m.add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 2, 2, 6}}}), std_inx);
-        auto ty = m.add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), iny);
-        auto r  = m.add_instruction(migraphx::make_op("add"), rsp, ty);
+        auto ty =
+            m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), iny);
+        auto r = m.add_instruction(migraphx::make_op("add"), rsp, ty);
         m.add_return({r});
 
         return m;

--- a/test/tf/tf_test.cpp
+++ b/test/tf/tf_test.cpp
@@ -359,10 +359,10 @@ TEST_CASE(conv_relu6_test)
     auto l0      = std::prev(mm->end());
     auto min_val = mm->add_literal(0.0f);
     auto max_val = mm->add_literal(6.0f);
-    min_val      = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), min_val);
-    max_val = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), max_val);
+    min_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}),
+                                  min_val);
+    max_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}),
+                                  max_val);
     mm->add_instruction(migraphx::make_op("clip"), l0, min_val, max_val);
     auto prog = optimize_tf("conv_relu6_test.pb", true);
 
@@ -389,7 +389,7 @@ TEST_CASE(depthwiseconv_test)
     op.group        = 3;
     auto l3 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {3, 2, 0, 1}}}), l1);
     auto l4 = mm->add_instruction(migraphx::make_op("contiguous"), l3);
-    auto l5 = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {3, 1, 3, 3}}}), l4);
+    auto l5 = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {3, 1, 3, 3}}}), l4);
     mm->add_instruction(op, l0, l5);
     auto prog = optimize_tf("depthwise_conv_test.pb", true);
 
@@ -404,7 +404,7 @@ TEST_CASE(expanddims_test)
 
     auto l0 = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3, 4}});
     mm->add_literal(0);
-    mm->add_instruction(migraphx::make_op("reshape", {{"dims", {1, 2, 3, 4}}}), l0);
+    mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {1, 2, 3, 4}}}), l0);
     auto prog = optimize_tf("expanddims_test.pb", false);
 
     EXPECT(p == prog);
@@ -419,7 +419,7 @@ TEST_CASE(expanddims_test_neg_dims)
 
     auto l0 = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3, 4}});
     mm->add_literal(-1);
-    mm->add_instruction(migraphx::make_op("reshape", {{"dims", {2, 3, 4, 1}}}), l0);
+    mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 3, 4, 1}}}), l0);
     auto prog = optimize_tf("expanddims_neg_test.pb", false);
 
     EXPECT(p == prog);
@@ -688,10 +688,10 @@ TEST_CASE(relu6_test)
     auto l0      = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, input_lens});
     auto min_val = mm->add_literal(0.0f);
     auto max_val = mm->add_literal(6.0f);
-    min_val      = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), min_val);
-    max_val = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), max_val);
+    min_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}),
+                                  min_val);
+    max_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}),
+                                  max_val);
     mm->add_instruction(migraphx::make_op("clip"), l0, min_val, max_val);
     auto prog = optimize_tf("relu6_test.pb", false);
 
@@ -707,7 +707,7 @@ TEST_CASE(reshape_test)
     migraphx::shape s0{migraphx::shape::int32_type, {4}};
     // in tf, the second arg is a literal that contains new dimensions
     mm->add_literal(migraphx::literal{s0, {1, 1, 1, 16}});
-    mm->add_instruction(migraphx::make_op("reshape", {{"dims", {1, 1, 1, 16}}}), l0);
+    mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {1, 1, 1, 16}}}), l0);
     auto prog = optimize_tf("reshape_test.pb", false);
 
     EXPECT(p == prog);

--- a/test/tf/tf_test.cpp
+++ b/test/tf/tf_test.cpp
@@ -151,9 +151,9 @@ TEST_CASE(batchmatmul_test)
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {1, 2, 4, 8}});
 
     auto trans_l0 =
-        mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l0);
+        mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l0);
     auto trans_l1 =
-        mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l1);
+        mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l1);
 
     mm->add_instruction(migraphx::make_op("dot"), trans_l0, trans_l1);
     auto prog = optimize_tf("batchmatmul_test.pb", false);
@@ -308,7 +308,7 @@ migraphx::program create_conv()
     op.padding      = {1, 1, 1, 1};
     op.stride       = {1, 1};
     op.dilation     = {1, 1};
-    auto l2 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {3, 2, 0, 1}}}), l1);
+    auto l2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {3, 2, 0, 1}}}), l1);
     mm->add_instruction(op, l0, l2);
     return p;
 }
@@ -387,7 +387,7 @@ TEST_CASE(depthwiseconv_test)
     op.stride       = {1, 1};
     op.dilation     = {1, 1};
     op.group        = 3;
-    auto l3 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {3, 2, 0, 1}}}), l1);
+    auto l3 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {3, 2, 0, 1}}}), l1);
     auto l4 = mm->add_instruction(migraphx::make_op("contiguous"), l3);
     auto l5 = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {3, 1, 3, 3}}}), l4);
     mm->add_instruction(op, l0, l5);
@@ -463,8 +463,8 @@ TEST_CASE(matmul_test)
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {8, 4}});
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {4, 8}});
 
-    auto trans_l0 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l0);
-    auto trans_l1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l1);
+    auto trans_l0 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l0);
+    auto trans_l1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
 
     mm->add_instruction(migraphx::make_op("dot"), trans_l0, trans_l1);
     auto prog = optimize_tf("matmul_test.pb", false);
@@ -497,7 +497,7 @@ TEST_CASE(mean_test_nhwc)
     auto* mm = p.get_main_module();
     migraphx::literal l{migraphx::shape{migraphx::shape::int32_type, {2}}, {1, 2}};
     auto l0 = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {1, 3, 16, 16}});
-    auto l1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), l0);
+    auto l1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l0);
     migraphx::op::reduce_mean op{{1, 2}};
     auto l2 = mm->add_instruction(op, l1);
     mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {1, 2}}}), l2);
@@ -595,11 +595,11 @@ TEST_CASE(pack_test_nhwc)
 
     auto* mm = p.get_main_module();
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {1, 2, 1, 1}});
-    auto lt0 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), l0);
+    auto lt0 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l0);
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {1, 2, 1, 1}});
-    auto lt1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), l1);
+    auto lt1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l1);
     auto l2  = mm->add_parameter("2", migraphx::shape{migraphx::shape::float_type, {1, 2, 1, 1}});
-    auto lt2 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), l2);
+    auto lt2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l2);
     std::vector<migraphx::instruction_ref> args{lt0, lt1, lt2};
     std::vector<migraphx::instruction_ref> unsqueezed_args;
     int64_t nchw_axis = 3;
@@ -882,7 +882,7 @@ TEST_CASE(stridedslice_test)
 
     auto* mm = p.get_main_module();
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {1, 10, 1, 1}});
-    auto l1  = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), l0);
+    auto l1  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l0);
     std::size_t num_axes = 4;
     migraphx::op::slice op;
     op.starts = {0, 0, 0, 0};
@@ -917,9 +917,9 @@ TEST_CASE(stridedslice_masks_test)
     mm->add_literal(migraphx::shape{migraphx::shape::int32_type, {4}},
                     std::vector<int>{1, 1, 1, 1});
 
-    auto l1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), l0);
+    auto l1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l0);
     auto l2 = mm->add_instruction(op, l1);
-    auto l3 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 3, 1, 2}}}), l2);
+    auto l3 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 3, 1, 2}}}), l2);
     mm->add_return({l3});
     auto prog = parse_tf("stridedslice_masks_test.pb", true);
 
@@ -961,7 +961,7 @@ TEST_CASE(transpose_test)
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {1, 3, 16, 16}});
     migraphx::shape s0{migraphx::shape::int32_type, {4}};
     mm->add_literal(migraphx::literal{s0, {0, 2, 3, 1}});
-    mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), l0);
+    mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l0);
     auto prog = optimize_tf("transpose_test.pb", false);
 
     EXPECT(p == prog);

--- a/test/tf/tf_test.cpp
+++ b/test/tf/tf_test.cpp
@@ -151,9 +151,9 @@ TEST_CASE(batchmatmul_test)
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {1, 2, 4, 8}});
 
     auto trans_l0 =
-        mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l0);
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), l0);
     auto trans_l1 =
-        mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l1);
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), l1);
 
     mm->add_instruction(migraphx::make_op("dot"), trans_l0, trans_l1);
     auto prog = optimize_tf("batchmatmul_test.pb", false);
@@ -308,7 +308,8 @@ migraphx::program create_conv()
     op.padding      = {1, 1, 1, 1};
     op.stride       = {1, 1};
     op.dilation     = {1, 1};
-    auto l2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {3, 2, 0, 1}}}), l1);
+    auto l2 =
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {3, 2, 0, 1}}}), l1);
     mm->add_instruction(op, l0, l2);
     return p;
 }
@@ -387,7 +388,8 @@ TEST_CASE(depthwiseconv_test)
     op.stride       = {1, 1};
     op.dilation     = {1, 1};
     op.group        = 3;
-    auto l3 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {3, 2, 0, 1}}}), l1);
+    auto l3 =
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {3, 2, 0, 1}}}), l1);
     auto l4 = mm->add_instruction(migraphx::make_op("contiguous"), l3);
     auto l5 = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {3, 1, 3, 3}}}), l4);
     mm->add_instruction(op, l0, l5);
@@ -463,8 +465,10 @@ TEST_CASE(matmul_test)
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {8, 4}});
     auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {4, 8}});
 
-    auto trans_l0 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l0);
-    auto trans_l1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
+    auto trans_l0 =
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l0);
+    auto trans_l1 =
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l1);
 
     mm->add_instruction(migraphx::make_op("dot"), trans_l0, trans_l1);
     auto prog = optimize_tf("matmul_test.pb", false);
@@ -497,7 +501,8 @@ TEST_CASE(mean_test_nhwc)
     auto* mm = p.get_main_module();
     migraphx::literal l{migraphx::shape{migraphx::shape::int32_type, {2}}, {1, 2}};
     auto l0 = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {1, 3, 16, 16}});
-    auto l1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l0);
+    auto l1 =
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), l0);
     migraphx::op::reduce_mean op{{1, 2}};
     auto l2 = mm->add_instruction(op, l1);
     mm->add_instruction(migraphx::make_op("squeeze", {{"axes", {1, 2}}}), l2);
@@ -595,11 +600,14 @@ TEST_CASE(pack_test_nhwc)
 
     auto* mm = p.get_main_module();
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {1, 2, 1, 1}});
-    auto lt0 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l0);
-    auto l1  = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {1, 2, 1, 1}});
-    auto lt1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l1);
-    auto l2  = mm->add_parameter("2", migraphx::shape{migraphx::shape::float_type, {1, 2, 1, 1}});
-    auto lt2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l2);
+    auto lt0 =
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), l0);
+    auto l1 = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {1, 2, 1, 1}});
+    auto lt1 =
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), l1);
+    auto l2 = mm->add_parameter("2", migraphx::shape{migraphx::shape::float_type, {1, 2, 1, 1}});
+    auto lt2 =
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), l2);
     std::vector<migraphx::instruction_ref> args{lt0, lt1, lt2};
     std::vector<migraphx::instruction_ref> unsqueezed_args;
     int64_t nchw_axis = 3;
@@ -882,7 +890,8 @@ TEST_CASE(stridedslice_test)
 
     auto* mm = p.get_main_module();
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {1, 10, 1, 1}});
-    auto l1  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l0);
+    auto l1 =
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), l0);
     std::size_t num_axes = 4;
     migraphx::op::slice op;
     op.starts = {0, 0, 0, 0};
@@ -917,9 +926,11 @@ TEST_CASE(stridedslice_masks_test)
     mm->add_literal(migraphx::shape{migraphx::shape::int32_type, {4}},
                     std::vector<int>{1, 1, 1, 1});
 
-    auto l1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l0);
+    auto l1 =
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), l0);
     auto l2 = mm->add_instruction(op, l1);
-    auto l3 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 3, 1, 2}}}), l2);
+    auto l3 =
+        mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 3, 1, 2}}}), l2);
     mm->add_return({l3});
     auto prog = parse_tf("stridedslice_masks_test.pb", true);
 
@@ -961,7 +972,7 @@ TEST_CASE(transpose_test)
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {1, 3, 16, 16}});
     migraphx::shape s0{migraphx::shape::int32_type, {4}};
     mm->add_literal(migraphx::literal{s0, {0, 2, 3, 1}});
-    mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l0);
+    mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), l0);
     auto prog = optimize_tf("transpose_test.pb", false);
 
     EXPECT(p == prog);

--- a/test/tf/tf_test.cpp
+++ b/test/tf/tf_test.cpp
@@ -87,7 +87,7 @@ TEST_CASE(add_bcast_test)
     auto l0 = mm->add_parameter("0", s0);
     auto l1 = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {2, 1}});
     auto l2 =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", s0.lens()}}), l1);
+        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s0.lens()}}), l1);
     mm->add_instruction(migraphx::make_op("add"), l0, l2);
     auto prog = optimize_tf("add_bcast_test.pb", false);
 
@@ -220,7 +220,7 @@ TEST_CASE(biasadd_test)
     auto l0       = mm->add_parameter("0", s0);
     auto l1       = mm->add_parameter("1", migraphx::shape{migraphx::shape::float_type, {500}});
     auto l2       = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", axis}, {"dims", l0->get_shape().lens()}}), l1);
+        migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", l0->get_shape().lens()}}), l1);
     mm->add_instruction(migraphx::make_op("add"), l0, l2);
     auto prog = optimize_tf("biasadd_test.pb", true);
 
@@ -238,7 +238,7 @@ TEST_CASE(biasadd_scalar_test)
     auto l1       = mm->add_literal(
         migraphx::literal{migraphx::shape{migraphx::shape::float_type, {1}, {0}}, {1.0}});
     auto l2 = mm->add_instruction(
-        migraphx::make_op("broadcast", {{"axis", axis}, {"dims", l0->get_shape().lens()}}), l1);
+        migraphx::make_op("broadcast", {{"axis", axis}, {"out_lens", l0->get_shape().lens()}}), l1);
     mm->add_instruction(migraphx::make_op("add"), l0, l2);
     auto prog = optimize_tf("biasadd_scalar_test.pb", true);
 
@@ -360,9 +360,9 @@ TEST_CASE(conv_relu6_test)
     auto min_val = mm->add_literal(0.0f);
     auto max_val = mm->add_literal(6.0f);
     min_val      = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), min_val);
+        migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), min_val);
     max_val = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), max_val);
+        migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), max_val);
     mm->add_instruction(migraphx::make_op("clip"), l0, min_val, max_val);
     auto prog = optimize_tf("conv_relu6_test.pb", true);
 
@@ -689,9 +689,9 @@ TEST_CASE(relu6_test)
     auto min_val = mm->add_literal(0.0f);
     auto max_val = mm->add_literal(6.0f);
     min_val      = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), min_val);
+        migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), min_val);
     max_val = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), max_val);
+        migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), max_val);
     mm->add_instruction(migraphx::make_op("clip"), l0, min_val, max_val);
     auto prog = optimize_tf("relu6_test.pb", false);
 

--- a/test/tf/tf_test.cpp
+++ b/test/tf/tf_test.cpp
@@ -391,7 +391,7 @@ TEST_CASE(depthwiseconv_test)
     auto l3 =
         mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {3, 2, 0, 1}}}), l1);
     auto l4 = mm->add_instruction(migraphx::make_op("contiguous"), l3);
-    auto l5 = mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {3, 1, 3, 3}}}), l4);
+    auto l5 = mm->add_instruction(migraphx::make_op("reshape", {{"dims", {3, 1, 3, 3}}}), l4);
     mm->add_instruction(op, l0, l5);
     auto prog = optimize_tf("depthwise_conv_test.pb", true);
 
@@ -406,7 +406,7 @@ TEST_CASE(expanddims_test)
 
     auto l0 = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3, 4}});
     mm->add_literal(0);
-    mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {1, 2, 3, 4}}}), l0);
+    mm->add_instruction(migraphx::make_op("reshape", {{"dims", {1, 2, 3, 4}}}), l0);
     auto prog = optimize_tf("expanddims_test.pb", false);
 
     EXPECT(p == prog);
@@ -421,7 +421,7 @@ TEST_CASE(expanddims_test_neg_dims)
 
     auto l0 = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3, 4}});
     mm->add_literal(-1);
-    mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {2, 3, 4, 1}}}), l0);
+    mm->add_instruction(migraphx::make_op("reshape", {{"dims", {2, 3, 4, 1}}}), l0);
     auto prog = optimize_tf("expanddims_neg_test.pb", false);
 
     EXPECT(p == prog);
@@ -715,7 +715,7 @@ TEST_CASE(reshape_test)
     migraphx::shape s0{migraphx::shape::int32_type, {4}};
     // in tf, the second arg is a literal that contains new dimensions
     mm->add_literal(migraphx::literal{s0, {1, 1, 1, 16}});
-    mm->add_instruction(migraphx::make_op("reshape", {{"out_lens", {1, 1, 1, 16}}}), l0);
+    mm->add_instruction(migraphx::make_op("reshape", {{"dims", {1, 1, 1, 16}}}), l0);
     auto prog = optimize_tf("reshape_test.pb", false);
 
     EXPECT(p == prog);

--- a/test/verify/batch_quant_dot_1.cpp
+++ b/test/verify/batch_quant_dot_1.cpp
@@ -16,10 +16,10 @@ struct batch_quant_dot_1 : verify_program<batch_quant_dot_1>
 
         auto l1 = mm->add_parameter("a", m1_shape);
         auto tl1 =
-            mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l1);
+            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l1);
         auto l2 = mm->add_parameter("b", m2_shape);
         auto tl2 =
-            mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l2);
+            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l2);
         auto l3 = mm->add_parameter("c", m3_shape);
         mm->add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 3}, {"beta", 2}}), tl1, tl2, l3);

--- a/test/verify/batch_quant_dot_1.cpp
+++ b/test/verify/batch_quant_dot_1.cpp
@@ -14,12 +14,12 @@ struct batch_quant_dot_1 : verify_program<batch_quant_dot_1>
         migraphx::shape m2_shape{migraphx::shape::int8_type, {3, 2, 7, 8}};
         migraphx::shape m3_shape{migraphx::shape::int32_type, {3, 2, 2, 7}};
 
-        auto l1 = mm->add_parameter("a", m1_shape);
-        auto tl1 =
-            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l1);
-        auto l2 = mm->add_parameter("b", m2_shape);
-        auto tl2 =
-            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l2);
+        auto l1  = mm->add_parameter("a", m1_shape);
+        auto tl1 = mm->add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), l1);
+        auto l2  = mm->add_parameter("b", m2_shape);
+        auto tl2 = mm->add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), l2);
         auto l3 = mm->add_parameter("c", m3_shape);
         mm->add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 3}, {"beta", 2}}), tl1, tl2, l3);

--- a/test/verify/batch_quant_dot_4.cpp
+++ b/test/verify/batch_quant_dot_4.cpp
@@ -13,12 +13,12 @@ struct batch_quant_dot_4 : verify_program<batch_quant_dot_4>
         migraphx::shape m1_shape{migraphx::shape::int8_type, {2, 4, 6, 3}};
         migraphx::shape m2_shape{migraphx::shape::int8_type, {7, 2, 6, 3}};
 
-        auto l1 = mm->add_parameter("a", m1_shape);
-        auto l2 = mm->add_parameter("b", m2_shape);
-        auto tl1 =
-            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {3, 0, 1, 2}}}), l1);
-        auto tl2 =
-            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {3, 1, 2, 0}}}), l2);
+        auto l1  = mm->add_parameter("a", m1_shape);
+        auto l2  = mm->add_parameter("b", m2_shape);
+        auto tl1 = mm->add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {3, 0, 1, 2}}}), l1);
+        auto tl2 = mm->add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {3, 1, 2, 0}}}), l2);
         mm->add_instruction(migraphx::make_op("quant_dot", {{"alpha", 1}, {"beta", 3}}), tl1, tl2);
         return p;
     }

--- a/test/verify/batch_quant_dot_4.cpp
+++ b/test/verify/batch_quant_dot_4.cpp
@@ -16,9 +16,9 @@ struct batch_quant_dot_4 : verify_program<batch_quant_dot_4>
         auto l1 = mm->add_parameter("a", m1_shape);
         auto l2 = mm->add_parameter("b", m2_shape);
         auto tl1 =
-            mm->add_instruction(migraphx::make_op("transpose", {{"dims", {3, 0, 1, 2}}}), l1);
+            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {3, 0, 1, 2}}}), l1);
         auto tl2 =
-            mm->add_instruction(migraphx::make_op("transpose", {{"dims", {3, 1, 2, 0}}}), l2);
+            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {3, 1, 2, 0}}}), l2);
         mm->add_instruction(migraphx::make_op("quant_dot", {{"alpha", 1}, {"beta", 3}}), tl1, tl2);
         return p;
     }

--- a/test/verify/batch_quant_dot_5.cpp
+++ b/test/verify/batch_quant_dot_5.cpp
@@ -13,13 +13,13 @@ struct batch_quant_dot_5 : verify_program<batch_quant_dot_5>
         migraphx::shape m1_shape{migraphx::shape::int8_type, {3, 2, 7, 2}};
         migraphx::shape m2_shape{migraphx::shape::int8_type, {3, 2, 5, 7}};
 
-        auto l1 = mm->add_parameter("a", m1_shape);
-        auto l2 = mm->add_parameter("b", m2_shape);
-        auto tl1 =
-            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l1);
+        auto l1  = mm->add_parameter("a", m1_shape);
+        auto l2  = mm->add_parameter("b", m2_shape);
+        auto tl1 = mm->add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), l1);
         auto sl1 = mm->add_instruction(migraphx::make_op("add"), tl1, tl1);
-        auto tl2 =
-            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l2);
+        auto tl2 = mm->add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), l2);
         auto sl2 = mm->add_instruction(migraphx::make_op("add"), tl2, tl2);
         mm->add_instruction(migraphx::make_op("quant_dot", {{"alpha", 1}}), sl1, sl2);
         return p;

--- a/test/verify/batch_quant_dot_5.cpp
+++ b/test/verify/batch_quant_dot_5.cpp
@@ -16,10 +16,10 @@ struct batch_quant_dot_5 : verify_program<batch_quant_dot_5>
         auto l1 = mm->add_parameter("a", m1_shape);
         auto l2 = mm->add_parameter("b", m2_shape);
         auto tl1 =
-            mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l1);
+            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l1);
         auto sl1 = mm->add_instruction(migraphx::make_op("add"), tl1, tl1);
         auto tl2 =
-            mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), l2);
+            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), l2);
         auto sl2 = mm->add_instruction(migraphx::make_op("add"), tl2, tl2);
         mm->add_instruction(migraphx::make_op("quant_dot", {{"alpha", 1}}), sl1, sl2);
         return p;

--- a/test/verify/gemm_2args_bmv.cpp
+++ b/test/verify/gemm_2args_bmv.cpp
@@ -16,7 +16,7 @@ struct gemm_2args_bmv : verify_program<gemm_2args_bmv>
         auto l2   = mm->add_parameter("2", m2_shape);
         auto ul2  = mm->add_instruction(migraphx::make_op("unsqueeze", {{"axes", {1}}}), l2);
         auto bul2 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 3, 5, 1}}}), ul2);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 5, 1}}}), ul2);
 
         mm->add_instruction(migraphx::make_op("dot"), l1, bul2);
 

--- a/test/verify/gemm_2args_mm_1.cpp
+++ b/test/verify/gemm_2args_mm_1.cpp
@@ -12,10 +12,10 @@ struct gemm_2args_mm_1 : verify_program<gemm_2args_mm_1>
         auto* mm = p.get_main_module();
         migraphx::shape m1_shape{migraphx::shape::float_type, {2, 2, 3}};
         migraphx::shape m2_shape{migraphx::shape::float_type, {1, 3, 4}};
-        auto l1  = mm->add_parameter("1", m1_shape);
-        auto l2  = mm->add_parameter("2", m2_shape);
-        auto bl2 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4}}}), l2);
+        auto l1 = mm->add_parameter("1", m1_shape);
+        auto l2 = mm->add_parameter("2", m2_shape);
+        auto bl2 =
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4}}}), l2);
 
         mm->add_instruction(migraphx::make_op("dot"), l1, bl2);
 

--- a/test/verify/gemm_2args_mm_1.cpp
+++ b/test/verify/gemm_2args_mm_1.cpp
@@ -15,7 +15,7 @@ struct gemm_2args_mm_1 : verify_program<gemm_2args_mm_1>
         auto l1  = mm->add_parameter("1", m1_shape);
         auto l2  = mm->add_parameter("2", m2_shape);
         auto bl2 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 3, 4}}}), l2);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4}}}), l2);
 
         mm->add_instruction(migraphx::make_op("dot"), l1, bl2);
 

--- a/test/verify/gemm_2args_mm_2.cpp
+++ b/test/verify/gemm_2args_mm_2.cpp
@@ -12,10 +12,10 @@ struct gemm_2args_mm_2 : verify_program<gemm_2args_mm_2>
         auto* mm = p.get_main_module();
         migraphx::shape m1_shape{migraphx::shape::float_type, {2, 2, 3}};
         migraphx::shape m2_shape{migraphx::shape::float_type, {3, 4}};
-        auto l1  = mm->add_parameter("1", m1_shape);
-        auto l2  = mm->add_parameter("2", m2_shape);
-        auto bl2 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4}}}), l2);
+        auto l1 = mm->add_parameter("1", m1_shape);
+        auto l2 = mm->add_parameter("2", m2_shape);
+        auto bl2 =
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4}}}), l2);
 
         mm->add_instruction(migraphx::make_op("dot"), l1, bl2);
 

--- a/test/verify/gemm_2args_mm_2.cpp
+++ b/test/verify/gemm_2args_mm_2.cpp
@@ -15,7 +15,7 @@ struct gemm_2args_mm_2 : verify_program<gemm_2args_mm_2>
         auto l1  = mm->add_parameter("1", m1_shape);
         auto l2  = mm->add_parameter("2", m2_shape);
         auto bl2 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 3, 4}}}), l2);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 4}}}), l2);
 
         mm->add_instruction(migraphx::make_op("dot"), l1, bl2);
 

--- a/test/verify/gemm_2args_mm_3.cpp
+++ b/test/verify/gemm_2args_mm_3.cpp
@@ -12,9 +12,9 @@ struct gemm_2args_mm_3 : verify_program<gemm_2args_mm_3>
         auto* mm = p.get_main_module();
         migraphx::shape m1_shape{migraphx::shape::float_type, {1, 2, 3}};
         migraphx::shape m2_shape{migraphx::shape::float_type, {3, 3, 4}};
-        auto l1  = mm->add_parameter("1", m1_shape);
-        auto bl1 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {3, 2, 3}}}), l1);
+        auto l1 = mm->add_parameter("1", m1_shape);
+        auto bl1 =
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 2, 3}}}), l1);
         auto l2 = mm->add_parameter("2", m2_shape);
 
         mm->add_instruction(migraphx::make_op("dot"), bl1, l2);

--- a/test/verify/gemm_2args_mm_3.cpp
+++ b/test/verify/gemm_2args_mm_3.cpp
@@ -14,7 +14,7 @@ struct gemm_2args_mm_3 : verify_program<gemm_2args_mm_3>
         migraphx::shape m2_shape{migraphx::shape::float_type, {3, 3, 4}};
         auto l1  = mm->add_parameter("1", m1_shape);
         auto bl1 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {3, 2, 3}}}), l1);
+            migraphx::make_op("multibroadcast", {{"out_lens", {3, 2, 3}}}), l1);
         auto l2 = mm->add_parameter("2", m2_shape);
 
         mm->add_instruction(migraphx::make_op("dot"), bl1, l2);

--- a/test/verify/gemm_2args_mm_4.cpp
+++ b/test/verify/gemm_2args_mm_4.cpp
@@ -14,7 +14,7 @@ struct gemm_2args_mm_4 : verify_program<gemm_2args_mm_4>
         migraphx::shape m2_shape{migraphx::shape::float_type, {3, 3, 4}};
         auto l1  = mm->add_parameter("1", m1_shape);
         auto bl1 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {3, 2, 3}}}), l1);
+            migraphx::make_op("multibroadcast", {{"out_lens", {3, 2, 3}}}), l1);
         auto l2 = mm->add_parameter("2", m2_shape);
 
         mm->add_instruction(migraphx::make_op("dot"), bl1, l2);

--- a/test/verify/gemm_2args_mm_4.cpp
+++ b/test/verify/gemm_2args_mm_4.cpp
@@ -12,9 +12,9 @@ struct gemm_2args_mm_4 : verify_program<gemm_2args_mm_4>
         auto* mm = p.get_main_module();
         migraphx::shape m1_shape{migraphx::shape::float_type, {2, 3}};
         migraphx::shape m2_shape{migraphx::shape::float_type, {3, 3, 4}};
-        auto l1  = mm->add_parameter("1", m1_shape);
-        auto bl1 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {3, 2, 3}}}), l1);
+        auto l1 = mm->add_parameter("1", m1_shape);
+        auto bl1 =
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3, 2, 3}}}), l1);
         auto l2 = mm->add_parameter("2", m2_shape);
 
         mm->add_instruction(migraphx::make_op("dot"), bl1, l2);

--- a/test/verify/gemm_2args_mm_5.cpp
+++ b/test/verify/gemm_2args_mm_5.cpp
@@ -14,7 +14,7 @@ struct gemm_2args_mm_5 : verify_program<gemm_2args_mm_5>
         migraphx::shape m2_shape{migraphx::shape::float_type, {2, 3, 3, 4}};
         auto l1  = mm->add_parameter("1", m1_shape);
         auto bl1 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 3, 2, 3}}}), l1);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 2, 3}}}), l1);
         auto l2 = mm->add_parameter("2", m2_shape);
 
         mm->add_instruction(migraphx::make_op("dot"), bl1, l2);

--- a/test/verify/gemm_2args_mm_6.cpp
+++ b/test/verify/gemm_2args_mm_6.cpp
@@ -14,10 +14,10 @@ struct gemm_2args_mm_6 : verify_program<gemm_2args_mm_6>
         migraphx::shape m2_shape{migraphx::shape::float_type, {1, 3, 3, 4}};
         auto l1  = mm->add_parameter("1", m1_shape);
         auto bl1 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 3, 2, 3}}}), l1);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 2, 3}}}), l1);
         auto l2  = mm->add_parameter("2", m2_shape);
         auto bl2 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 3, 3, 4}}}), l2);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 3, 4}}}), l2);
 
         mm->add_instruction(migraphx::make_op("dot"), bl1, bl2);
 

--- a/test/verify/gemm_2args_mm_7.cpp
+++ b/test/verify/gemm_2args_mm_7.cpp
@@ -14,7 +14,7 @@ struct gemm_2args_mm_7 : verify_program<gemm_2args_mm_7>
         migraphx::shape m2_shape{migraphx::shape::float_type, {2, 3, 3, 4}};
         auto l1  = mm->add_parameter("1", m1_shape);
         auto bl1 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 3, 2, 3}}}), l1);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 3, 2, 3}}}), l1);
         auto l2 = mm->add_parameter("2", m2_shape);
 
         mm->add_instruction(migraphx::make_op("dot"), bl1, l2);

--- a/test/verify/gemm_2args_vbm.cpp
+++ b/test/verify/gemm_2args_vbm.cpp
@@ -15,7 +15,7 @@ struct gemm_2args_vbm : verify_program<gemm_2args_vbm>
         auto l1   = mm->add_parameter("1", m1_shape);
         auto ul1  = mm->add_instruction(migraphx::make_op("unsqueeze", {{"axes", {0}}}), l1);
         auto bul1 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 2, 1, 5}}}), ul1);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 2, 1, 5}}}), ul1);
 
         auto l2 = mm->add_parameter("2", m2_shape);
 

--- a/test/verify/gemm_multi_transpose.cpp
+++ b/test/verify/gemm_multi_transpose.cpp
@@ -12,9 +12,10 @@ struct gemm_multi_transpose : verify_program<gemm_multi_transpose>
         auto* mm = p.get_main_module();
         migraphx::shape m1_shape{migraphx::shape::float_type, {2, 2, 3}};
         migraphx::shape m2_shape{migraphx::shape::float_type, {3, 2, 4}};
-        auto l1  = mm->add_parameter("1", m1_shape);
-        auto l2  = mm->add_parameter("2", m2_shape);
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0, 2}}}), l2);
+        auto l1 = mm->add_parameter("1", m1_shape);
+        auto l2 = mm->add_parameter("2", m2_shape);
+        auto tl2 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0, 2}}}), l2);
 
         float alpha = 1.0f;
         float beta  = 1.0f;

--- a/test/verify/gemm_multi_transpose.cpp
+++ b/test/verify/gemm_multi_transpose.cpp
@@ -14,7 +14,7 @@ struct gemm_multi_transpose : verify_program<gemm_multi_transpose>
         migraphx::shape m2_shape{migraphx::shape::float_type, {3, 2, 4}};
         auto l1  = mm->add_parameter("1", m1_shape);
         auto l2  = mm->add_parameter("2", m2_shape);
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0, 2}}}), l2);
+        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0, 2}}}), l2);
 
         float alpha = 1.0f;
         float beta  = 1.0f;

--- a/test/verify/quant_dot_3args_2.cpp
+++ b/test/verify/quant_dot_3args_2.cpp
@@ -15,7 +15,7 @@ struct quant_dot_3args_2 : verify_program<quant_dot_3args_2>
         migraphx::shape m3_shape{migraphx::shape::int32_type, {2, 7}};
 
         auto l1  = mm->add_parameter("a", m1_shape);
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l1);
+        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
         auto l2  = mm->add_parameter("b", m2_shape);
         auto l3  = mm->add_parameter("c", m3_shape);
         mm->add_instruction(

--- a/test/verify/quant_dot_3args_2.cpp
+++ b/test/verify/quant_dot_3args_2.cpp
@@ -14,10 +14,11 @@ struct quant_dot_3args_2 : verify_program<quant_dot_3args_2>
         migraphx::shape m2_shape{migraphx::shape::int8_type, {8, 7}};
         migraphx::shape m3_shape{migraphx::shape::int32_type, {2, 7}};
 
-        auto l1  = mm->add_parameter("a", m1_shape);
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
-        auto l2  = mm->add_parameter("b", m2_shape);
-        auto l3  = mm->add_parameter("c", m3_shape);
+        auto l1 = mm->add_parameter("a", m1_shape);
+        auto tl1 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l1);
+        auto l2 = mm->add_parameter("b", m2_shape);
+        auto l3 = mm->add_parameter("c", m3_shape);
         mm->add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 1}, {"beta", 3}}), tl1, l2, l3);
         return p;

--- a/test/verify/quant_dot_3args_3.cpp
+++ b/test/verify/quant_dot_3args_3.cpp
@@ -14,10 +14,11 @@ struct quant_dot_3args_3 : verify_program<quant_dot_3args_3>
         migraphx::shape m2_shape{migraphx::shape::int8_type, {7, 8}};
         migraphx::shape m3_shape{migraphx::shape::int32_type, {2, 7}};
 
-        auto l1  = mm->add_parameter("a", m1_shape);
-        auto l2  = mm->add_parameter("b", m2_shape);
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
-        auto l3  = mm->add_parameter("c", m3_shape);
+        auto l1 = mm->add_parameter("a", m1_shape);
+        auto l2 = mm->add_parameter("b", m2_shape);
+        auto tl2 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l2);
+        auto l3 = mm->add_parameter("c", m3_shape);
         mm->add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 2}, {"beta", 3}}), l1, tl2, l3);
         return p;

--- a/test/verify/quant_dot_3args_3.cpp
+++ b/test/verify/quant_dot_3args_3.cpp
@@ -16,7 +16,7 @@ struct quant_dot_3args_3 : verify_program<quant_dot_3args_3>
 
         auto l1  = mm->add_parameter("a", m1_shape);
         auto l2  = mm->add_parameter("b", m2_shape);
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l2);
+        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
         auto l3  = mm->add_parameter("c", m3_shape);
         mm->add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 2}, {"beta", 3}}), l1, tl2, l3);

--- a/test/verify/quant_dot_3args_4.cpp
+++ b/test/verify/quant_dot_3args_4.cpp
@@ -14,11 +14,13 @@ struct quant_dot_3args_4 : verify_program<quant_dot_3args_4>
         migraphx::shape m2_shape{migraphx::shape::int8_type, {7, 8}};
         migraphx::shape m3_shape{migraphx::shape::int32_type, {2, 7}};
 
-        auto l1  = mm->add_parameter("a", m1_shape);
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
-        auto l2  = mm->add_parameter("b", m2_shape);
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
-        auto l3  = mm->add_parameter("c", m3_shape);
+        auto l1 = mm->add_parameter("a", m1_shape);
+        auto tl1 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l1);
+        auto l2 = mm->add_parameter("b", m2_shape);
+        auto tl2 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l2);
+        auto l3 = mm->add_parameter("c", m3_shape);
         mm->add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 3}, {"beta", 2}}), tl1, tl2, l3);
         return p;

--- a/test/verify/quant_dot_3args_4.cpp
+++ b/test/verify/quant_dot_3args_4.cpp
@@ -15,9 +15,9 @@ struct quant_dot_3args_4 : verify_program<quant_dot_3args_4>
         migraphx::shape m3_shape{migraphx::shape::int32_type, {2, 7}};
 
         auto l1  = mm->add_parameter("a", m1_shape);
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l1);
+        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
         auto l2  = mm->add_parameter("b", m2_shape);
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l2);
+        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
         auto l3  = mm->add_parameter("c", m3_shape);
         mm->add_instruction(
             migraphx::make_op("quant_dot", {{"alpha", 3}, {"beta", 2}}), tl1, tl2, l3);

--- a/test/verify/quant_dot_3args_5.cpp
+++ b/test/verify/quant_dot_3args_5.cpp
@@ -14,9 +14,9 @@ struct quant_dot_3args_5 : verify_program<quant_dot_3args_5>
         migraphx::shape m2_shape{migraphx::shape::int8_type, {7, 6}};
 
         auto l1  = mm->add_parameter("a", m1_shape);
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l1);
+        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
         auto l2  = mm->add_parameter("b", m2_shape);
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), l2);
+        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
         mm->add_instruction(migraphx::make_op("quant_dot", {{"alpha", 3}, {"beta", 2}}), tl1, tl2);
         return p;
     }

--- a/test/verify/quant_dot_3args_5.cpp
+++ b/test/verify/quant_dot_3args_5.cpp
@@ -13,10 +13,12 @@ struct quant_dot_3args_5 : verify_program<quant_dot_3args_5>
         migraphx::shape m1_shape{migraphx::shape::int8_type, {6, 2}};
         migraphx::shape m2_shape{migraphx::shape::int8_type, {7, 6}};
 
-        auto l1  = mm->add_parameter("a", m1_shape);
-        auto tl1 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l1);
-        auto l2  = mm->add_parameter("b", m2_shape);
-        auto tl2 = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), l2);
+        auto l1 = mm->add_parameter("a", m1_shape);
+        auto tl1 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l1);
+        auto l2 = mm->add_parameter("b", m2_shape);
+        auto tl2 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), l2);
         mm->add_instruction(migraphx::make_op("quant_dot", {{"alpha", 3}, {"beta", 2}}), tl1, tl2);
         return p;
     }

--- a/test/verify/test_acosh.cpp
+++ b/test/verify/test_acosh.cpp
@@ -14,9 +14,9 @@ struct test_acosh : verify_program<test_acosh>
         auto x       = mm->add_parameter("x", s);
         auto min_val = mm->add_literal(1.1f);
         auto max_val = mm->add_literal(100.0f);
-        min_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {16}}}),
+        min_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {16}}}),
                                       min_val);
-        max_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {16}}}),
+        max_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {16}}}),
                                       max_val);
         auto cx = mm->add_instruction(migraphx::make_op("clip"), x, min_val, max_val);
         mm->add_instruction(migraphx::make_op("acosh"), cx);

--- a/test/verify/test_acosh.cpp
+++ b/test/verify/test_acosh.cpp
@@ -14,10 +14,10 @@ struct test_acosh : verify_program<test_acosh>
         auto x       = mm->add_parameter("x", s);
         auto min_val = mm->add_literal(1.1f);
         auto max_val = mm->add_literal(100.0f);
-        min_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {16}}}),
-                                      min_val);
-        max_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {16}}}),
-                                      max_val);
+        min_val =
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {16}}}), min_val);
+        max_val =
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {16}}}), max_val);
         auto cx = mm->add_instruction(migraphx::make_op("clip"), x, min_val, max_val);
         mm->add_instruction(migraphx::make_op("acosh"), cx);
         return p;

--- a/test/verify/test_add_broadcast.cpp
+++ b/test/verify/test_add_broadcast.cpp
@@ -16,7 +16,7 @@ struct test_add_broadcast : verify_program<test_add_broadcast>
         auto x  = mm->add_parameter("x", {migraphx::shape::float_type, {2, 2, 3}});
         auto y  = mm->add_parameter("y", {migraphx::shape::float_type, {2, 2}});
         auto by = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 0}, {"dims", x->get_shape().lens()}}), y);
+            migraphx::make_op("broadcast", {{"axis", 0}, {"out_lens", x->get_shape().lens()}}), y);
         mm->add_instruction(migraphx::make_op("add"), x, by);
         return p;
     }

--- a/test/verify/test_add_broadcast2.cpp
+++ b/test/verify/test_add_broadcast2.cpp
@@ -16,7 +16,7 @@ struct test_add_broadcast2 : verify_program<test_add_broadcast2>
         auto x  = mm->add_parameter("x", {migraphx::shape::float_type, {2, 3, 4}});
         auto y  = mm->add_parameter("y", {migraphx::shape::float_type, {3}});
         auto by = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", x->get_shape().lens()}}), y);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", x->get_shape().lens()}}), y);
         mm->add_instruction(migraphx::make_op("add"), x, by);
         return p;
     }

--- a/test/verify/test_add_broadcast3.cpp
+++ b/test/verify/test_add_broadcast3.cpp
@@ -16,7 +16,7 @@ struct test_add_broadcast3 : verify_program<test_add_broadcast3>
         auto x  = mm->add_parameter("x", {migraphx::shape::float_type, {2, 4, 5}});
         auto y  = mm->add_parameter("y", {migraphx::shape::float_type, {4}});
         auto by = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", x->get_shape().lens()}}), y);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", x->get_shape().lens()}}), y);
         mm->add_instruction(migraphx::make_op("add"), x, by);
         return p;
     }

--- a/test/verify/test_add_broadcast4.cpp
+++ b/test/verify/test_add_broadcast4.cpp
@@ -16,7 +16,7 @@ struct test_add_broadcast4 : verify_program<test_add_broadcast4>
         auto x  = mm->add_parameter("x", {migraphx::shape::float_type, {2, 3, 5}});
         auto y  = mm->add_parameter("y", {migraphx::shape::float_type, {3}});
         auto by = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", x->get_shape().lens()}}), y);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", x->get_shape().lens()}}), y);
         mm->add_instruction(migraphx::make_op("add"), x, by);
         return p;
     }

--- a/test/verify/test_add_broadcast5.cpp
+++ b/test/verify/test_add_broadcast5.cpp
@@ -16,7 +16,7 @@ struct test_add_broadcast5 : verify_program<test_add_broadcast5>
         auto x  = mm->add_parameter("x", {migraphx::shape::float_type, {2, 4, 8}});
         auto y  = mm->add_parameter("y", {migraphx::shape::float_type, {4}});
         auto by = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", x->get_shape().lens()}}), y);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", x->get_shape().lens()}}), y);
         mm->add_instruction(migraphx::make_op("add"), x, by);
         return p;
     }

--- a/test/verify/test_add_broadcast6.cpp
+++ b/test/verify/test_add_broadcast6.cpp
@@ -15,7 +15,7 @@ struct test_add_broadcast6 : verify_program<test_add_broadcast6>
         auto x   = mm->add_parameter("x", {migraphx::shape::float_type, {1, 64, 568, 1328}});
         auto y   = mm->add_parameter("y", {migraphx::shape::float_type, {64}});
         auto by  = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", {1, 64, 568, 1328}}}), y);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", {1, 64, 568, 1328}}}), y);
         mm->add_instruction(migraphx::make_op("add"), x, by);
         return p;
     }

--- a/test/verify/test_add_gelu.cpp
+++ b/test/verify/test_add_gelu.cpp
@@ -18,14 +18,14 @@ struct test_add_gelu : verify_program<test_add_gelu>
         auto sqrt2       = mm->add_literal(static_cast<float>(M_SQRT2));
         auto add         = mm->add_instruction(migraphx::make_op("add"), x, y);
         auto half_mbcast = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), half);
+            migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), half);
         auto mul_half     = mm->add_instruction(migraphx::make_op("mul"), add, half_mbcast);
         auto sqrt2_mbcast = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), sqrt2);
+            migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), sqrt2);
         auto div        = mm->add_instruction(migraphx::make_op("div"), add, sqrt2_mbcast);
         auto erf        = mm->add_instruction(migraphx::make_op("erf"), div);
         auto one_mbcast = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), one);
+            migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), one);
         auto add_one = mm->add_instruction(migraphx::make_op("add"), erf, one_mbcast);
         mm->add_instruction(migraphx::make_op("mul"), mul_half, add_one);
         return p;

--- a/test/verify/test_atanh.cpp
+++ b/test/verify/test_atanh.cpp
@@ -14,9 +14,9 @@ struct test_atanh : verify_program<test_atanh>
         auto x       = mm->add_parameter("x", s);
         auto min_val = mm->add_literal(-0.95f);
         auto max_val = mm->add_literal(0.95f);
-        min_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {16}}}),
+        min_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {16}}}),
                                       min_val);
-        max_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {16}}}),
+        max_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {16}}}),
                                       max_val);
         auto cx = mm->add_instruction(migraphx::make_op("clip"), x, min_val, max_val);
         mm->add_instruction(migraphx::make_op("atanh"), cx);

--- a/test/verify/test_atanh.cpp
+++ b/test/verify/test_atanh.cpp
@@ -14,10 +14,10 @@ struct test_atanh : verify_program<test_atanh>
         auto x       = mm->add_parameter("x", s);
         auto min_val = mm->add_literal(-0.95f);
         auto max_val = mm->add_literal(0.95f);
-        min_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {16}}}),
-                                      min_val);
-        max_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {16}}}),
-                                      max_val);
+        min_val =
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {16}}}), min_val);
+        max_val =
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {16}}}), max_val);
         auto cx = mm->add_instruction(migraphx::make_op("clip"), x, min_val, max_val);
         mm->add_instruction(migraphx::make_op("atanh"), cx);
         return p;

--- a/test/verify/test_clip.cpp
+++ b/test/verify/test_clip.cpp
@@ -13,10 +13,10 @@ struct test_clip : verify_program<test_clip>
         auto x       = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {3}});
         auto min_val = mm->add_literal(0.0f);
         auto max_val = mm->add_literal(6.0f);
-        min_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3}}}),
-                                      min_val);
-        max_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3}}}),
-                                      max_val);
+        min_val =
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3}}}), min_val);
+        max_val =
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3}}}), max_val);
         mm->add_instruction(migraphx::make_op("clip"), x, min_val, max_val);
         return p;
     }

--- a/test/verify/test_clip.cpp
+++ b/test/verify/test_clip.cpp
@@ -13,9 +13,9 @@ struct test_clip : verify_program<test_clip>
         auto x       = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {3}});
         auto min_val = mm->add_literal(0.0f);
         auto max_val = mm->add_literal(6.0f);
-        min_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {3}}}),
+        min_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3}}}),
                                       min_val);
-        max_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", {3}}}),
+        max_val = mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {3}}}),
                                       max_val);
         mm->add_instruction(migraphx::make_op("clip"), x, min_val, max_val);
         return p;

--- a/test/verify/test_concat_pooling.cpp
+++ b/test/verify/test_concat_pooling.cpp
@@ -12,11 +12,11 @@ struct test_concat_pooling : verify_program<test_concat_pooling>
         auto* mm = p.get_main_module();
         auto input =
             mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {1, 256, 8, 8}});
-        auto transpose =
-            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), input);
-        auto concat = mm->add_instruction(migraphx::make_op("concat", {{"axis", 3}}), transpose);
-        auto concat_t =
-            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 3, 1, 2}}}), concat);
+        auto transpose = mm->add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), input);
+        auto concat   = mm->add_instruction(migraphx::make_op("concat", {{"axis", 3}}), transpose);
+        auto concat_t = mm->add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 3, 1, 2}}}), concat);
 
         auto pooling = mm->add_instruction(migraphx::make_op("pooling",
                                                              {{"mode", "average"},

--- a/test/verify/test_concat_pooling.cpp
+++ b/test/verify/test_concat_pooling.cpp
@@ -13,10 +13,10 @@ struct test_concat_pooling : verify_program<test_concat_pooling>
         auto input =
             mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {1, 256, 8, 8}});
         auto transpose =
-            mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), input);
+            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), input);
         auto concat = mm->add_instruction(migraphx::make_op("concat", {{"axis", 3}}), transpose);
         auto concat_t =
-            mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 3, 1, 2}}}), concat);
+            mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 3, 1, 2}}}), concat);
 
         auto pooling = mm->add_instruction(migraphx::make_op("pooling",
                                                              {{"mode", "average"},

--- a/test/verify/test_concat_transpose.cpp
+++ b/test/verify/test_concat_transpose.cpp
@@ -16,7 +16,7 @@ struct test_concat_transpose : verify_program<test_concat_transpose>
         migraphx::shape s2{migraphx::shape::int32_type, {2, 4}};
         auto l0  = mm->add_parameter("x", s0);
         auto lp1 = mm->add_parameter("y", s1);
-        auto l1  = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), lp1);
+        auto l1  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), lp1);
         auto l2  = mm->add_parameter("z", s2);
         mm->add_instruction(migraphx::make_op("concat", {{"axis", axis}}), l0, l1, l2);
         return p;

--- a/test/verify/test_concat_transpose.cpp
+++ b/test/verify/test_concat_transpose.cpp
@@ -16,8 +16,9 @@ struct test_concat_transpose : verify_program<test_concat_transpose>
         migraphx::shape s2{migraphx::shape::int32_type, {2, 4}};
         auto l0  = mm->add_parameter("x", s0);
         auto lp1 = mm->add_parameter("y", s1);
-        auto l1  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), lp1);
-        auto l2  = mm->add_parameter("z", s2);
+        auto l1 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), lp1);
+        auto l2 = mm->add_parameter("z", s2);
         mm->add_instruction(migraphx::make_op("concat", {{"axis", axis}}), l0, l1, l2);
         return p;
     }

--- a/test/verify/test_concat_transpose2.cpp
+++ b/test/verify/test_concat_transpose2.cpp
@@ -17,7 +17,7 @@ struct test_concat_transpose2 : verify_program<test_concat_transpose2>
         auto l0  = mm->add_parameter("x", s0);
         auto l1  = mm->add_parameter("y", s1);
         auto lp2 = mm->add_parameter("z", s2);
-        auto l2  = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), lp2);
+        auto l2  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), lp2);
         mm->add_instruction(migraphx::make_op("concat", {{"axis", axis}}), l0, l1, l2);
         return p;
     }

--- a/test/verify/test_concat_transpose2.cpp
+++ b/test/verify/test_concat_transpose2.cpp
@@ -17,7 +17,8 @@ struct test_concat_transpose2 : verify_program<test_concat_transpose2>
         auto l0  = mm->add_parameter("x", s0);
         auto l1  = mm->add_parameter("y", s1);
         auto lp2 = mm->add_parameter("z", s2);
-        auto l2  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), lp2);
+        auto l2 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), lp2);
         mm->add_instruction(migraphx::make_op("concat", {{"axis", axis}}), l0, l1, l2);
         return p;
     }

--- a/test/verify/test_concat_transpose3.cpp
+++ b/test/verify/test_concat_transpose3.cpp
@@ -16,9 +16,11 @@ struct test_concat_transpose3 : verify_program<test_concat_transpose3>
         migraphx::shape s2{migraphx::shape::int32_type, {5, 2}};
         auto l0  = mm->add_parameter("x", s0);
         auto lp1 = mm->add_parameter("y", s1);
-        auto l1  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), lp1);
+        auto l1 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), lp1);
         auto lp2 = mm->add_parameter("z", s2);
-        auto l2  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), lp2);
+        auto l2 =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), lp2);
         mm->add_instruction(migraphx::make_op("concat", {{"axis", axis}}), l0, l1, l2);
         return p;
     }

--- a/test/verify/test_concat_transpose3.cpp
+++ b/test/verify/test_concat_transpose3.cpp
@@ -16,9 +16,9 @@ struct test_concat_transpose3 : verify_program<test_concat_transpose3>
         migraphx::shape s2{migraphx::shape::int32_type, {5, 2}};
         auto l0  = mm->add_parameter("x", s0);
         auto lp1 = mm->add_parameter("y", s1);
-        auto l1  = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), lp1);
+        auto l1  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), lp1);
         auto lp2 = mm->add_parameter("z", s2);
-        auto l2  = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), lp2);
+        auto l2  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), lp2);
         mm->add_instruction(migraphx::make_op("concat", {{"axis", axis}}), l0, l1, l2);
         return p;
     }

--- a/test/verify/test_conv_bias_clipped_relu.cpp
+++ b/test/verify/test_conv_bias_clipped_relu.cpp
@@ -22,15 +22,15 @@ struct test_conv_bias_clipped_relu : verify_program<test_conv_bias_clipped_relu>
         auto bias      = mm->add_literal(l0);
         auto conv      = mm->add_instruction(migraphx::make_op("convolution"), input, weights);
         auto bcast_add = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", conv->get_shape().lens()}}),
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", conv->get_shape().lens()}}),
             bias);
         auto bias_add = mm->add_instruction(migraphx::make_op("add"), conv, bcast_add);
         auto min_val  = mm->add_literal(0.0f);
         auto max_val  = mm->add_literal(6.0f);
         min_val       = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), min_val);
+            migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), min_val);
         max_val = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), max_val);
+            migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), max_val);
         mm->add_instruction(migraphx::make_op("clip"), bias_add, min_val, max_val);
         return p;
     }

--- a/test/verify/test_div2.cpp
+++ b/test/verify/test_div2.cpp
@@ -16,7 +16,7 @@ struct test_div2 : verify_program<test_div2>
         auto y  = mm->add_parameter("y", s);
         auto z  = mm->add_parameter("z", b);
         auto zb = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", s.lens()}}), z);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", s.lens()}}), z);
         auto diff = mm->add_instruction(migraphx::make_op("div"), x, y);
         mm->add_instruction(migraphx::make_op("div"), diff, zb);
         return p;

--- a/test/verify/test_equal_brcst.cpp
+++ b/test/verify/test_equal_brcst.cpp
@@ -13,9 +13,9 @@ struct test_equal_brcst : verify_program<test_equal_brcst>
         migraphx::shape s0{migraphx::shape::float_type, {3, 3}};
         auto l0 = mm->add_parameter("x", s0);
         migraphx::shape s1{migraphx::shape::float_type, {3, 1}};
-        auto l1  = mm->add_parameter("y", s1);
-        auto bl1 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", s0.lens()}}), l1);
+        auto l1 = mm->add_parameter("y", s1);
+        auto bl1 =
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s0.lens()}}), l1);
         auto r = mm->add_instruction(migraphx::make_op("equal"), l0, bl1);
         mm->add_return({r});
 

--- a/test/verify/test_equal_brcst.cpp
+++ b/test/verify/test_equal_brcst.cpp
@@ -15,7 +15,7 @@ struct test_equal_brcst : verify_program<test_equal_brcst>
         migraphx::shape s1{migraphx::shape::float_type, {3, 1}};
         auto l1  = mm->add_parameter("y", s1);
         auto bl1 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", s0.lens()}}), l1);
+            migraphx::make_op("multibroadcast", {{"out_lens", s0.lens()}}), l1);
         auto r = mm->add_instruction(migraphx::make_op("equal"), l0, bl1);
         mm->add_return({r});
 

--- a/test/verify/test_gelu.cpp
+++ b/test/verify/test_gelu.cpp
@@ -16,14 +16,14 @@ struct test_gelu : verify_program<test_gelu>
         auto one         = mm->add_literal(1.0f);
         auto sqrt2       = mm->add_literal(static_cast<float>(M_SQRT2));
         auto half_mbcast = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), half);
+            migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), half);
         auto mul_half     = mm->add_instruction(migraphx::make_op("mul"), x, half_mbcast);
         auto sqrt2_mbcast = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), sqrt2);
+            migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), sqrt2);
         auto div        = mm->add_instruction(migraphx::make_op("div"), x, sqrt2_mbcast);
         auto erf        = mm->add_instruction(migraphx::make_op("erf"), div);
         auto one_mbcast = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), one);
+            migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), one);
         auto add_one = mm->add_instruction(migraphx::make_op("add"), erf, one_mbcast);
         mm->add_instruction(migraphx::make_op("mul"), mul_half, add_one);
         return p;

--- a/test/verify/test_gemm_transposea.cpp
+++ b/test/verify/test_gemm_transposea.cpp
@@ -12,7 +12,7 @@ struct test_gemm_transposea : verify_program<test_gemm_transposea>
         auto* mm = p.get_main_module();
         auto a   = mm->add_parameter("a", migraphx::shape{migraphx::shape::float_type, {5, 4}});
         auto b   = mm->add_parameter("b", migraphx::shape{migraphx::shape::float_type, {5, 3}});
-        auto at  = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), a);
+        auto at  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), a);
         mm->add_instruction(migraphx::make_op("dot"), at, b);
         return p;
     }

--- a/test/verify/test_gemm_transposea.cpp
+++ b/test/verify/test_gemm_transposea.cpp
@@ -12,7 +12,7 @@ struct test_gemm_transposea : verify_program<test_gemm_transposea>
         auto* mm = p.get_main_module();
         auto a   = mm->add_parameter("a", migraphx::shape{migraphx::shape::float_type, {5, 4}});
         auto b   = mm->add_parameter("b", migraphx::shape{migraphx::shape::float_type, {5, 3}});
-        auto at  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), a);
+        auto at = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), a);
         mm->add_instruction(migraphx::make_op("dot"), at, b);
         return p;
     }

--- a/test/verify/test_gemm_transposea_ex.cpp
+++ b/test/verify/test_gemm_transposea_ex.cpp
@@ -12,7 +12,7 @@ struct test_gemm_transposea_ex : verify_program<test_gemm_transposea_ex>
         auto* mm = p.get_main_module();
         auto a = mm->add_parameter("a", migraphx::shape{migraphx::shape::float_type, {1, 1, 5, 4}});
         auto b = mm->add_parameter("b", migraphx::shape{migraphx::shape::float_type, {1, 1, 5, 3}});
-        auto at = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), a);
+        auto at = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), a);
         mm->add_instruction(migraphx::make_op("dot"), at, b);
         return p;
     }

--- a/test/verify/test_gemm_transposea_ex.cpp
+++ b/test/verify/test_gemm_transposea_ex.cpp
@@ -12,7 +12,8 @@ struct test_gemm_transposea_ex : verify_program<test_gemm_transposea_ex>
         auto* mm = p.get_main_module();
         auto a = mm->add_parameter("a", migraphx::shape{migraphx::shape::float_type, {1, 1, 5, 4}});
         auto b = mm->add_parameter("b", migraphx::shape{migraphx::shape::float_type, {1, 1, 5, 3}});
-        auto at = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), a);
+        auto at =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), a);
         mm->add_instruction(migraphx::make_op("dot"), at, b);
         return p;
     }

--- a/test/verify/test_gemm_transposeab.cpp
+++ b/test/verify/test_gemm_transposeab.cpp
@@ -12,8 +12,8 @@ struct test_gemm_transposeab : verify_program<test_gemm_transposeab>
         auto* mm = p.get_main_module();
         auto a   = mm->add_parameter("a", migraphx::shape{migraphx::shape::float_type, {5, 4}});
         auto b   = mm->add_parameter("b", migraphx::shape{migraphx::shape::float_type, {3, 5}});
-        auto at  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), a);
-        auto bt  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), b);
+        auto at = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), a);
+        auto bt = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), b);
         mm->add_instruction(migraphx::make_op("dot"), at, bt);
         return p;
     }

--- a/test/verify/test_gemm_transposeab.cpp
+++ b/test/verify/test_gemm_transposeab.cpp
@@ -12,8 +12,8 @@ struct test_gemm_transposeab : verify_program<test_gemm_transposeab>
         auto* mm = p.get_main_module();
         auto a   = mm->add_parameter("a", migraphx::shape{migraphx::shape::float_type, {5, 4}});
         auto b   = mm->add_parameter("b", migraphx::shape{migraphx::shape::float_type, {3, 5}});
-        auto at  = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), a);
-        auto bt  = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), b);
+        auto at  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), a);
+        auto bt  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), b);
         mm->add_instruction(migraphx::make_op("dot"), at, bt);
         return p;
     }

--- a/test/verify/test_gemm_transposeb.cpp
+++ b/test/verify/test_gemm_transposeb.cpp
@@ -12,7 +12,7 @@ struct test_gemm_transposeb : verify_program<test_gemm_transposeb>
         auto* mm = p.get_main_module();
         auto a   = mm->add_parameter("a", migraphx::shape{migraphx::shape::float_type, {4, 5}});
         auto b   = mm->add_parameter("b", migraphx::shape{migraphx::shape::float_type, {3, 5}});
-        auto bt  = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {1, 0}}}), b);
+        auto bt  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), b);
         mm->add_instruction(migraphx::make_op("dot"), a, bt);
         return p;
     }

--- a/test/verify/test_gemm_transposeb.cpp
+++ b/test/verify/test_gemm_transposeb.cpp
@@ -12,7 +12,7 @@ struct test_gemm_transposeb : verify_program<test_gemm_transposeb>
         auto* mm = p.get_main_module();
         auto a   = mm->add_parameter("a", migraphx::shape{migraphx::shape::float_type, {4, 5}});
         auto b   = mm->add_parameter("b", migraphx::shape{migraphx::shape::float_type, {3, 5}});
-        auto bt  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {1, 0}}}), b);
+        auto bt = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {1, 0}}}), b);
         mm->add_instruction(migraphx::make_op("dot"), a, bt);
         return p;
     }

--- a/test/verify/test_gemm_transposeb_ex.cpp
+++ b/test/verify/test_gemm_transposeb_ex.cpp
@@ -12,7 +12,7 @@ struct test_gemm_transposeb_ex : verify_program<test_gemm_transposeb_ex>
         auto* mm = p.get_main_module();
         auto a   = mm->add_parameter("a", migraphx::shape{migraphx::shape::float_type, {1, 4, 5}});
         auto b   = mm->add_parameter("b", migraphx::shape{migraphx::shape::float_type, {1, 3, 5}});
-        auto bt  = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 1}}}), b);
+        auto bt  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 1}}}), b);
         mm->add_instruction(migraphx::make_op("dot"), a, bt);
         return p;
     }

--- a/test/verify/test_gemm_transposeb_ex.cpp
+++ b/test/verify/test_gemm_transposeb_ex.cpp
@@ -12,7 +12,8 @@ struct test_gemm_transposeb_ex : verify_program<test_gemm_transposeb_ex>
         auto* mm = p.get_main_module();
         auto a   = mm->add_parameter("a", migraphx::shape{migraphx::shape::float_type, {1, 4, 5}});
         auto b   = mm->add_parameter("b", migraphx::shape{migraphx::shape::float_type, {1, 3, 5}});
-        auto bt  = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 1}}}), b);
+        auto bt =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 1}}}), b);
         mm->add_instruction(migraphx::make_op("dot"), a, bt);
         return p;
     }

--- a/test/verify/test_greater_brcst.cpp
+++ b/test/verify/test_greater_brcst.cpp
@@ -15,7 +15,7 @@ struct test_greater_brcst : verify_program<test_greater_brcst>
         migraphx::shape s1{migraphx::shape::float_type, {3, 1}};
         auto l1  = mm->add_parameter("y", s1);
         auto bl1 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", s0.lens()}}), l1);
+            migraphx::make_op("multibroadcast", {{"out_lens", s0.lens()}}), l1);
         auto r = mm->add_instruction(migraphx::make_op("greater"), l0, bl1);
         mm->add_return({r});
 

--- a/test/verify/test_greater_brcst.cpp
+++ b/test/verify/test_greater_brcst.cpp
@@ -13,9 +13,9 @@ struct test_greater_brcst : verify_program<test_greater_brcst>
         migraphx::shape s0{migraphx::shape::float_type, {3, 3}};
         auto l0 = mm->add_parameter("x", s0);
         migraphx::shape s1{migraphx::shape::float_type, {3, 1}};
-        auto l1  = mm->add_parameter("y", s1);
-        auto bl1 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", s0.lens()}}), l1);
+        auto l1 = mm->add_parameter("y", s1);
+        auto bl1 =
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s0.lens()}}), l1);
         auto r = mm->add_instruction(migraphx::make_op("greater"), l0, bl1);
         mm->add_return({r});
 

--- a/test/verify/test_layernorm.cpp
+++ b/test/verify/test_layernorm.cpp
@@ -18,24 +18,24 @@ add_layernorm(migraphx::module& m, migraphx::instruction_ref x, std::vector<size
 
     auto mean = m.add_instruction(migraphx::op::reduce_mean({2}), x);
     auto mean_mbcast =
-        m.add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", dims}}), mean);
+        m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", dims}}), mean);
     auto sub = m.add_instruction(migraphx::make_op("sub"), x, mean_mbcast);
     auto exponent_mbcast =
-        m.add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", dims}}), exponent);
+        m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", dims}}), exponent);
     auto pow            = m.add_instruction(migraphx::make_op("pow"), sub, exponent_mbcast);
     auto var            = m.add_instruction(migraphx::op::reduce_mean({2}), pow);
     auto epsilon_mbcast = m.add_instruction(
-        migraphx::make_op("multibroadcast", {{"output_lens", {1, dims.at(1), 1}}}), epsilon);
+        migraphx::make_op("multibroadcast", {{"out_lens", {1, dims.at(1), 1}}}), epsilon);
     auto add_epsilon = m.add_instruction(migraphx::make_op("add"), var, epsilon_mbcast);
     auto sqrt        = m.add_instruction(migraphx::make_op("sqrt"), add_epsilon);
     auto sqrt_mbcast =
-        m.add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", dims}}), sqrt);
+        m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", dims}}), sqrt);
     auto div = m.add_instruction(migraphx::make_op("div"), sub, sqrt_mbcast);
     auto scale_mbcast =
-        m.add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", dims}}), scale);
+        m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", dims}}), scale);
     auto mul = m.add_instruction(migraphx::make_op("mul"), scale_mbcast, div);
     auto bias_mbcast =
-        m.add_instruction(migraphx::make_op("multibroadcast", {{"output_lens", dims}}), bias);
+        m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", dims}}), bias);
     return m.add_instruction(migraphx::make_op("add"), mul, bias_mbcast);
 }
 

--- a/test/verify/test_less_brcst.cpp
+++ b/test/verify/test_less_brcst.cpp
@@ -13,9 +13,9 @@ struct test_less_brcst : verify_program<test_less_brcst>
         migraphx::shape s0{migraphx::shape::float_type, {3, 3}};
         auto l0 = mm->add_parameter("x", s0);
         migraphx::shape s1{migraphx::shape::float_type, {3, 1}};
-        auto l1  = mm->add_parameter("y", s1);
-        auto bl1 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", s0.lens()}}), l1);
+        auto l1 = mm->add_parameter("y", s1);
+        auto bl1 =
+            mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", s0.lens()}}), l1);
         auto r = mm->add_instruction(migraphx::make_op("less"), l0, bl1);
         mm->add_return({r});
 

--- a/test/verify/test_less_brcst.cpp
+++ b/test/verify/test_less_brcst.cpp
@@ -15,7 +15,7 @@ struct test_less_brcst : verify_program<test_less_brcst>
         migraphx::shape s1{migraphx::shape::float_type, {3, 1}};
         auto l1  = mm->add_parameter("y", s1);
         auto bl1 = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", s0.lens()}}), l1);
+            migraphx::make_op("multibroadcast", {{"out_lens", s0.lens()}}), l1);
         auto r = mm->add_instruction(migraphx::make_op("less"), l0, bl1);
         mm->add_return({r});
 

--- a/test/verify/test_logsoftmax1.cpp
+++ b/test/verify/test_logsoftmax1.cpp
@@ -11,7 +11,7 @@ struct test_logsoftmax1 : verify_program<test_logsoftmax1>
         migraphx::program p;
         auto* mm = p.get_main_module();
         auto x = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {5, 3, 3, 4}});
-        auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {2, 3, 0, 1}}}), x);
+        auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {2, 3, 0, 1}}}), x);
         auto r  = mm->add_instruction(migraphx::make_op("logsoftmax", {{"axis", 0}}), tx);
         mm->add_return({r});
         return p;

--- a/test/verify/test_logsoftmax1.cpp
+++ b/test/verify/test_logsoftmax1.cpp
@@ -11,8 +11,9 @@ struct test_logsoftmax1 : verify_program<test_logsoftmax1>
         migraphx::program p;
         auto* mm = p.get_main_module();
         auto x = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {5, 3, 3, 4}});
-        auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {2, 3, 0, 1}}}), x);
-        auto r  = mm->add_instruction(migraphx::make_op("logsoftmax", {{"axis", 0}}), tx);
+        auto tx =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {2, 3, 0, 1}}}), x);
+        auto r = mm->add_instruction(migraphx::make_op("logsoftmax", {{"axis", 0}}), tx);
         mm->add_return({r});
         return p;
     }

--- a/test/verify/test_mul_add.cpp
+++ b/test/verify/test_mul_add.cpp
@@ -16,9 +16,9 @@ struct test_mul_add : verify_program<test_mul_add>
         auto a  = mm->add_parameter("a", bs);
         auto b  = mm->add_parameter("b", bs);
         auto ab = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", s.lens()}}), a);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", s.lens()}}), a);
         auto bb = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", s.lens()}}), b);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", s.lens()}}), b);
         auto mul = mm->add_instruction(migraphx::make_op("mul"), x, ab);
         mm->add_instruction(migraphx::make_op("add"), mul, bb);
         return p;

--- a/test/verify/test_pad_transposed.cpp
+++ b/test/verify/test_pad_transposed.cpp
@@ -12,7 +12,8 @@ struct test_pad_transposed : verify_program<test_pad_transposed>
         auto* mm = p.get_main_module();
         migraphx::shape s{migraphx::shape::int32_type, {1, 224, 224, 3}};
         auto x = mm->add_parameter("x", s);
-        auto t = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 3, 1, 2}}}), x);
+        auto t =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 3, 1, 2}}}), x);
         mm->add_instruction(migraphx::make_op("pad", {{"pads", {0, 0, 2, 2, 0, 0, 3, 3}}}), t);
         return p;
     }

--- a/test/verify/test_pad_transposed.cpp
+++ b/test/verify/test_pad_transposed.cpp
@@ -12,7 +12,7 @@ struct test_pad_transposed : verify_program<test_pad_transposed>
         auto* mm = p.get_main_module();
         migraphx::shape s{migraphx::shape::int32_type, {1, 224, 224, 3}};
         auto x = mm->add_parameter("x", s);
-        auto t = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 3, 1, 2}}}), x);
+        auto t = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 3, 1, 2}}}), x);
         mm->add_instruction(migraphx::make_op("pad", {{"pads", {0, 0, 2, 2, 0, 0, 3, 3}}}), t);
         return p;
     }

--- a/test/verify/test_rsqrt.cpp
+++ b/test/verify/test_rsqrt.cpp
@@ -16,9 +16,9 @@ struct test_rsqrt : verify_program<test_rsqrt>
         auto min_val = mm->add_literal(1.0f);
         auto max_val = mm->add_literal(std::numeric_limits<float>::max());
         min_val      = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), min_val);
+            migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), min_val);
         max_val = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", input_lens}}), max_val);
+            migraphx::make_op("multibroadcast", {{"out_lens", input_lens}}), max_val);
         auto l0 = mm->add_instruction(migraphx::make_op("clip"), x, min_val, max_val);
         mm->add_instruction(migraphx::make_op("rsqrt"), l0);
         return p;

--- a/test/verify/test_step_broadcast_transpose.cpp
+++ b/test/verify/test_step_broadcast_transpose.cpp
@@ -13,7 +13,7 @@ struct test_step_broadcast_transpose : verify_program<test_step_broadcast_transp
         migraphx::shape s1{migraphx::shape::float_type, {1, 1, 1, 6}};
         auto l0 = mm->add_parameter("x", s1);
         auto ml = mm->add_instruction(
-            migraphx::make_op("multibroadcast", {{"output_lens", {2, 1, 4, 6}}}), l0);
+            migraphx::make_op("multibroadcast", {{"out_lens", {2, 1, 4, 6}}}), l0);
         auto tl = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), ml);
         auto r  = mm->add_instruction(
             migraphx::make_op("step", {{"axes", {0, 1, 2}}, {"steps", {2, 2, 3}}}), tl);

--- a/test/verify/test_step_broadcast_transpose.cpp
+++ b/test/verify/test_step_broadcast_transpose.cpp
@@ -14,8 +14,9 @@ struct test_step_broadcast_transpose : verify_program<test_step_broadcast_transp
         auto l0 = mm->add_parameter("x", s1);
         auto ml = mm->add_instruction(
             migraphx::make_op("multibroadcast", {{"out_lens", {2, 1, 4, 6}}}), l0);
-        auto tl = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), ml);
-        auto r  = mm->add_instruction(
+        auto tl = mm->add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), ml);
+        auto r = mm->add_instruction(
             migraphx::make_op("step", {{"axes", {0, 1, 2}}, {"steps", {2, 2, 3}}}), tl);
         mm->add_return({r});
 

--- a/test/verify/test_step_broadcast_transpose.cpp
+++ b/test/verify/test_step_broadcast_transpose.cpp
@@ -14,7 +14,7 @@ struct test_step_broadcast_transpose : verify_program<test_step_broadcast_transp
         auto l0 = mm->add_parameter("x", s1);
         auto ml = mm->add_instruction(
             migraphx::make_op("multibroadcast", {{"out_lens", {2, 1, 4, 6}}}), l0);
-        auto tl = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), ml);
+        auto tl = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), ml);
         auto r  = mm->add_instruction(
             migraphx::make_op("step", {{"axes", {0, 1, 2}}, {"steps", {2, 2, 3}}}), tl);
         mm->add_return({r});

--- a/test/verify/test_step_transpose.cpp
+++ b/test/verify/test_step_transpose.cpp
@@ -12,8 +12,9 @@ struct test_step_transpose : verify_program<test_step_transpose>
         auto* mm = p.get_main_module();
         migraphx::shape s1{migraphx::shape::float_type, {2, 1, 4, 6}};
         auto l0 = mm->add_parameter("x", s1);
-        auto tl = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l0);
-        auto r  = mm->add_instruction(
+        auto tl = mm->add_instruction(
+            migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), l0);
+        auto r = mm->add_instruction(
             migraphx::make_op("step", {{"axes", {0, 1, 2}}, {"steps", {2, 2, 3}}}), tl);
         mm->add_return({r});
 

--- a/test/verify/test_step_transpose.cpp
+++ b/test/verify/test_step_transpose.cpp
@@ -12,7 +12,7 @@ struct test_step_transpose : verify_program<test_step_transpose>
         auto* mm = p.get_main_module();
         migraphx::shape s1{migraphx::shape::float_type, {2, 1, 4, 6}};
         auto l0 = mm->add_parameter("x", s1);
-        auto tl = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 2, 3, 1}}}), l0);
+        auto tl = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 2, 3, 1}}}), l0);
         auto r  = mm->add_instruction(
             migraphx::make_op("step", {{"axes", {0, 1, 2}}, {"steps", {2, 2, 3}}}), tl);
         mm->add_return({r});

--- a/test/verify/test_sub2.cpp
+++ b/test/verify/test_sub2.cpp
@@ -16,7 +16,7 @@ struct test_sub2 : verify_program<test_sub2>
         auto y  = mm->add_parameter("y", s);
         auto z  = mm->add_parameter("z", b);
         auto zb = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", s.lens()}}), z);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", s.lens()}}), z);
         auto diff = mm->add_instruction(migraphx::make_op("sub"), x, y);
         mm->add_instruction(migraphx::make_op("sub"), diff, zb);
         return p;

--- a/test/verify/test_trans_abs.cpp
+++ b/test/verify/test_trans_abs.cpp
@@ -11,7 +11,8 @@ struct test_trans_abs : verify_program<test_trans_abs>
         migraphx::program p;
         auto* mm = p.get_main_module();
         auto x = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {4, 3, 3, 3}});
-        auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), x);
+        auto tx =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), x);
         auto absx = mm->add_instruction(migraphx::make_op("abs"), tx);
         auto r    = mm->add_instruction(migraphx::make_op("add"), absx, absx);
         mm->add_instruction(migraphx::make_op("contiguous"), r);

--- a/test/verify/test_trans_abs.cpp
+++ b/test/verify/test_trans_abs.cpp
@@ -11,7 +11,7 @@ struct test_trans_abs : verify_program<test_trans_abs>
         migraphx::program p;
         auto* mm = p.get_main_module();
         auto x = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {4, 3, 3, 3}});
-        auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), x);
+        auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), x);
         auto absx = mm->add_instruction(migraphx::make_op("abs"), tx);
         auto r    = mm->add_instruction(migraphx::make_op("add"), absx, absx);
         mm->add_instruction(migraphx::make_op("contiguous"), r);

--- a/test/verify/test_trans_ret.cpp
+++ b/test/verify/test_trans_ret.cpp
@@ -11,7 +11,8 @@ struct test_trans_ret : verify_program<test_trans_ret>
         migraphx::program p;
         auto* mm = p.get_main_module();
         auto x = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {4, 3, 3, 3}});
-        auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), x);
+        auto tx =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), x);
         mm->add_return({tx});
 
         return p;

--- a/test/verify/test_trans_ret.cpp
+++ b/test/verify/test_trans_ret.cpp
@@ -11,7 +11,7 @@ struct test_trans_ret : verify_program<test_trans_ret>
         migraphx::program p;
         auto* mm = p.get_main_module();
         auto x = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {4, 3, 3, 3}});
-        auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), x);
+        auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), x);
         mm->add_return({tx});
 
         return p;

--- a/test/verify/test_trans_tanh.cpp
+++ b/test/verify/test_trans_tanh.cpp
@@ -11,7 +11,7 @@ struct test_trans_tanh : verify_program<test_trans_tanh>
         migraphx::program p;
         auto* mm = p.get_main_module();
         auto x = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {4, 3, 3, 3}});
-        auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), x);
+        auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), x);
         auto tanhx = mm->add_instruction(migraphx::make_op("tanh"), tx);
         auto r     = mm->add_instruction(migraphx::make_op("add"), tanhx, tanhx);
         mm->add_instruction(migraphx::make_op("contiguous"), r);

--- a/test/verify/test_trans_tanh.cpp
+++ b/test/verify/test_trans_tanh.cpp
@@ -11,7 +11,8 @@ struct test_trans_tanh : verify_program<test_trans_tanh>
         migraphx::program p;
         auto* mm = p.get_main_module();
         auto x = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {4, 3, 3, 3}});
-        auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), x);
+        auto tx =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), x);
         auto tanhx = mm->add_instruction(migraphx::make_op("tanh"), tx);
         auto r     = mm->add_instruction(migraphx::make_op("add"), tanhx, tanhx);
         mm->add_instruction(migraphx::make_op("contiguous"), r);

--- a/test/verify/test_trans_tanh1.cpp
+++ b/test/verify/test_trans_tanh1.cpp
@@ -11,7 +11,7 @@ struct test_trans_tanh1 : verify_program<test_trans_tanh1>
         migraphx::program p;
         auto* mm = p.get_main_module();
         auto x = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {4, 3, 3, 3}});
-        auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"dims", {0, 1, 3, 2}}}), x);
+        auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), x);
         auto tanhx = mm->add_instruction(migraphx::make_op("tanh"), tx);
         auto r     = mm->add_instruction(migraphx::make_op("add"), tanhx, tanhx);
         mm->add_return({tx, r});

--- a/test/verify/test_trans_tanh1.cpp
+++ b/test/verify/test_trans_tanh1.cpp
@@ -11,7 +11,8 @@ struct test_trans_tanh1 : verify_program<test_trans_tanh1>
         migraphx::program p;
         auto* mm = p.get_main_module();
         auto x = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {4, 3, 3, 3}});
-        auto tx = mm->add_instruction(migraphx::make_op("transpose", {{"perm", {0, 1, 3, 2}}}), x);
+        auto tx =
+            mm->add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 1, 3, 2}}}), x);
         auto tanhx = mm->add_instruction(migraphx::make_op("tanh"), tx);
         auto r     = mm->add_instruction(migraphx::make_op("add"), tanhx, tanhx);
         mm->add_return({tx, r});

--- a/test/verify/test_transpose.cpp
+++ b/test/verify/test_transpose.cpp
@@ -13,7 +13,7 @@ struct test_transpose : verify_program<test_transpose>
         migraphx::shape s{migraphx::shape::float_type, {4, 3, 4, 4}};
         auto x                    = mm->add_parameter("x", s);
         std::vector<int64_t> perm = {0, 2, 3, 1};
-        auto l = mm->add_instruction(migraphx::make_op("transpose", {{"dims", perm}}), x);
+        auto l = mm->add_instruction(migraphx::make_op("transpose", {{"perm", perm}}), x);
         mm->add_instruction(migraphx::make_op("contiguous"), l);
         return p;
     }

--- a/test/verify/test_transpose.cpp
+++ b/test/verify/test_transpose.cpp
@@ -13,7 +13,7 @@ struct test_transpose : verify_program<test_transpose>
         migraphx::shape s{migraphx::shape::float_type, {4, 3, 4, 4}};
         auto x                    = mm->add_parameter("x", s);
         std::vector<int64_t> perm = {0, 2, 3, 1};
-        auto l = mm->add_instruction(migraphx::make_op("transpose", {{"perm", perm}}), x);
+        auto l = mm->add_instruction(migraphx::make_op("transpose", {{"permutation", perm}}), x);
         mm->add_instruction(migraphx::make_op("contiguous"), l);
         return p;
     }

--- a/test/verify/test_triadd2.cpp
+++ b/test/verify/test_triadd2.cpp
@@ -16,7 +16,7 @@ struct test_triadd2 : verify_program<test_triadd2>
         auto y  = mm->add_parameter("y", s);
         auto z  = mm->add_parameter("z", b);
         auto zb = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 1}, {"dims", s.lens()}}), z);
+            migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", s.lens()}}), z);
         auto sum = mm->add_instruction(migraphx::make_op("add"), x, y);
         mm->add_instruction(migraphx::make_op("add"), sum, zb);
         return p;

--- a/test/verify/test_triadd_broadcast.cpp
+++ b/test/verify/test_triadd_broadcast.cpp
@@ -17,7 +17,7 @@ struct test_triadd_broadcast : verify_program<test_triadd_broadcast>
         auto y  = mm->add_parameter("y", {migraphx::shape::float_type, {2, 2}});
         auto z  = mm->add_parameter("z", {migraphx::shape::float_type, {2, 2, 3}});
         auto by = mm->add_instruction(
-            migraphx::make_op("broadcast", {{"axis", 0}, {"dims", x->get_shape().lens()}}), y);
+            migraphx::make_op("broadcast", {{"axis", 0}, {"out_lens", x->get_shape().lens()}}), y);
         auto sum = mm->add_instruction(migraphx::make_op("add"), x, by);
         mm->add_instruction(migraphx::make_op("add"), sum, z);
         return p;


### PR DESCRIPTION
Fixes #786 

Changes 

broadcast operator's attribute name "dims" to "out_lens"
multibroadcast operators' attribute name "output_lens" to "out_lens"
~~reshape op's attribute name "dims" to "out_lens"~~
transpose op's attribute name "dims" to ~~"perm"~~ to "permutation"