### PR TITLE
Make get_context experimental

### DIFF
--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -1102,8 +1102,8 @@ migraphx_program_equal(bool* out, const_migraphx_program_t program, const_migrap
     return api_error_result;
 }
 
-extern "C" migraphx_status migraphx_program_get_context(migraphx_context_t* out,
-                                                        const_migraphx_program_t program)
+extern "C" migraphx_status
+migraphx_program_experimental_get_context(migraphx_context_t* out, const_migraphx_program_t program)
 {
     auto api_error_result = migraphx::try_([&] {
         if(program == nullptr)

--- a/src/api/include/migraphx/migraphx.h
+++ b/src/api/include/migraphx/migraphx.h
@@ -291,8 +291,8 @@ migraphx_status migraphx_program_run(migraphx_arguments_t* out,
 migraphx_status
 migraphx_program_equal(bool* out, const_migraphx_program_t program, const_migraphx_program_t x);
 
-migraphx_status migraphx_program_get_context(migraphx_context_t* out,
-                                             const_migraphx_program_t program);
+migraphx_status migraphx_program_experimental_get_context(migraphx_context_t* out,
+                                                          const_migraphx_program_t program);
 
 migraphx_status migraphx_operation_destroy(migraphx_operation_t operation);
 

--- a/src/api/include/migraphx/migraphx.hpp
+++ b/src/api/include/migraphx/migraphx.hpp
@@ -733,10 +733,10 @@ struct program : MIGRAPHX_HANDLE_BASE(program)
         return module{p_modu};
     }
 
-    context get_context()
+    context experimental_get_context()
     {
         migraphx_context_t ctx;
-        call(&migraphx_program_get_context, &ctx, this->get_handle_ptr());
+        call(&migraphx_program_experimental_get_context, &ctx, this->get_handle_ptr());
         return context{ctx};
     }
 

--- a/src/api/migraphx.py
+++ b/src/api/migraphx.py
@@ -248,7 +248,7 @@ def program(h):
              invoke='migraphx::equal($@)',
              returns='bool',
              const=True)
-    h.method('get_context',
+    h.method('experimental_get_context',
              invoke='migraphx::get_context($@)',
              const=True,
              returns='migraphx::context')

--- a/src/include/migraphx/operation.hpp
+++ b/src/include/migraphx/operation.hpp
@@ -461,8 +461,8 @@ lifetime get_lifetime_op(const T&)
  *      shape compute_shape(const std::vector<shape>& input) const;
  *      shape compute_shape(const std::vector<shape>& inputs,const std::vector<module_ref>&
  * mod_args) const; argument compute(context& ctx,const shape& output,const std::vector<argument>&
- * input) const; argument compute(const shape& output,const std::vector<argument>& input)
- * const; argument compute(const shape& output,const std::vector<argument>& input,const
+ * input) const; argument compute(const shape& output,const std::vector<argument>& input) const;
+ *      argument compute(const shape& output,const std::vector<argument>& input,const
  * std::vector<module_ref>& module_args,std::function<std::vector<argument>(module_ref&, const
  * std::unordered_map<std::string, argument>&)> run) const; argument compute(context& ctx,const
  * shape& output,const std::vector<argument>& input,const std::vector<module_ref>&

--- a/test/api/test_gpu.cpp
+++ b/test/api/test_gpu.cpp
@@ -37,7 +37,7 @@ TEST_CASE(load_and_run_ctx)
     {
         pp.add(name, migraphx::argument::generate(param_shapes[name]));
     }
-    auto ctx = p.get_context();
+    auto ctx = p.experimental_get_context();
     p.eval(pp);
     ctx.finish();
 }


### PR DESCRIPTION
The `get_context` may change in the future(when we support multi-targets) so make this experimental for now.