### PR TITLE
Non std shape auto contiguous

### DIFF
--- a/src/auto_contiguous.cpp
+++ b/src/auto_contiguous.cpp
@@ -16,7 +16,7 @@ void auto_contiguous::apply(module& p) const
         if(not s.standard() and s.elements() != 0)
         {
             auto c = p.insert_instruction(std::next(ins), make_op("contiguous"), ins);
-            p.replace_instruction(ins, c);
+            p.replace_instruction(ins, c, true);
         }
     }
 }

--- a/src/include/migraphx/instruction.hpp
+++ b/src/include/migraphx/instruction.hpp
@@ -36,7 +36,7 @@ struct instruction
 
     void replace(operation o);
 
-    void recompute_shape();
+    void recompute_shape(bool non_std_stop = false);
 
     void clear_arguments();
 
@@ -83,7 +83,7 @@ struct instruction
 
     static void backreference(instruction_ref ref);
 
-    static void replace_argument(instruction_ref ins, instruction_ref old, instruction_ref new_ins);
+    static void replace_argument(instruction_ref ins, instruction_ref old, instruction_ref new_ins, bool stop = false);
 
     static void replace_mod_argument(instruction_ref ins, module_ref old, module_ref new_mod);
 
@@ -139,7 +139,7 @@ struct instruction
     // internal
     void replace_mod_argument(module_ref old, module_ref new_mod);
 
-    void replace(const shape& r);
+    void replace(const shape& r, bool stop = false);
 
     operation op;
     shape result{};

--- a/src/include/migraphx/instruction.hpp
+++ b/src/include/migraphx/instruction.hpp
@@ -83,7 +83,10 @@ struct instruction
 
     static void backreference(instruction_ref ref);
 
-    static void replace_argument(instruction_ref ins, instruction_ref old, instruction_ref new_ins, bool stop = false);
+    static void replace_argument(instruction_ref ins,
+                                 instruction_ref old,
+                                 instruction_ref new_ins,
+                                 bool stop = false);
 
     static void replace_mod_argument(instruction_ref ins, module_ref old, module_ref new_mod);
 

--- a/src/include/migraphx/module.hpp
+++ b/src/include/migraphx/module.hpp
@@ -88,7 +88,8 @@ struct module
                                         std::vector<instruction_ref> args,
                                         std::vector<module_ref> module_args) MIGRAPHX_TIDY_CONST;
 
-    instruction_ref replace_instruction(instruction_ref ins, instruction_ref rep, bool stop = false);
+    instruction_ref
+    replace_instruction(instruction_ref ins, instruction_ref rep, bool stop = false);
 
     instruction_ref remove_instruction(instruction_ref ins);
     instruction_ref remove_instructions(instruction_ref first, instruction_ref last);

--- a/src/include/migraphx/module.hpp
+++ b/src/include/migraphx/module.hpp
@@ -88,7 +88,7 @@ struct module
                                         std::vector<instruction_ref> args,
                                         std::vector<module_ref> module_args) MIGRAPHX_TIDY_CONST;
 
