### PR TITLE
Expose `add_literal` in C and Python API

### DIFF
--- a/doc/src/reference/py.rst
+++ b/doc/src/reference/py.rst
@@ -148,9 +148,9 @@ module
 
 .. py:method:: add_literal(data)
 
-    Adds constant or literal data of provided shape into the module from python array or numpy array.    
+    Adds constant or literal data of provided shape into the module from python buffer which includes numpy array.    
 
-    :param py::buffer data: Python array or numpy array 
+    :param py::buffer data: Python buffer or numpy array 
     :rtype instruction 
 
 .. py:method:: add_parameter(name, shape)

--- a/doc/src/reference/py.rst
+++ b/doc/src/reference/py.rst
@@ -146,6 +146,14 @@ module
     :param list[module] mod_args: optional list of module arguments to the operator.
     :rtype instruction
 
+.. py:method:: add_literal(s, data)
+
+    Adds constant or literal data of provided shape into the module from python array or numpy array.    
+
+    :param shape s: shape of the literal
+    :param py::buffer data: Python array or numpy array 
+    :rtype instruction 
+
 .. py:method:: add_parameter(name, shape)
     
     Adds a parameter to the module with provided name and shape.

--- a/doc/src/reference/py.rst
+++ b/doc/src/reference/py.rst
@@ -146,11 +146,10 @@ module
     :param list[module] mod_args: optional list of module arguments to the operator.
     :rtype instruction
 
-.. py:method:: add_literal(s, data)
+.. py:method:: add_literal(data)
 
     Adds constant or literal data of provided shape into the module from python array or numpy array.    
 
-    :param shape s: shape of the literal
     :param py::buffer data: Python array or numpy array 
     :rtype instruction 
 

--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -1072,6 +1072,22 @@ migraphx_module_add_instruction_with_mod_args(migraphx_instruction_t* out,
     return api_error_result;
 }
 
+extern "C" migraphx_status migraphx_module_add_literal(migraphx_instruction_t* out,
+                                                       migraphx_module_t module,
+                                                       const_migraphx_shape_t shape,
+                                                       const char* buffer)
+{
+    auto api_error_result = migraphx::try_([&] {
+        if(module == nullptr)
+            MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter module: Null pointer");
+        if(shape == nullptr)
+            MIGRAPHX_THROW(migraphx_status_bad_param, "Bad parameter shape: Null pointer");
+        *out = allocate<migraphx_instruction_t>(
+            (module->object).add_literal((shape->object), (buffer)));
+    });
+    return api_error_result;
+}
+
 extern "C" migraphx_status migraphx_module_add_parameter(migraphx_instruction_t* out,
                                                          migraphx_module_t module,
                                                          const char* name,

--- a/src/api/include/migraphx/migraphx.h
+++ b/src/api/include/migraphx/migraphx.h
@@ -258,6 +258,11 @@ migraphx_status migraphx_module_add_instruction_with_mod_args(migraphx_instructi
                                                               migraphx_instructions_t args,
                                                               migraphx_modules_t module_refs);
 
+migraphx_status migraphx_module_add_literal(migraphx_instruction_t* out,
+                                            migraphx_module_t module,
+                                            const_migraphx_shape_t shape,
+                                            const char* buffer);
+
 migraphx_status migraphx_module_add_parameter(migraphx_instruction_t* out,
                                               migraphx_module_t module,
                                               const char* name,

--- a/src/api/include/migraphx/migraphx.hpp
+++ b/src/api/include/migraphx/migraphx.hpp
@@ -766,7 +766,7 @@ struct module
     instruction add_literal(const migraphx::shape& s, T* buffer)
     {
         migraphx_instruction_t literal_ins;
-        auto buffer_ptr = reinterpret_cast<const char*>(buffer);
+        const auto* buffer_ptr = reinterpret_cast<const char*>(buffer);
         call(&migraphx_module_add_literal, &literal_ins, mm, s.get_handle_ptr(), buffer_ptr);
         return instruction(literal_ins, own{});
     }

--- a/src/api/include/migraphx/migraphx.hpp
+++ b/src/api/include/migraphx/migraphx.hpp
@@ -762,6 +762,12 @@ struct module
         return instruction(op_ins, own{});
     }
 
+    instruction add_literal(const migraphx::shape& s, const char* buffer) {
+        migraphx_instruction_t literal_ins;
+        call(&migraphx_module_add_literal, &literal_ins, mm, s.get_handle_ptr(), buffer);
+        return instruction(literal_ins, own{});
+    }
+
     instruction add_parameter(const std::string& name, shape s)
     {
         migraphx_instruction_t param_ins;

--- a/src/api/include/migraphx/migraphx.hpp
+++ b/src/api/include/migraphx/migraphx.hpp
@@ -762,10 +762,12 @@ struct module
         return instruction(op_ins, own{});
     }
 
-    instruction add_literal(const migraphx::shape& s, const char* buffer)
+    template<typename T>
+    instruction add_literal(const migraphx::shape& s, T* buffer)
     {
         migraphx_instruction_t literal_ins;
-        call(&migraphx_module_add_literal, &literal_ins, mm, s.get_handle_ptr(), buffer);
+        auto buffer_ptr = reinterpret_cast<const char*>(buffer);
+        call(&migraphx_module_add_literal, &literal_ins, mm, s.get_handle_ptr(), buffer_ptr);
         return instruction(literal_ins, own{});
     }
 

--- a/src/api/include/migraphx/migraphx.hpp
+++ b/src/api/include/migraphx/migraphx.hpp
@@ -767,7 +767,7 @@ struct module
     {
         migraphx_instruction_t literal_ins;
         const auto* buffer_ptr = reinterpret_cast<const char*>(buffer);
-        call(&migraphx_module_add_literal, &literal_ins, mm, s.get_handle_ptr(), buffer_ptr);
+        call(&migraphx_module_add_literal, &literal_ins, mm.get(), s.get_handle_ptr(), buffer_ptr);
         return instruction(literal_ins, own{});
     }
 

--- a/src/api/include/migraphx/migraphx.hpp
+++ b/src/api/include/migraphx/migraphx.hpp
@@ -762,7 +762,8 @@ struct module
         return instruction(op_ins, own{});
     }
 
