### PR TITLE
Remove prints from debugging dyn_conv

### DIFF
--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -954,13 +954,11 @@ TEST_CASE(conv_dynamic_img_same_upper)
 
 TEST_CASE(conv_dynamic_kernel_same_lower)
 {
-    std::cout << "here1\n";
     migraphx::program p;
     auto* mm = p.get_main_module();
     auto l0  = mm->add_parameter("0", {migraphx::shape::float_type, {1, 3, 5, 5}});
     auto l1  = mm->add_parameter(
         "1", {migraphx::shape::float_type, {{1, 1, 0}, {3, 3, 0}, {2, 4, 0}, {2, 4, 0}}});
-    std::cout << "here2\n";
     auto c0 = mm->add_instruction(
         migraphx::make_op("convolution",
                           {{"padding", {0, 0}},
@@ -970,12 +968,10 @@ TEST_CASE(conv_dynamic_kernel_same_lower)
                            {"use_dynamic_same_auto_pad", true}}),
         l0,
         l1);
-    std::cout << "here3\n";
     mm->add_return({c0});
 
     migraphx::onnx_options options;
     options.default_dyn_dim_value = {2, 4, 0};
-    std::cout << "here\n";
     auto prog = migraphx::parse_onnx("conv_dynamic_kernel_same_lower_test.onnx", options);
     EXPECT(p == prog);
 }


### PR DESCRIPTION
Remove the `std::cout` calls I left in this test.