### PR TITLE
Fix test case for min & max operators

### DIFF
--- a/test/onnx/gen_onnx.py
+++ b/test/onnx/gen_onnx.py
@@ -3220,7 +3220,7 @@ def min_test():
     a = helper.make_tensor_value_info('0', TensorProto.FLOAT, [3])
     b = helper.make_tensor_value_info('1', TensorProto.FLOAT, [3])
     c = helper.make_tensor_value_info('2', TensorProto.FLOAT, [3])
-    y = helper.make_tensor_value_info('2', TensorProto.FLOAT, [3])
+    y = helper.make_tensor_value_info('3', TensorProto.FLOAT, [3])
 
     node = onnx.helper.make_node(
         'Min',

--- a/test/onnx/gen_onnx.py
+++ b/test/onnx/gen_onnx.py
@@ -3086,7 +3086,7 @@ def max_test():
     a = helper.make_tensor_value_info('0', TensorProto.FLOAT, [3])
     b = helper.make_tensor_value_info('1', TensorProto.FLOAT, [3])
     c = helper.make_tensor_value_info('2', TensorProto.FLOAT, [3])
-    y = helper.make_tensor_value_info('2', TensorProto.FLOAT, [3])
+    y = helper.make_tensor_value_info('3', TensorProto.FLOAT, [3])
 
     node = onnx.helper.make_node(
         'Max',

--- a/test/onnx/max_test.onnx
+++ b/test/onnx/max_test.onnx
@@ -1,8 +1,8 @@
-max-example:e
+max_test:a
 
 0
 1
-23"Maxtest-dropoutZ
+23"Maxmax_testZ
 0
 
 
@@ -15,7 +15,7 @@
 
 
 b
-2
+3
 
 
-B
+B

--- a/test/onnx/min_test.onnx
+++ b/test/onnx/min_test.onnx
@@ -1,8 +1,8 @@
-min-example:e
+min_test:a
 
 0
 1
-23"Mintest-dropoutZ
+23"Minmin_testZ
 0
 
 
@@ -15,7 +15,7 @@
 
 
 b
-2
+3
 
 
-B
+B

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -2832,9 +2832,9 @@ TEST_CASE(max_test)
     auto l0     = mm->add_instruction(migraphx::make_op("max"), input0, input1);
     mm->add_instruction(migraphx::make_op("max"), l0, input2);
 
-    auto p_onnx = optimize_onnx("max_test.onnx");
+    auto prog = optimize_onnx("max_test.onnx");
 
-    EXPECT(p == p_onnx);
+    EXPECT(p == prog);
 }
 
 TEST_CASE(maxpool_notset_test)
@@ -2949,9 +2949,9 @@ TEST_CASE(min_test)
     auto l0     = mm->add_instruction(migraphx::make_op("min"), input0, input1);
     mm->add_instruction(migraphx::make_op("min"), l0, input2);
 
-    auto onnx_p = optimize_onnx("min_test.onnx");
+    auto prog = optimize_onnx("min_test.onnx");
 
-    EXPECT(p == onnx_p);
+    EXPECT(p == prog);
 }
 
 TEST_CASE(multinomial_test)

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -2832,7 +2832,9 @@ TEST_CASE(max_test)
     auto l0     = mm->add_instruction(migraphx::make_op("max"), input0, input1);
     mm->add_instruction(migraphx::make_op("max"), l0, input2);
 
-    optimize_onnx("max_test.onnx");
+    auto p_onnx = optimize_onnx("max_test.onnx");
+
+    EXPECT(p == p_onnx);
 }
 
 TEST_CASE(maxpool_notset_test)

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -2947,7 +2947,9 @@ TEST_CASE(min_test)
     auto l0     = mm->add_instruction(migraphx::make_op("min"), input0, input1);
     mm->add_instruction(migraphx::make_op("min"), l0, input2);
 
-    optimize_onnx("min_test.onnx");
+    auto onnx_p = optimize_onnx("min_test.onnx");
+
+    EXPECT(p == onnx_p);
 }
 
 TEST_CASE(multinomial_test)


### PR DESCRIPTION
Fix min_test.onnx generation as well as add a proper check to the parse program vs the expect program.

Adding this in to fix test converge for the min case.

Regenerated the min_test.onnx as well and re -ran tests to verify everything should be working as intended.