### PR TITLE
Update perf report to show the number of operators and per operator avg time in summary

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -681,11 +681,13 @@ void program::perf_report(std::ostream& os,
     double overhead_percent       = overhead_time * 100.0 / total_time;
     double total_instruction_time = 0.0;
     std::unordered_map<std::string, double> op_times;
+    std::unordered_map<std::string, std::size_t> op_n;
     for(auto&& p : ins_vec)
     {
         double avg = common_average(p.second);
         op_times[perf_group(p.first->get_operator())] += avg;
         total_instruction_time += avg;
+        op_n[perf_group(p.first->get_operator())]++;
     }
     double calculate_overhead_time    = total_time - total_instruction_time;
     double calculate_overhead_percent = calculate_overhead_time * 100.0 / total_time;
@@ -706,18 +708,20 @@ void program::perf_report(std::ostream& os,
 
     os << std::endl;
     os << "Summary:" << std::endl;
-    std::vector<std::pair<double, std::string>> op_times_sorted;
+    std::vector<std::tuple<double, std::size_t, std::string>> op_times_sorted;
     std::transform(op_times.begin(),
                    op_times.end(),
                    std::back_inserter(op_times_sorted),
-                   [](auto p) { return std::make_pair(p.second, p.first); });
+                   [&](auto p) { 
+                    auto&& name = p.first;
+                    return std::make_tuple(p.second, op_n.at(name), name); 
+                });
     std::sort(op_times_sorted.begin(), op_times_sorted.end(), std::greater<>{});
-    for(auto&& p : op_times_sorted)
+    for(auto&& [avg, nn, name] : op_times_sorted)
     {
-        auto&& name    = p.second;
-        double avg     = p.first;
         double percent = std::ceil(100.0 * avg / total_instruction_time);
-        os << name << ": " << avg << "ms, " << percent << "%" << std::endl;
+        double per_ins = avg / nn;
+        os << name << ": " << avg << "ms / " << nn << " = " << per_ins << "ms, " << percent << "%" << std::endl;
     }
 
     os << std::endl;

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -709,19 +709,18 @@ void program::perf_report(std::ostream& os,
     os << std::endl;
     os << "Summary:" << std::endl;
     std::vector<std::tuple<double, std::size_t, std::string>> op_times_sorted;
-    std::transform(op_times.begin(),
-                   op_times.end(),
-                   std::back_inserter(op_times_sorted),
-                   [&](auto p) { 
-                    auto&& name = p.first;
-                    return std::make_tuple(p.second, op_n.at(name), name); 
-                });
+    std::transform(
+        op_times.begin(), op_times.end(), std::back_inserter(op_times_sorted), [&](auto p) {
+            auto&& name = p.first;
+            return std::make_tuple(p.second, op_n.at(name), name);
+        });
     std::sort(op_times_sorted.begin(), op_times_sorted.end(), std::greater<>{});
     for(auto&& [avg, nn, name] : op_times_sorted)
     {
         double percent = std::ceil(100.0 * avg / total_instruction_time);
         double per_ins = avg / nn;
-        os << name << ": " << avg << "ms / " << nn << " = " << per_ins << "ms, " << percent << "%" << std::endl;
+        os << name << ": " << avg << "ms / " << nn << " = " << per_ins << "ms, " << percent << "%"
+           << std::endl;
     }
 
     os << std::endl;


### PR DESCRIPTION
The perf report now looks like this:

```
Summary:
gpu::gemm: 8.738ms / 73 = 0.119699ms, 64%
gpu::triadd_layernorm: 0.831381ms / 24 = 0.0346409ms, 7%
gpu::softmax: 0.810817ms / 12 = 0.0675681ms, 6%
gpu::code_object::add_kernel: 0.681062ms / 25 = 0.0272425ms, 5%
gpu::code_object::mul_kernel: 0.65772ms / 24 = 0.027405ms, 5%
gpu::code_object::add_mul_erf_add_mul_mul_kernel: 0.517353ms / 12 = 0.0431128ms, 4%
gpu::code_object::mul_add_kernel: 0.495187ms / 13 = 0.0380913ms, 4%
gpu::code_object::contiguous_kernel: 0.32261ms / 12 = 0.0268842ms, 3%
hip::hip_copy_literal: 0.166268ms / 176 = 0.000944705ms, 2%
load: 0.137222ms / 199 = 0.00068956ms, 2%
gpu::gather: 0.0753129ms / 2 = 0.0376565ms, 1%
gpu::code_object::convert_kernel: 0.051564ms / 2 = 0.025782ms, 1%
multibroadcast: 0.0448711ms / 63 = 0.00071224ms, 1%
gpu::layernorm: 0.0335509ms / 1 = 0.0335509ms, 1%
transpose: 0.0286511ms / 48 = 0.000596898ms, 1%
slice: 0.0280959ms / 36 = 0.000780442ms, 1%
gpu::code_object::add_tanh_convert_kernel: 0.025883ms / 1 = 0.025883ms, 1%
reshape: 0.0219375ms / 24 = 0.000914062ms, 1%
@param: 0.00183054ms / 3 = 0.00061018ms, 1%
check_context::migraphx::version_1::gpu::context: 0.00088258ms / 1 = 0.00088258ms, 1%
hip::hip_allocate_memory: 0.000443ms / 1 = 0.000443ms, 1%

Batch size: 1
Rate: 115.075/sec
Total time: 8.68999ms
Total instructions time: 13.6706ms
Overhead time: 0.145536ms, -4.98065ms
Overhead: 2%, -57%
```
