### PR TITLE
Simplify algebra for  x / 1 operations

### DIFF
--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -853,10 +853,7 @@ struct find_div_const
 
 struct find_unit_div_const
 {
-    auto matcher() const
-    {
-        return match::name("div")(match::arg(1)(match::has_value(1.0f)));
-    }
+    auto matcher() const { return match::name("div")(match::arg(1)(match::has_value(1.0f))); }
 
     void apply(module& m, const match::matcher_result& r) const
     {

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -851,6 +851,22 @@ struct find_div_const
     }
 };
 
+struct find_unit_div_const
+{
+    auto matcher() const
+    {
+        return match::name("div")(match::arg(1)(match::has_value(1.0f)));
+    }
+
+    void apply(module& m, const match::matcher_result& r) const
+    {
+        auto ins  = r.result;
+        auto args = ins->inputs();
+
+        m.replace_instruction(ins, args.front());
+    }
+};
+
 struct find_sub_const
 {
     auto matcher() const
@@ -1048,6 +1064,7 @@ void simplify_algebra::apply(module& m) const
                             find_mul_conv{},
                             find_mul_slice_conv{},
                             find_mul_add{},
+                            find_unit_div_const{},
                             find_div_const{},
                             find_sub_const{},
                             find_rsqrt{},

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -740,14 +740,15 @@ TEST_CASE(simplify_unit_div_const)
     {
         auto x    = m1.add_parameter("x", {migraphx::shape::int32_type, {1}});
         auto unit = m1.add_literal(1);
-        m1.add_instruction(migraphx::make_op("div"), x, unit);
+        auto div  = m1.add_instruction(migraphx::make_op("div"), x, unit);
+        m1.add_return({div});
     }
     run_pass(m1);
 
     migraphx::module m2;
     {
         auto x = m2.add_parameter("x", {migraphx::shape::int32_type, {1}});
-        m2.add_instruction(migraphx::make_op("identity"), x);
+        m2.add_return({x});
     }
 
     EXPECT(m1 == m2);

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -734,6 +734,25 @@ TEST_CASE(simplify_div_const)
     EXPECT(m1 == m2);
 }
 
+TEST_CASE(simplify_unit_div_const)
+{
+    migraphx::module m1;
+    {
+        auto x    = m1.add_parameter("x", {migraphx::shape::int32_type, {1}});
+        auto unit = m1.add_literal(1);
+        m1.add_instruction(migraphx::make_op("div"), x, unit);
+    }
+    run_pass(m1);
+
+    migraphx::module m2;
+    {
+        auto x = m2.add_parameter("x", {migraphx::shape::int32_type, {1}});
+        m2.add_instruction(migraphx::make_op("identity"), x);
+    }
+
+    EXPECT(m1 == m2);
+}
+
 TEST_CASE(simplify_sub_const)
 {
     migraphx::module m1;


### PR DESCRIPTION
Done to satisfy simplifications specified by #1236 .  Just replace every  parameter divided by 1 with itself. It's assumed that the eliminate_identity() pass will handle generated identity operators in our run_pass()