### PR TITLE
Add support for division by zero errors

### DIFF
--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -851,6 +851,16 @@ struct find_div_const
     }
 };
 
+struct find_zero_div_const
+{
+    auto matcher() const { return match::name("div")(match::arg(1)(match::has_value(0.0f))); }
+
+    void apply(module& m, const match::matcher_result& r) const
+    {
+        MIGRAPHX_THROW("ERROR: Matched division by zero in pass");
+    }
+};
+
 struct find_unit_div_const
 {
     auto matcher() const { return match::name("div")(match::arg(1)(match::has_value(1.0f))); }
@@ -1061,6 +1071,7 @@ void simplify_algebra::apply(module& m) const
                             find_mul_conv{},
                             find_mul_slice_conv{},
                             find_mul_add{},
+                            find_zero_div_const{},
                             find_unit_div_const{},
                             find_div_const{},
                             find_sub_const{},

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -753,6 +753,27 @@ TEST_CASE(simplify_unit_div_const)
     EXPECT(m1 == m2);
 }
 
+TEST_CASE(simplify_zero_div_const)
+{
+    migraphx::module m1;
+    {
+        auto x    = m1.add_parameter("x", {migraphx::shape::int32_type, {1}});
+        auto unit = m1.add_literal(0);
+        m1.add_instruction(migraphx::make_op("div"), x, unit);
+    }
+
+    bool result = false;
+    try
+    {
+        run_pass(m1);
+    }
+    catch(const std::runtime_error& e)
+    {
+        result = true;
+    }
+    EXPECT(result);
+}
+
 TEST_CASE(simplify_sub_const)
 {
     migraphx::module m1;


### PR DESCRIPTION
Throw an exception when this occurs to indicate our simpliciation passes resulted in a singularity somewhere. Related to #1236