### PR TITLE
Simplify Algebra of 0+x & x+0  = x

### DIFF
--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -851,6 +851,23 @@ struct find_div_const
     }
 };
 
+struct find_zero_add_const
+{
+    auto matcher() const
+    {
+        return match::name("add")(
+            match::either_arg(0, 1)(match::has_value(0.0f), match::any().bind("x")));
+    }
+
+    void apply(module& m, const match::matcher_result& r) const
+    {
+        auto ins  = r.result;
+        auto x_in = r.instructions["x"];
+
+        m.replace_instruction(ins, x_in);
+    }
+};
+
 struct find_sub_const
 {
     auto matcher() const
@@ -1042,6 +1059,7 @@ void simplify_algebra::apply(module& m) const
         match::find_matches(m,
                             find_inner_broadcast{},
                             find_double_add_lit_broadcast{},
+                            find_zero_add_const{},
                             find_add_lit_broadcast{},
                             find_add_convs{},
                             find_conv_dot_horiz_fusion{},

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -123,6 +123,33 @@ TEST_CASE(simplify_add3)
     EXPECT(m1 == m2);
 }
 
+TEST_CASE(simplify_zero_add_constant)
+{
+    migraphx::module m1;
+    {
+        auto x    = m1.add_parameter("x", {migraphx::shape::int32_type, {1}});
+        auto zero = m1.add_literal(0);
+        m1.add_instruction(migraphx::make_op("add"), zero, x);
+    }
+    run_pass(m1);
+
+    migraphx::module m2;
+    {
+        auto x = m2.add_parameter("x", {migraphx::shape::int32_type, {1}});
+        m2.add_instruction(migraphx::make_op("identity"), x);
+    }
+
+    migraphx::module m3;
+    {
+        auto x    = m3.add_parameter("x", {migraphx::shape::int32_type, {1}});
+        auto zero = m3.add_literal(0);
+        m3.add_instruction(migraphx::make_op("add"), x, zero);
+    }
+    run_pass(m3);
+
+    EXPECT((m1 == m2) && (m2 == m3));
+}
+
 TEST_CASE(simplify_add_broadcast1)
 {
     migraphx::shape inner{migraphx::shape::int32_type, {2}};


### PR DESCRIPTION
Added test case and code to simplify zero additions between paremeters and literals during simplifications.  In reference to issue #1236