### PR TITLE
Drop support for Ubuntu 16.04 in CI runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,16 +161,12 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-16.04
           - ubuntu-18.04
           - ubuntu-20.04
         configuration:
           - debug
           - release
           - codecov
-        exclude:
-          - os: ubuntu-16.04
-            configuration: debug
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Github CI Actions will be dropping support for 16.04
This commit will remove that OS from our CI infrastructure