-    instruction add_literal(const migraphx::shape& s, const char* buffer) {
+    instruction add_literal(const migraphx::shape& s, const char* buffer)
+    {
         migraphx_instruction_t literal_ins;
         call(&migraphx_module_add_literal, &literal_ins, mm, s.get_handle_ptr(), buffer);
         return instruction(literal_ins, own{});

--- a/src/api/include/migraphx/migraphx.hpp
+++ b/src/api/include/migraphx/migraphx.hpp
@@ -762,7 +762,7 @@ struct module
         return instruction(op_ins, own{});
     }
 
-    template<typename T>
+    template <typename T>
     instruction add_literal(const migraphx::shape& s, T* buffer)
     {
         migraphx_instruction_t literal_ins;

--- a/src/api/migraphx.py
+++ b/src/api/migraphx.py
@@ -212,7 +212,9 @@ def module(h):
                         module_refs='std::vector<migraphx::module*>'),
              fname='add_instruction',
              returns='migraphx::instruction_ref')
-    h.method('add_literal', api.params(shape='const migraphx::shape&', buffer='const char*'), returns='migraphx::instruction_ref')
+    h.method('add_literal',
+             api.params(shape='const migraphx::shape&', buffer='const char*'),
+             returns='migraphx::instruction_ref')
     h.method('add_parameter',
              api.params(name='const char*', shape='const migraphx::shape&'),
              returns='migraphx::instruction_ref')

--- a/src/api/migraphx.py
+++ b/src/api/migraphx.py
@@ -212,6 +212,7 @@ def module(h):
                         module_refs='std::vector<migraphx::module*>'),
              fname='add_instruction',
              returns='migraphx::instruction_ref')
