### PR TITLE
backout devel package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,14 @@ rocm_enable_cppcheck(
 enable_testing()
 
 include(ROCMCreatePackage)
+rocm_create_package(
+    NAME MIGraphX
+    DESCRIPTION "AMD's graph optimizer"
+    MAINTAINER "Paul Fultz II <paul.fultz@amd.com>"
+    LDCONFIG
+    PTH
+    DEPENDS miopen-hip rocblas hip-rocclr hip-base half
+)
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
@@ -238,11 +246,3 @@ foreach(py_file ${backend_files})
 endforeach(py_file)
 configure_file(${CMAKE_SOURCE_DIR}/test/py/onnx_backend_test.py ${DEST_DIR}/onnx_backend_test.py COPYONLY)
 
-rocm_create_package(
-    NAME MIGraphX
-    DESCRIPTION "AMD's graph optimizer"
-    MAINTAINER "Paul Fultz II <paul.fultz@amd.com>"
-    LDCONFIG
-    PTH
-    DEPENDS miopen-hip rocblas hip-rocclr hip-base half
-)


### PR DESCRIPTION
This change caused a failure during the uninstall process.  The fix requested for this release is to back out the change and not provide a devel package.  