### PR TITLE
File ext rename

### DIFF
--- a/examples/migraphx/cpp_parse_load_save/README.md
+++ b/examples/migraphx/cpp_parse_load_save/README.md
@@ -15,7 +15,7 @@ p = parse_onnx(input_file, options);
 ```
 
 ## Saving
-An instantiated migraphx::program object can then be serialized to MessagePack (.msgpack) format and saved so that it can be loaded for future uses. 
+An instantiated migraphx::program object can then be serialized to MessagePack (.mxr) format and saved so that it can be loaded for future uses. 
 
 A program can be saved with either of the following:
 ```

--- a/examples/migraphx/cpp_parse_load_save/parse_load_save.cpp
+++ b/examples/migraphx/cpp_parse_load_save/parse_load_save.cpp
@@ -77,7 +77,7 @@ int main(int argc, char** argv)
         std::cout << "Saving program..." << std::endl;
         std::string output_file;
         output_file = save_arg == nullptr ? "out" : save_arg;
-        output_file.append(".msgpack");
+        output_file.append(".mxr");
 
         migraphx::file_options options;
         options.set_file_format("msgpack");

--- a/examples/vision/python_yolov4/yolov4_inference.ipynb
+++ b/examples/vision/python_yolov4/yolov4_inference.ipynb
@@ -50,10 +50,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if not os.path.exists(\"yolov4_fp16.msgpack\"):\n",
-    "    !/opt/rocm/bin/migraphx-driver compile ./utilities/yolov4.onnx --gpu --enable-offload-copy --fp16ref --binary -o yolov4_fp16.msgpack\n",
-    "if not os.path.exists(\"yolov4.msgpack\"):\n",
-    "    !/opt/rocm/bin/migraphx-driver compile ./utilities/yolov4.onnx --gpu --enable-offload-copy --binary -o yolov4.msgpack"
+    "if not os.path.exists(\"yolov4_fp16.mxr\"):\n",
+    "    !/opt/rocm/bin/migraphx-driver compile ./utilities/yolov4.onnx --gpu --enable-offload-copy --fp16ref --binary -o yolov4_fp16.mxr\n",
+    "if not os.path.exists(\"yolov4.mxr\"):\n",
+    "    !/opt/rocm/bin/migraphx-driver compile ./utilities/yolov4.onnx --gpu --enable-offload-copy --binary -o yolov4.mxr"
    ]
   },
   {
@@ -115,8 +115,8 @@
    "outputs": [],
    "source": [
     "# Load serialized model (either single- or half-precision)\n",
-    "model = migraphx.load(\"yolov4.msgpack\", format=\"msgpack\")\n",
-    "#model = migraphx.load(\"yolov4_fp16.msgpack\", format=\"msgpack\")\n",
+    "model = migraphx.load(\"yolov4.mxr\", format=\"msgpack\")\n",
+    "#model = migraphx.load(\"yolov4_fp16.mxr\", format=\"msgpack\")\n",
     "\n",
     "# Get the name of the input parameter and convert image data to an MIGraphX argument\n",
     "input_name = next(iter(model.get_parameter_shapes()))\n",

--- a/test/api/test_save_load.cpp
+++ b/test/api/test_save_load.cpp
@@ -4,7 +4,7 @@
 
 TEST_CASE(load_save_default)
 {
-    std::string filename = "migraphx_api_load_save.dat";
+    std::string filename = "migraphx_api_load_save.mxr";
     auto p1              = migraphx::parse_onnx("conv_relu_maxpool_test.onnx");
     auto s1              = p1.get_output_shapes();
 

--- a/test/serialize_program.cpp
+++ b/test/serialize_program.cpp
@@ -48,7 +48,7 @@ TEST_CASE(as_json)
 
 TEST_CASE(as_file)
 {
-    std::string filename = "migraphx_program.dat";
+    std::string filename = "migraphx_program.mxr";
     migraphx::program p1 = create_program();
     migraphx::save(p1, filename);
     migraphx::program p2 = migraphx::load(filename);

--- a/test/verify/run_verify.cpp
+++ b/test/verify/run_verify.cpp
@@ -128,7 +128,7 @@ void run_verify::verify(const std::string& name, const migraphx::program& p) con
         std::future<std::pair<migraphx::program, std::vector<migraphx::argument>>>;
     auto_print::set_terminate_handler(name);
     if(migraphx::enabled(MIGRAPHX_DUMP_TEST{}))
-        migraphx::save(p, name + ".mx");
+        migraphx::save(p, name + ".mxr");
     std::vector<std::pair<std::string, result_future>> results;
     std::vector<std::string> target_names;
     for(const auto& tname : migraphx::get_targets())


### PR DESCRIPTION
Changed MessagePack file extensions to mxr.

The yolov4 example using Python notebooks looks for a .msgpack extension. Not sure if those should be changed.