### PR TITLE
Invalid parameter for yolov4 example

### DIFF
--- a/examples/vision/python_yolov4/yolov4_inference.ipynb
+++ b/examples/vision/python_yolov4/yolov4_inference.ipynb
@@ -80,7 +80,7 @@
    "outputs": [],
    "source": [
     "if not os.path.exists(\"yolov4_fp16.mxr\"):\n",
-    "    !/opt/rocm/bin/migraphx-driver compile ./utilities/yolov4.onnx --gpu --enable-offload-copy --fp16ref --binary -o yolov4_fp16.mxr\n",
+    "    !/opt/rocm/bin/migraphx-driver compile ./utilities/yolov4.onnx --gpu --enable-offload-copy --fp16 --binary -o yolov4_fp16.mxr\n",
     "if not os.path.exists(\"yolov4.mxr\"):\n",
     "    !/opt/rocm/bin/migraphx-driver compile ./utilities/yolov4.onnx --gpu --enable-offload-copy --binary -o yolov4.mxr"
    ]


### PR DESCRIPTION
fixed spelling of parameter in yolov4 example.  Should be --fp16 , not --fp16ref
Resolves #1260 