### PR TITLE
Fix compilation on Debian bookworm/sid

### DIFF
--- a/cmake/Embed.cmake
+++ b/cmake/Embed.cmake
@@ -39,6 +39,8 @@ function(generate_embed_source EMBED_NAME)
 
     file(WRITE "${PARSE_HEADER}" "
 #include <unordered_map>
+#include <string>
+#include <utility>
 const std::unordered_map<std::string, std::pair<const char*,const char*>>& ${EMBED_NAME}();
 ")
 


### PR DESCRIPTION
I had clang++ complaining about not knowing about std::string until I implement this.