### PR TITLE
Improve eliminate contiguous pass

### DIFF
--- a/src/eliminate_contiguous.cpp
+++ b/src/eliminate_contiguous.cpp
@@ -105,14 +105,14 @@ void eliminate_contiguous::apply(module& m) const
         }
     }
 
-    //Perform evaluations in parallel
+    // Perform evaluations in parallel
     std::vector<argument> literals(prevs.size());
-    par_for(inputs.size(), 1, [&](const auto i){
-        auto c = op::contiguous{};
+    par_for(inputs.size(), 1, [&](const auto i) {
+        auto c      = op::contiguous{};
         literals[i] = c.compute(c.compute_shape({prevs[i]->get_shape()}), {prevs[i]->eval()});
     });
 
-    for (size_t i = 0; i < prevs.size(); i++)
+    for(size_t i = 0; i < prevs.size(); i++)
     {
         auto l = m.add_literal(literals[i].get_shape(), literals[i].data());
         m.replace_instruction(inputs[i], l);


### PR DESCRIPTION
Following up on issue #1166 and PR #1220.  Using the same approach as in #1220 for parallelizing the eval calls, we can significantly reduce the time spent on eliminate_contiguous pass.

Applying this on top of changes in #1220 yields:
`wget https://zenodo.org/record/3733910/files/model.onnx`
`time AMDMIGraphX/build/bin/migraphx-driver compile model.onnx --fill1 input_ids --fill1 input_mask --fill1 segment_ids --batch 16 --fp16`

real    9m43.252s
user    25m5.624s
sys     1m41.403s
 