### PR TITLE
Failing fusion plan workaround

### DIFF
--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -168,9 +168,11 @@ MIGRAPHX_PRED_MATCHER(bias_shape, instruction_ref ins)
 
 MIGRAPHX_PRED_MATCHER(fusable_conv, instruction_ref ins)
 {
-    const auto device_name = get_device_name();
+    const auto device_name     = get_device_name();
     const auto supported_archs = get_supported_archs();
-    if (std::none_of(supported_archs.begin(), supported_archs.end(), [&](auto s){ return device_name.find(s) != std::string::npos; }))
+    if(std::none_of(supported_archs.begin(), supported_archs.end(), [&](auto s) {
+           return device_name.find(s) != std::string::npos;
+       }))
         return false;
     if(enabled(MIGRAPHX_DISABLE_MIOPEN_FUSION{}))
         return false;

--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -169,7 +169,7 @@ MIGRAPHX_PRED_MATCHER(bias_shape, instruction_ref ins)
 
 MIGRAPHX_PRED_MATCHER(fusable_conv, instruction_ref ins)
 {
-    const auto device_name     = split_string(get_device_name(), ':').front();
+    const auto device_name = split_string(get_device_name(), ':').front();
     if(not contains(get_supported_archs(), device_name))
         return false;
     if(enabled(MIGRAPHX_DISABLE_MIOPEN_FUSION{}))

--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -155,7 +155,7 @@ struct fusion
 
 std::vector<std::string> get_supported_archs()
 {
-    static std::vector<std::string> supported_archs{"gfx900", "gfx906", "gfx908"};
+    static std::vector<std::string> supported_archs{"gfx900", "gfx906", "gfx908", "gfx1030"};
     return supported_archs;
 }
 

--- a/src/targets/gpu/fuse_ops.cpp
+++ b/src/targets/gpu/fuse_ops.cpp
@@ -154,7 +154,7 @@ struct fusion
     }
 };
 
-std::unordered_set<std::string> get_supported_archs()
+const std::unordered_set<std::string>& get_supported_archs()
 {
     static std::unordered_set<std::string> supported_archs{"gfx900", "gfx906", "gfx908", "gfx1030"};
     return supported_archs;
@@ -170,8 +170,7 @@ MIGRAPHX_PRED_MATCHER(bias_shape, instruction_ref ins)
 MIGRAPHX_PRED_MATCHER(fusable_conv, instruction_ref ins)
 {
     const auto device_name     = split_string(get_device_name(), ':').front();
-    const auto supported_archs = get_supported_archs();
-    if(not contains(supported_archs, device_name))
+    if(not contains(get_supported_archs(), device_name))
         return false;
     if(enabled(MIGRAPHX_DISABLE_MIOPEN_FUSION{}))
         return false;


### PR DESCRIPTION
Add workaround for devices that do not support miopen conv fusions

Fixes the error: `what():  /code/AMDMIGraphX/src/targets/gpu/fuse_ops.cpp:131: compile: Compiling fusion plan failed ` that was occuring on MI200. 