### PR TITLE
Add tests for C API

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -46,7 +46,7 @@ else
 fi
 
 # do the formatting
-for file in $(git diff-index --cached --name-only $against | grep -E '\.h$|\.hpp$|\.cpp$|\.cl$|\.h\.in$|\.hpp\.in$|\.cpp\.in$|\.py$')
+for file in $(git diff-index --cached --name-only $against | grep -E '\.h$|\.hpp$|\.cpp$|\.cl$|\.c$|\.h\.in$|\.hpp\.in$|\.cpp\.in$|\.py$')
 do
     if [ -e "$file" ]
     then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,6 +133,7 @@ jobs:
               -o -iname '*.hpp.in' \
               -o -iname '*.cpp.in' \
               -o -iname '*.cl' \
+              -o -iname '*.c' \
           | grep -v 'build/' \
           | xargs -n 1 -P 1 -I{} -t sh -c 'clang-format-10 -style=file {} | diff - {}'
           find . -iname '*.py' \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ endif()
 set(MIGRAPHX_ENABLE_CPU Off CACHE BOOL "")
 
 set(CMAKE_CXX_STANDARD_DEFAULT "")
-add_compile_options(-std=c++17)
+add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=c++17>)
 
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
     set(CONFIGURE_DEPENDS)

--- a/src/api/include/migraphx/migraphx.h
+++ b/src/api/include/migraphx/migraphx.h
@@ -25,6 +25,7 @@
 #define MIGRAPHX_GUARD_C_API_MIGRAPHX_H
 
 #include <stdlib.h>
+#include <stdbool.h>
 
 // Add new types here
 // clang-format off

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -41,6 +41,7 @@ add_api_test(module_construct test_module_construct.cpp ${TEST_ONNX_DIR})
 add_api_test(ref test_cpu.cpp ${TEST_ONNX_DIR})
 add_api_test(save_load test_save_load.cpp ${TEST_ONNX_DIR})
 add_api_test(op test_op_construct.cpp ${TEST_ONNX_DIR})
+add_api_test(c_op test_op_construct.c ${TEST_ONNX_DIR})
 add_api_test(tf_parser test_tf_parser.cpp ${TEST_TF_DIR})
 # GPU-based tests
 if(MIGRAPHX_ENABLE_GPU)

--- a/test/api/test_op_construct.c
+++ b/test/api/test_op_construct.c
@@ -26,11 +26,11 @@
 
 void expect_equal(const char* x, const char* y)
 {
-    if (strcmp(x, y) != 0)
+    if(strcmp(x, y) != 0)
         abort();
 }
 
-int main() 
+int main()
 {
     char name[1024];
     migraphx_operation_t op;

--- a/test/api/test_op_construct.c
+++ b/test/api/test_op_construct.c
@@ -30,7 +30,8 @@ void expect_equal(const char* x, const char* y)
         abort();
 }
 
-int main() {
+int main() 
+{
     char name[1024];
     migraphx_operation_t op;
     migraphx_operation_create(&op, "add", 0);

--- a/test/api/test_op_construct.c
+++ b/test/api/test_op_construct.c
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2022 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <migraphx/migraphx.h>
+#include <string.h>
+
+void expect_equal(const char* x, const char* y)
+{
+    if (strcmp(x, y) != 0)
+        abort();
+}
+
+int main() {
+    char name[1024];
+    migraphx_operation_t op;
+    migraphx_operation_create(&op, "add", 0);
+    migraphx_operation_name(name, 1024, op);
+    migraphx_operation_destroy(op);
+    expect_equal(name, "add");
+}

--- a/tools/api/migraphx.h
+++ b/tools/api/migraphx.h
@@ -25,6 +25,7 @@
 #define MIGRAPHX_GUARD_C_API_MIGRAPHX_H
 
 #include <stdlib.h>
+#include <stdbool.h>
 
 // Add new types here
 // clang-format off


### PR DESCRIPTION
This will ensure that `migraphx.h` can be included from a C compiler, and check that the C API can be called. This includes `stdbool.h` which is needed when using `bool` from C. 