-    instruction_ref replace_instruction(instruction_ref ins, instruction_ref rep);
+    instruction_ref replace_instruction(instruction_ref ins, instruction_ref rep, bool stop = false);
 
     instruction_ref remove_instruction(instruction_ref ins);
     instruction_ref remove_instructions(instruction_ref first, instruction_ref last);

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -39,7 +39,8 @@ void instruction::replace(const shape& r, bool stop)
     if(r != result)
     {
         result = r;
-        if(stop and not r.standard()) return;
+        if(stop and not r.standard())
+            return;
 
         for(auto&& ins : output)
         {
@@ -59,9 +60,9 @@ void instruction::replace(operation o)
     recompute_shape();
 }
 
-void instruction::recompute_shape(bool non_std_stop) 
+void instruction::recompute_shape(bool non_std_stop)
 {
-    replace(compute_shape(op, arguments, module_args), non_std_stop); 
+    replace(compute_shape(op, arguments, module_args), non_std_stop);
 }
 
 void instruction::clear_arguments()

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -232,7 +232,7 @@ instruction_ref module::replace_instruction(instruction_ref ins,
     return ins;
 }
 
-instruction_ref module::replace_instruction(instruction_ref ins, instruction_ref rep)
+instruction_ref module::replace_instruction(instruction_ref ins, instruction_ref rep, bool stop)
 {
     assert(has_instruction(ins));
     assert(has_instruction(rep));
@@ -255,7 +255,7 @@ instruction_ref module::replace_instruction(instruction_ref ins, instruction_ref
         // TODO: Check for possible cycles
         if(out != rep)
         {
-            instruction::replace_argument(out, ins, rep);
+            instruction::replace_argument(out, ins, rep, stop);
         }
         assert(out->valid(begin()));
     }

--- a/test/auto_contiguous_test.cpp
+++ b/test/auto_contiguous_test.cpp
@@ -103,14 +103,15 @@ TEST_CASE(after_param_broadcast)
 
 TEST_CASE(two_transpose_gather)
 {
-    auto create_module = [] 
-    {
+    auto create_module = [] {
         migraphx::module m;
         auto data = m.add_parameter("2x2", {migraphx::shape::float_type, {2, 3, 4, 5}});
-        auto ind = m.add_parameter("ind", {migraphx::shape::float_type, {2, 3}});
-        auto td = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), data);
+        auto ind  = m.add_parameter("ind", {migraphx::shape::float_type, {2, 3}});
+        auto td = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}),
+                                    data);
         auto sd = m.add_instruction(migraphx::make_op("softmax", {{"axis", 2}}), td);
-        auto bd = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 3, 1, 2}}}), sd);
+        auto bd =
+            m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 3, 1, 2}}}), sd);
         auto r = m.add_instruction(migraphx::make_op("gather", {{"axis", 2}}), bd, ind);
         m.add_return({r});
 
@@ -120,17 +121,18 @@ TEST_CASE(two_transpose_gather)
     auto m = create_module();
     run_pass(m);
 
-    auto create_cont_module = [] 
-    {
+    auto create_cont_module = [] {
         migraphx::module m;
         auto data = m.add_parameter("2x2", {migraphx::shape::float_type, {2, 3, 4, 5}});
-        auto ind = m.add_parameter("ind", {migraphx::shape::float_type, {2, 3}});
-        auto td = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}), data);
+        auto ind  = m.add_parameter("ind", {migraphx::shape::float_type, {2, 3}});
+        auto td = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 2, 3, 1}}}),
+                                    data);
         auto ctd = m.add_instruction(migraphx::make_op("contiguous"), td);
-        auto sd = m.add_instruction(migraphx::make_op("softmax", {{"axis", 2}}), ctd);
-        auto bd = m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 3, 1, 2}}}), sd);
+        auto sd  = m.add_instruction(migraphx::make_op("softmax", {{"axis", 2}}), ctd);
+        auto bd =
+            m.add_instruction(migraphx::make_op("transpose", {{"permutation", {0, 3, 1, 2}}}), sd);
         auto cbd = m.add_instruction(migraphx::make_op("contiguous"), bd);
-        auto r = m.add_instruction(migraphx::make_op("gather", {{"axis", 2}}), cbd, ind);
+        auto r   = m.add_instruction(migraphx::make_op("gather", {{"axis", 2}}), cbd, ind);
         m.add_return({r});
 
         return m;


### PR DESCRIPTION
This PR is to resolve a problem in parsing the ssd-10 model. 

The problem is, after inserting contiguous in the auto_contiguous pass, standard output shape of some operators becomes non-standard. Then, if the next operator requires standard input shape, an exception is throw. 

For example, if we pass the following model:
  Input (standard shape) -> transpose (transposed) -> softmax (transposed) -> transpose (standard) -> gather. 
It works fine, and no contiguous is required. 

In the auto_contiguous pass, a contiguous is inserted after the first transpose. Then we need to replace the first transpose with the contiguous and recompute all shapes. When it comes to the gather operator, its input is a transposed shape, and an exception is thrown.

The solution is in the recompute_shape() function. If it is called by the auto_contiguous pass and shape of an instruction is changed, and the shape is non_standard, we do not recompute shape of its output. The reason is: since its output shape is non_standard, a contiguous op will be added after the instruction, which will recompute shape for later operators.
