### PR TITLE
Group code objects by kernel name in perf report summary

### DIFF
--- a/src/targets/gpu/include/migraphx/gpu/code_object_op.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/code_object_op.hpp
@@ -34,6 +34,10 @@ struct code_object_op
                     f(self.output, "output"));
     }
 
+    value attributes() const { return {{"group", group()}}; }
+
+    std::string group() const { return "gpu::code_object::" + symbol_name; }
+
     std::string name() const { return "gpu::code_object"; }
     shape compute_shape(std::vector<shape> inputs) const;
     argument


### PR DESCRIPTION
Bert now show a summary like this:

```
Summary:
gpu::gemm: 8.582ms, 65%
gpu::triadd_layernorm: 0.804272ms, 7%
gpu::softmax: 0.794769ms, 6%
gpu::code_object::add_kernel: 0.646121ms, 5%
gpu::code_object::mul_kernel: 0.623822ms, 5%
gpu::code_object::add_mul_erf_add_mul_mul_kernel: 0.498902ms, 4%
gpu::code_object::mul_add_kernel: 0.478352ms, 4%
gpu::contiguous: 0.333988ms, 3%
hip::hip_copy_literal: 0.162432ms, 2%
load: 0.125854ms, 1%
gpu::gather: 0.0729777ms, 1%
gpu::code_object::convert_kernel: 0.049062ms, 1%
multibroadcast: 0.044116ms, 1%
gpu::layernorm: 0.032414ms, 1%
transpose: 0.0297579ms, 1%
slice: 0.0296842ms, 1%
gpu::code_object::add_tanh_convert_kernel: 0.0249871ms, 1%
reshape: 0.0216463ms, 1%
@param: 0.00238ms, 1%
check_context::migraphx::version_1::gpu::context: 0.000734ms, 1%
hip::hip_allocate_memory: 0.00047ms, 1%
```
