### PR TITLE
std::distance bugfix in instruction::valid

### DIFF
--- a/src/include/migraphx/instruction.hpp
+++ b/src/include/migraphx/instruction.hpp
@@ -42,7 +42,7 @@ struct instruction
 
     friend bool operator==(const instruction& i, instruction_ref ref);
 
-    bool valid(instruction_ref start, bool check_order = false) const;
+    bool valid(const module& m, bool check_order = false) const;
 
     bool valid() const;
 

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -76,27 +76,16 @@ bool operator==(const instruction& i, instruction_ref ref)
 
 static void debug_name(std::ostream& os, const instruction& ins);
 
-bool instruction::valid(instruction_ref start, bool check_order) const
+bool instruction::valid(const module& m, bool check_order) const
 {
-    // Need this lambda because std::distance has undefined behavior when comparing iterators of
-    // from different ranges
-    auto ins_dist = [](instruction_ref s, instruction_ref e) {
-        int dist = 0;
-        while((*s) != (*e))
-        {
-            ++s;
-            ++dist;
-        }
-        return dist;
-    };
-
     return valid() && std::all_of(arguments.begin(), arguments.end(), [&](instruction_ref i) {
                auto self = std::find(i->outputs().begin(), i->outputs().end(), *this);
                bool ret  = self != i->outputs().end();
-               if(check_order)
+               // assume argument is in previous module if m.has_instruction(i) is false
+               if(check_order and m.has_instruction(i))
                {
-                   // arguments for this instruction before this instruction
-                   ret = ret and (ins_dist(start, i) < ins_dist(start, *self));
+                   // check arguments for this instruction before this instruction
+                   ret = ret and (std::distance(m.begin(), i) < std::distance(m.begin(), *self));
                }
                return ret;
            });

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -184,7 +184,7 @@ instruction_ref module::insert_instruction(instruction_ref ins,
     shape r     = compute_shape(op, args);
     auto result = impl->insert(ins, {op, r, std::move(args)});
     instruction::backreference(result);
-    assert(result->valid(begin()));
+    assert(result->valid(*this));
     return result;
 }
 
@@ -206,7 +206,7 @@ instruction_ref module::insert_instruction(instruction_ref ins,
     auto out_shape = compute_shape(op, args, module_args);
     auto result    = impl->insert(ins, {op, out_shape, std::move(args), std::move(module_args)});
     instruction::backreference(result);
-    assert(result->valid(begin()));
+    assert(result->valid(*this));
     return result;
 }
 
@@ -219,7 +219,7 @@ instruction_ref module::replace_instruction(instruction_ref ins,
 
     shape r = compute_shape(op, args);
     instruction::replace(ins, op, r, std::move(args));
-    assert(ins->valid(begin()));
+    assert(ins->valid(*this));
     return ins;
 }
 
@@ -232,7 +232,7 @@ instruction_ref module::replace_instruction(instruction_ref ins,
     assert(not starts_with(op.name(), "@"));
     auto out_shape = compute_shape(op, args, module_args);
     instruction::replace(ins, op, out_shape, std::move(args), std::move(module_args));
-    assert(ins->valid(begin()));
+    assert(ins->valid(*this));
     return ins;
 }
 
@@ -261,7 +261,7 @@ instruction_ref module::replace_instruction(instruction_ref ins, instruction_ref
         {
             instruction::replace_argument(out, ins, rep);
         }
-        assert(out->valid(begin()));
+        assert(out->valid(*this));
     }
     // Replacement should not be dead code unless its the last instruction
     assert(!rep->outputs().empty() or rep == std::prev(end()));
@@ -269,8 +269,8 @@ instruction_ref module::replace_instruction(instruction_ref ins, instruction_ref
     assert(ins->outputs().empty() or std::all_of(ins->outputs().begin(),
                                                  ins->outputs().end(),
                                                  [&](auto i) { return i == rep; }));
-    assert(ins->valid(begin()));
-    assert(rep->valid(begin()));
+    assert(ins->valid(*this));
+    assert(rep->valid(*this));
     return rep;
 }
 
@@ -383,7 +383,7 @@ instruction_ref module::add_return(std::vector<instruction_ref> args)
     impl->push_back({builtin::returns{}, {}, std::move(args)});
     auto result = std::prev(impl->instructions.end());
     instruction::backreference(result);
-    assert(result->valid(begin()));
+    assert(result->valid(*this));
 
     return result;
 }
@@ -397,7 +397,7 @@ instruction_ref module::replace_return(std::vector<instruction_ref> args)
 
     shape r = compute_shape(last->get_operator(), args);
     instruction::replace(last, last->get_operator(), r, std::move(args));
-    assert(last->valid(begin()));
+    assert(last->valid(*this));
 
     return last;
 }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -511,7 +511,7 @@ instruction_ref module::validate() const
             bool check_order = std::all_of(inputs.begin(), inputs.end(), [&](auto in) {
                 return contains(impl->instructions, *in);
             });
-            return !i.valid(impl->instructions.begin(), check_order);
+            return !i.valid(*this, check_order);
         });
 }
 


### PR DESCRIPTION
* Fixes hanging issue when an argument to an instruction is from another module.
  * Assumes the argument is ordered correctly (before the current one) and does not check the instruction distance.
* Allows SSD-Resnet34 to compile
  * Model still stuck on allocation due to extremely high max_iterations for the loop instruction