+    h.method('add_literal', api.params(shape='const migraphx::shape&', buffer='const char*'), returns='migraphx::instruction_ref')
     h.method('add_parameter',
              api.params(name='const char*', shape='const migraphx::shape&'),
              returns='migraphx::instruction_ref')

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -277,7 +277,7 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             "add_literal",
             [](migraphx::module& mm, py::buffer data) {
                 py::buffer_info info = data.request();
-                auto literal_shape = to_shape(info);
+                auto literal_shape   = to_shape(info);
                 return mm.add_literal(literal_shape, reinterpret_cast<char*>(info.ptr));
             },
             py::arg("data"))

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -276,12 +276,12 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             py::arg("mod_args") = std::vector<migraphx::module*>{})
         .def(
             "add_literal",
-            [](migraphx::module& mm, const migraphx::shape& s, py::buffer b) {
-                py::buffer_info info = b.request();
+            [](migraphx::module& mm, const migraphx::shape& s, py::buffer data) {
+                py::buffer_info info = data.request();
                 return mm.add_literal(s, reinterpret_cast<char*>(info.ptr));
             },
             py::arg("s"),
-            py::arg("b"))
+            py::arg("data"))
         .def(
             "add_parameter",
             [](migraphx::module& mm, const std::string& name, const migraphx::shape shape) {

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -1,5 +1,4 @@
 
-#include <pybind11/detail/common.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -275,11 +275,11 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             py::arg("mod_args") = std::vector<migraphx::module*>{})
         .def(
             "add_literal",
-            [](migraphx::module& mm, const migraphx::shape& s, py::buffer data) {
+            [](migraphx::module& mm, py::buffer data) {
                 py::buffer_info info = data.request();
-                return mm.add_literal(s, reinterpret_cast<char*>(info.ptr));
+                auto literal_shape = to_shape(info);
+                return mm.add_literal(literal_shape, reinterpret_cast<char*>(info.ptr));
             },
-            py::arg("s"),
             py::arg("data"))
         .def(
             "add_parameter",

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -1,4 +1,5 @@
 
+#include <pybind11/detail/common.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
@@ -273,6 +274,10 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             py::arg("op"),
             py::arg("args"),
             py::arg("mod_args") = std::vector<migraphx::module*>{})
+        .def("add_literal", [](migraphx::module& mm, const migraphx::shape& s, py::buffer b) {
+            py::buffer_info info = b.request();
+            return mm.add_literal(s, reinterpret_cast<char*>(info.ptr));
+        }, py::arg("s"), py::arg("b"))
         .def(
             "add_parameter",
             [](migraphx::module& mm, const std::string& name, const migraphx::shape shape) {

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -274,10 +274,14 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
             py::arg("op"),
             py::arg("args"),
             py::arg("mod_args") = std::vector<migraphx::module*>{})
-        .def("add_literal", [](migraphx::module& mm, const migraphx::shape& s, py::buffer b) {
-            py::buffer_info info = b.request();
-            return mm.add_literal(s, reinterpret_cast<char*>(info.ptr));
-        }, py::arg("s"), py::arg("b"))
+        .def(
+            "add_literal",
+            [](migraphx::module& mm, const migraphx::shape& s, py::buffer b) {
+                py::buffer_info info = b.request();
+                return mm.add_literal(s, reinterpret_cast<char*>(info.ptr));
+            },
+            py::arg("s"),
+            py::arg("b"))
         .def(
             "add_parameter",
             [](migraphx::module& mm, const std::string& name, const migraphx::shape shape) {

--- a/test/api/test_module_construct.cpp
+++ b/test/api/test_module_construct.cpp
@@ -3,7 +3,7 @@
 #include <migraphx/migraphx.hpp>
 #include "test.hpp"
 
-TEST_CASE(add_op)
+TEST_CASE(add_literals)
 {
     migraphx::program p;
     migraphx::module m = p.get_main_module();

--- a/test/api/test_module_construct.cpp
+++ b/test/api/test_module_construct.cpp
@@ -8,18 +8,16 @@ TEST_CASE(add_op)
     migraphx::program p;
     migraphx::module m = p.get_main_module();
     migraphx::shape param_shape{migraphx_shape_float_type, {3, 3}};
-    auto x      = m.add_parameter("x", param_shape);
-    auto y      = m.add_parameter("y", param_shape);
+    std::vector<float> x_values(9, 1);
+    auto x = m.add_literal(param_shape, reinterpret_cast<char*>(x_values.data()));
+    std::vector<float> y_values(9, -1);
+    auto y      = m.add_literal(param_shape, reinterpret_cast<char*>(y_values.data()));
     auto add_op = migraphx::operation("add");
     auto r      = m.add_instruction(add_op, {x, y});
     m.add_return({r});
     // run on ref target
     p.compile(migraphx::target("ref"));
     migraphx::program_parameters pp;
-    std::vector<float> x_data(9, 1);
-    std::vector<float> y_data(9, -1);
-    pp.add("x", migraphx::argument(param_shape, x_data.data()));
-    pp.add("y", migraphx::argument(param_shape, y_data.data()));
     auto outputs = p.eval(pp);
     auto output  = outputs[0];
     std::vector<float> expected(9, 0);

--- a/test/api/test_module_construct.cpp
+++ b/test/api/test_module_construct.cpp
@@ -9,11 +9,9 @@ TEST_CASE(add_op)
     migraphx::module m = p.get_main_module();
     migraphx::shape param_shape{migraphx_shape_float_type, {3, 3}};
     std::vector<float> x_values(9, 1);
-    // cppcheck-suppress invalidPointerCast
-    auto x = m.add_literal(param_shape, reinterpret_cast<char*>(x_values.data()));
+    auto x = m.add_literal(param_shape, x_values.data());
     std::vector<float> y_values(9, -1);
-    // cppcheck-suppress invalidPointerCast
-    auto y      = m.add_literal(param_shape, reinterpret_cast<char*>(y_values.data()));
+    auto y      = m.add_literal(param_shape, y_values.data());
     auto add_op = migraphx::operation("add");
     auto r      = m.add_instruction(add_op, {x, y});
     m.add_return({r});

--- a/test/api/test_module_construct.cpp
+++ b/test/api/test_module_construct.cpp
@@ -9,10 +9,10 @@ TEST_CASE(add_op)
     migraphx::module m = p.get_main_module();
     migraphx::shape param_shape{migraphx_shape_float_type, {3, 3}};
     std::vector<float> x_values(9, 1);
-    //cppcheck-suppress invalidPointerCast
+    // cppcheck-suppress invalidPointerCast
     auto x = m.add_literal(param_shape, reinterpret_cast<char*>(x_values.data()));
     std::vector<float> y_values(9, -1);
-    //cppcheck-suppress invalidPointerCast
+    // cppcheck-suppress invalidPointerCast
     auto y      = m.add_literal(param_shape, reinterpret_cast<char*>(y_values.data()));
     auto add_op = migraphx::operation("add");
     auto r      = m.add_instruction(add_op, {x, y});

--- a/test/api/test_module_construct.cpp
+++ b/test/api/test_module_construct.cpp
@@ -9,8 +9,10 @@ TEST_CASE(add_op)
     migraphx::module m = p.get_main_module();
     migraphx::shape param_shape{migraphx_shape_float_type, {3, 3}};
     std::vector<float> x_values(9, 1);
+    //cppcheck-suppress invalidPointerCast
     auto x = m.add_literal(param_shape, reinterpret_cast<char*>(x_values.data()));
     std::vector<float> y_values(9, -1);
+    //cppcheck-suppress invalidPointerCast
     auto y      = m.add_literal(param_shape, reinterpret_cast<char*>(y_values.data()));
     auto add_op = migraphx::operation("add");
     auto r      = m.add_instruction(add_op, {x, y});

--- a/test/py/test_module_construct.py
+++ b/test/py/test_module_construct.py
@@ -1,9 +1,4 @@
 import migraphx, array, sys
-try:
-    import numpy as np
-except:
-    sys.exit()
-
 
 def create_buffer(t, data, shape):
     a = array.array(t, data)

--- a/test/py/test_module_construct.py
+++ b/test/py/test_module_construct.py
@@ -19,17 +19,14 @@ def test_add_op():
     p = migraphx.program()
     mm = p.get_main_module()
     param_shape = migraphx.shape(lens=[3, 3], type="float")
-    # test add_literal with python array
-    x = mm.add_literal(param_shape, create_buffer('f', [1.0] * 9, (3, 3)))
-    # test add_literal with numpy array
-    y = mm.add_literal(param_shape, np.ones((3, 3), dtype='float32'))
+    x = mm.add_literal(create_buffer('f', [1.0] * 9, (3, 3)))
+    y = mm.add_literal(create_buffer('f', [2.0] * 9, (3, 3)))
     add_op = mm.add_instruction(migraphx.op("add"), [x, y])
     mm.add_return([add_op])
     p.compile(migraphx.get_target("ref"))
     params = {}
     output = p.run(params)[-1].tolist()
-    assert output == list(2 * np.ones((9), dtype='float32'))
-
+    assert output == list([3.0] * 9)
 
 def test_if_then_else():
     param_shape = migraphx.shape(lens=[3, 3], type="float")

--- a/test/py/test_module_construct.py
+++ b/test/py/test_module_construct.py
@@ -6,7 +6,6 @@ except:
     sys.exit()
 
 
-
 def test_add_op():
     p = migraphx.program()
     mm = p.get_main_module()
@@ -19,6 +18,7 @@ def test_add_op():
     params = {}
     output = p.run(params)[-1].tolist()
     assert output == list(2 * np.ones((9), dtype='float32'))
+
 
 def test_if_then_else():
     param_shape = migraphx.shape(lens=[3, 3], type="float")

--- a/test/py/test_module_construct.py
+++ b/test/py/test_module_construct.py
@@ -28,6 +28,7 @@ def test_add_op():
     output = p.run(params)[-1].tolist()
     assert output == list([3.0] * 9)
 
+
 def test_if_then_else():
     param_shape = migraphx.shape(lens=[3, 3], type="float")
     cond_shape = migraphx.shape(type="bool", lens=[1], strides=[0])

--- a/test/py/test_module_construct.py
+++ b/test/py/test_module_construct.py
@@ -4,6 +4,7 @@ try:
 except:
     sys.exit()
 
+
 def create_buffer(t, data, shape):
     a = array.array(t, data)
     if sys.version_info >= (3, 0):
@@ -13,12 +14,13 @@ def create_buffer(t, data, shape):
         m = memoryview(a.tostring())
         return m
 
+
 def test_add_op():
     p = migraphx.program()
     mm = p.get_main_module()
     param_shape = migraphx.shape(lens=[3, 3], type="float")
     # test add_literal with python array
-    x = mm.add_literal(param_shape, create_buffer('f', [1.0]*9, (3, 3)))
+    x = mm.add_literal(param_shape, create_buffer('f', [1.0] * 9, (3, 3)))
     # test add_literal with numpy array
     y = mm.add_literal(param_shape, np.ones((3, 3), dtype='float32'))
     add_op = mm.add_instruction(migraphx.op("add"), [x, y])

--- a/test/py/test_module_construct.py
+++ b/test/py/test_module_construct.py
@@ -1,16 +1,25 @@
-import sys
-import migraphx
+import migraphx, array, sys
 try:
     import numpy as np
 except:
     sys.exit()
 
+def create_buffer(t, data, shape):
+    a = array.array(t, data)
+    if sys.version_info >= (3, 0):
+        m = memoryview(a.tobytes())
+        return m.cast(t, shape)
+    else:
+        m = memoryview(a.tostring())
+        return m
 
 def test_add_op():
     p = migraphx.program()
     mm = p.get_main_module()
     param_shape = migraphx.shape(lens=[3, 3], type="float")
-    x = mm.add_literal(param_shape, np.ones((3, 3), dtype='float32'))
+    # test add_literal with python array
+    x = mm.add_literal(param_shape, create_buffer('f', [1.0]*9, (3, 3)))
+    # test add_literal with numpy array
     y = mm.add_literal(param_shape, np.ones((3, 3), dtype='float32'))
     add_op = mm.add_instruction(migraphx.op("add"), [x, y])
     mm.add_return([add_op])

--- a/test/py/test_module_construct.py
+++ b/test/py/test_module_construct.py
@@ -14,7 +14,6 @@ def create_buffer(t, data, shape):
 def test_add_op():
     p = migraphx.program()
     mm = p.get_main_module()
-    param_shape = migraphx.shape(lens=[3, 3], type="float")
     x = mm.add_literal(create_buffer('f', [1.0] * 9, (3, 3)))
     y = mm.add_literal(create_buffer('f', [2.0] * 9, (3, 3)))
     add_op = mm.add_instruction(migraphx.op("add"), [x, y])

--- a/test/py/test_module_construct.py
+++ b/test/py/test_module_construct.py
@@ -5,7 +5,7 @@ def create_buffer(t, data, shape):
     a = array.array(t, data)
     m = memoryview(a.tobytes())
     return m.cast(t, shape)
-    
+
 
 def test_add_op():
     p = migraphx.program()

--- a/test/py/test_module_construct.py
+++ b/test/py/test_module_construct.py
@@ -1,23 +1,24 @@
+import sys
 import migraphx
+try:
+    import numpy as np
+except:
+    sys.exit()
+
 
 
 def test_add_op():
     p = migraphx.program()
     mm = p.get_main_module()
     param_shape = migraphx.shape(lens=[3, 3], type="float")
-    x = mm.add_parameter("x", param_shape)
-    y = mm.add_parameter("y", param_shape)
+    x = mm.add_literal(param_shape, np.ones((3, 3), dtype='float32'))
+    y = mm.add_literal(param_shape, np.ones((3, 3), dtype='float32'))
     add_op = mm.add_instruction(migraphx.op("add"), [x, y])
     mm.add_return([add_op])
     p.compile(migraphx.get_target("ref"))
     params = {}
-    params["x"] = migraphx.generate_argument(param_shape)
-    params["y"] = migraphx.generate_argument(param_shape)
     output = p.run(params)[-1].tolist()
-    assert output == [
-        a + b for a, b in zip(params["x"].tolist(), params["y"].tolist())
-    ]
-
+    assert output == list(2 * np.ones((9), dtype='float32'))
 
 def test_if_then_else():
     param_shape = migraphx.shape(lens=[3, 3], type="float")

--- a/test/py/test_module_construct.py
+++ b/test/py/test_module_construct.py
@@ -3,13 +3,9 @@ import migraphx, array, sys
 
 def create_buffer(t, data, shape):
     a = array.array(t, data)
-    if sys.version_info >= (3, 0):
-        m = memoryview(a.tobytes())
-        return m.cast(t, shape)
-    else:
-        m = memoryview(a.tostring())
-        return m
-
+    m = memoryview(a.tobytes())
+    return m.cast(t, shape)
+    
 
 def test_add_op():
     p = migraphx.program()
@@ -65,5 +61,6 @@ def test_if_then_else():
 
 
 if __name__ == "__main__":
-    test_add_op()
+    if sys.version_info >= (3, 0):
+        test_add_op()
     test_if_then_else()

--- a/test/py/test_module_construct.py
+++ b/test/py/test_module_construct.py
@@ -1,5 +1,6 @@
 import migraphx, array, sys
 
+
 def create_buffer(t, data, shape):
     a = array.array(t, data)
     if sys.version_info >= (3, 0):

--- a/test/py/test_numpy.py
+++ b/test/py/test_numpy.py
@@ -4,6 +4,7 @@ try:
 except:
     sys.exit()
 
+
 def test_add_op():
     p = migraphx.program()
     mm = p.get_main_module()
@@ -16,6 +17,7 @@ def test_add_op():
     params = {}
     output = p.run(params)[-1].tolist()
     assert output == list(3 * np.ones((9), dtype='float32'))
+
 
 if __name__ == "__main__":
     test_add_op()

--- a/test/py/test_numpy.py
+++ b/test/py/test_numpy.py
@@ -1,0 +1,21 @@
+import migraphx, sys, array
+try:
+    import numpy as np
+except:
+    sys.exit()
+
+def test_add_op():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    param_shape = migraphx.shape(lens=[3, 3], type="float")
+    x = mm.add_literal(np.ones((3, 3), dtype='float32'))
+    y = mm.add_literal(2 * np.ones((3, 3), dtype='float32'))
+    add_op = mm.add_instruction(migraphx.op("add"), [x, y])
+    mm.add_return([add_op])
+    p.compile(migraphx.get_target("ref"))
+    params = {}
+    output = p.run(params)[-1].tolist()
+    assert output == list(3 * np.ones((9), dtype='float32'))
+
+if __name__ == "__main__":
+    test_add_op()

--- a/test/py/test_numpy.py
+++ b/test/py/test_numpy.py
@@ -1,4 +1,4 @@
-import migraphx, sys, array
+import migraphx, sys
 try:
     import numpy as np
 except:
@@ -8,7 +8,6 @@ except:
 def test_add_op():
     p = migraphx.program()
     mm = p.get_main_module()
-    param_shape = migraphx.shape(lens=[3, 3], type="float")
     x = mm.add_literal(np.ones((3, 3), dtype='float32'))
     y = mm.add_literal(2 * np.ones((3, 3), dtype='float32'))
     add_op = mm.add_instruction(migraphx.op("add"), [x, y])


### PR DESCRIPTION
This PR simply exposes the method.  It doesn't require exposing full literal class into the API. 