### PR TITLE
Correcting hip package dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,7 @@ rocm_create_package(
     MAINTAINER "Paul Fultz II <paul.fultz@amd.com>"
     LDCONFIG
     PTH
-    DEPENDS miopen-hip rocblas hip-hcc half
+    DEPENDS miopen-hip rocblas hip-devel hip-runtime-amd half
 )
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)


### PR DESCRIPTION
Hip package names have been changed because of the new rocm packaging standards. Hence the hip-hcc dependency needs to be changed to hip-devel hip-runtime-amd