### PR TITLE
Simplifiy Algebra for x*(-1) operations to simply negative x

### DIFF
--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -870,6 +870,26 @@ struct find_unit_mult_const
     }
 };
 
+struct find_neg_unit_mult_const
+{
+    auto matcher() const
+    {
+        return match::name("mul")(
+            match::either_arg(0, 1)(match::has_value(-1.0f), match::any().bind("x")));
+    }
+
+    void apply(module& m, const match::matcher_result& r) const
+    {
+        auto ins  = r.result;
+        auto args = ins->inputs();
+
+        auto c_in = r.instructions["x"];
+
+        auto neg = m.add_instruction(make_op("neg"), c_in);
+        m.replace_instruction(ins, neg);
+    }
+};
+
 struct find_sub_const
 {
     auto matcher() const
@@ -1070,6 +1090,7 @@ void simplify_algebra::apply(module& m) const
                             find_div_const{},
                             find_sub_const{},
                             find_rsqrt{},
+                            find_neg_unit_mult_const{},
                             find_unit_mult_const{},
                             find_concat_op{},
                             find_split_concat{},

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -761,6 +761,33 @@ TEST_CASE(simplify_unit_mult_const)
     EXPECT((m1 == m3) && (m1 == m2));
 }
 
+TEST_CASE(simplify_neg_unit_mult_const)
+{
+    migraphx::module m1;
+    {
+        auto x    = m1.add_parameter("x", {migraphx::shape::int32_type, {1}});
+        auto unit = m1.add_literal(-1);
+        m1.add_instruction(migraphx::make_op("mul"), x, unit);
+    }
+    run_pass(m1);
+
+    migraphx::module m2;
+    {
+        auto x = m2.add_parameter("x", {migraphx::shape::int32_type, {1}});
+        m2.add_instruction(migraphx::make_op("neg"), x);
+    }
+
+    migraphx::module m3;
+    {
+        auto unit = m3.add_literal(-1);
+        auto x    = m3.add_parameter("x", {migraphx::shape::int32_type, {1}});
+        m3.add_instruction(migraphx::make_op("mul"), unit, x);
+    }
+    run_pass(m3);
+
+    EXPECT((m1 == m3) && (m1 == m2));
+}
+
 TEST_CASE(simplify_sub_const)
 {
     migraphx::module m1;


### PR DESCRIPTION
Save a multiply operation with that of a negation of  input parameter x. Suggested improvement via #1236

Not sure if we want this in right away. Trying this change ontop of the previous multiply by 1 change results in not much of a change in total time running:

MIOPEN_FIND_ENFORCE=3 bin/driver perf    for resnet50-v2-7

