### PR TITLE
Fix json strings in driver models

### DIFF
--- a/src/driver/alexnet.cpp
+++ b/src/driver/alexnet.cpp
@@ -25,7 +25,6 @@
 #include <migraphx/make_op.hpp>
 #include <migraphx/program.hpp>
 #include <migraphx/generate.hpp>
-#include <migraphx/json.hpp>
 #include "models.hpp"
 namespace migraphx {
 namespace driver {
@@ -33,188 +32,75 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program alexnet(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-    migraphx::module_ref mmain = p.get_main_module();
-    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-    auto x_main_module_1       = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 1)));
-    auto x_main_module_2       = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 2)));
-    auto x_0                   = mmain->add_parameter(
-        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
-    auto x_main_module_4 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 3));
-    auto x_main_module_5 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 4096}}, 4));
-    auto x_main_module_6 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 5));
-    auto x_main_module_7 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 4096}}, 6));
-    auto x_main_module_8 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 7));
-    auto x_main_module_9 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 9216}}, 8));
-    auto x_main_module_10 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 9));
-    auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 10));
-    auto x_main_module_12 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 11));
-    auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 384, 3, 3}}, 12));
-    auto x_main_module_14 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13));
-    auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 192, 3, 3}}, 14));
-    auto x_main_module_16 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 15));
-    auto x_main_module_17 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 64, 5, 5}}, 16));
-    auto x_main_module_18 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 17));
-    auto x_main_module_19 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 3, 11, 11}}, 18));
-    auto x_main_module_20 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
-                              "mode\":0,\"stride\":[4,4],\"use_dynamic_same_auto_pad\":0}")),
-        x_0,
-        x_main_module_19); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_21 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,64,55,55]}")),
-        x_main_module_18); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_22 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_20, x_main_module_21);
-    auto x_main_module_23 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_22);
-    auto x_main_module_24 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        x_main_module_23); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_25 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_24,
-        x_main_module_17); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_26 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,192,27,27]}")),
-        x_main_module_16); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_27 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_25, x_main_module_26);
-    auto x_main_module_28 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_27);
-    auto x_main_module_29 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        x_main_module_28); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_30 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_29,
-        x_main_module_15); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_31 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,384,13,13]}")),
-        x_main_module_14); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_32 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_30, x_main_module_31);
-    auto x_main_module_33 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_32);
-    auto x_main_module_34 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_33,
-        x_main_module_13); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_35 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")),
-        x_main_module_12); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_36 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_34, x_main_module_35);
-    auto x_main_module_37 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_36);
-    auto x_main_module_38 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_37,
-        x_main_module_11); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_39 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")),
-        x_main_module_10); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_40 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_38, x_main_module_39);
-    auto x_main_module_41 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_40);
-    auto x_main_module_42 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        x_main_module_41); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_43 = mmain->add_instruction(
-        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_42); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_44 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_43);
-    auto x_main_module_45 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
-        x_main_module_9); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_46 =
-        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_44, x_main_module_45);
-    auto x_main_module_47 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
-        x_main_module_8); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_48 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
-        x_main_module_2); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_49 =
-        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_47, x_main_module_48);
-    auto x_main_module_50 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_46, x_main_module_49);
-    auto x_main_module_51 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_50);
-    auto x_main_module_52 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_51);
-    auto x_main_module_53 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
-        x_main_module_7); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_54 =
-        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_52, x_main_module_53);
-    auto x_main_module_55 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
-        x_main_module_6); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_56 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
-        x_main_module_1); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_57 =
-        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_55, x_main_module_56);
-    auto x_main_module_58 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_54, x_main_module_57);
-    auto x_main_module_59 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_58);
-    auto x_main_module_60 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
-        x_main_module_5); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_61 =
-        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_59, x_main_module_60);
-    auto x_main_module_62 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        x_main_module_4); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_63 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        x_main_module_0); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_64 =
-        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_62, x_main_module_63);
-    auto x_main_module_65 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_61, x_main_module_64);
-    mmain->add_return({x_main_module_65});
+migraphx::module_ref mmain = p.get_main_module();
+auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+auto x_main_module_1 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 1)));
+auto x_main_module_2 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 2)));
+auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
+auto x_main_module_4 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 3));
+auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 4096}}, 4));
+auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 5));
+auto x_main_module_7 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 4096}}, 6));
+auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 7));
+auto x_main_module_9 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 9216}}, 8));
+auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 9));
+auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 10));
+auto x_main_module_12 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 11));
+auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 384, 3, 3}}, 12));
+auto x_main_module_14 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13));
+auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 192, 3, 3}}, 14));
+auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 15));
+auto x_main_module_17 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 64, 5, 5}}, 16));
+auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 17));
+auto x_main_module_19 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 3, 11, 11}}, 18));
+auto x_main_module_20 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[4,4],use_dynamic_same_auto_pad:0}"), x_0, x_main_module_19);
+auto x_main_module_21 = mmain->add_instruction(migraphx::make_json_op("broadcast", "{axis:1,out_lens:[1,64,55,55]}"), x_main_module_18);
+auto x_main_module_22 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_20, x_main_module_21);
+auto x_main_module_23 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_22);
+auto x_main_module_24 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"), x_main_module_23);
+auto x_main_module_25 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_24, x_main_module_17);
+auto x_main_module_26 = mmain->add_instruction(migraphx::make_json_op("broadcast", "{axis:1,out_lens:[1,192,27,27]}"), x_main_module_16);
+auto x_main_module_27 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_25, x_main_module_26);
+auto x_main_module_28 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_27);
+auto x_main_module_29 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"), x_main_module_28);
+auto x_main_module_30 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_29, x_main_module_15);
+auto x_main_module_31 = mmain->add_instruction(migraphx::make_json_op("broadcast", "{axis:1,out_lens:[1,384,13,13]}"), x_main_module_14);
+auto x_main_module_32 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_30, x_main_module_31);
+auto x_main_module_33 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_32);
+auto x_main_module_34 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_33, x_main_module_13);
+auto x_main_module_35 = mmain->add_instruction(migraphx::make_json_op("broadcast", "{axis:1,out_lens:[1,256,13,13]}"), x_main_module_12);
+auto x_main_module_36 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_34, x_main_module_35);
+auto x_main_module_37 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_36);
+auto x_main_module_38 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_37, x_main_module_11);
+auto x_main_module_39 = mmain->add_instruction(migraphx::make_json_op("broadcast", "{axis:1,out_lens:[1,256,13,13]}"), x_main_module_10);
+auto x_main_module_40 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_38, x_main_module_39);
+auto x_main_module_41 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_40);
+auto x_main_module_42 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"), x_main_module_41);
+auto x_main_module_43 = mmain->add_instruction(migraphx::make_json_op("flatten", "{axis:1}"), x_main_module_42);
+auto x_main_module_44 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_43);
+auto x_main_module_45 = mmain->add_instruction(migraphx::make_json_op("transpose", "{permutation:[1,0]}"), x_main_module_9);
+auto x_main_module_46 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_44, x_main_module_45);
+auto x_main_module_47 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,4096]}"), x_main_module_8);
+auto x_main_module_48 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,4096]}"), x_main_module_2);
+auto x_main_module_49 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_47, x_main_module_48);
+auto x_main_module_50 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_46, x_main_module_49);
+auto x_main_module_51 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_50);
+auto x_main_module_52 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_51);
+auto x_main_module_53 = mmain->add_instruction(migraphx::make_json_op("transpose", "{permutation:[1,0]}"), x_main_module_7);
+auto x_main_module_54 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_52, x_main_module_53);
+auto x_main_module_55 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,4096]}"), x_main_module_6);
+auto x_main_module_56 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,4096]}"), x_main_module_1);
+auto x_main_module_57 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_55, x_main_module_56);
+auto x_main_module_58 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_54, x_main_module_57);
+auto x_main_module_59 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_58);
+auto x_main_module_60 = mmain->add_instruction(migraphx::make_json_op("transpose", "{permutation:[1,0]}"), x_main_module_5);
+auto x_main_module_61 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_59, x_main_module_60);
+auto x_main_module_62 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_4);
+auto x_main_module_63 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_0);
+auto x_main_module_64 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_62, x_main_module_63);
+auto x_main_module_65 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_61, x_main_module_64);
+mmain->add_return({x_main_module_65});
+
 
     return p;
 }

--- a/src/driver/alexnet.cpp
+++ b/src/driver/alexnet.cpp
@@ -33,75 +33,187 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program alexnet(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-migraphx::module_ref mmain = p.get_main_module();
-auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-auto x_main_module_1 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 1)));
-auto x_main_module_2 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 2)));
-auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
-auto x_main_module_4 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 3));
-auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 4096}}, 4));
-auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 5));
-auto x_main_module_7 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 4096}}, 6));
-auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 7));
-auto x_main_module_9 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 9216}}, 8));
-auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 9));
-auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 10));
-auto x_main_module_12 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 11));
-auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 384, 3, 3}}, 12));
-auto x_main_module_14 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13));
-auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 192, 3, 3}}, 14));
-auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 15));
-auto x_main_module_17 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 64, 5, 5}}, 16));
-auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 17));
-auto x_main_module_19 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 3, 11, 11}}, 18));
-auto x_main_module_20 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[4,4],\"use_dynamic_same_auto_pad\":0}")), x_0, x_main_module_19);
-auto x_main_module_21 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,64,55,55]}")), x_main_module_18);
-auto x_main_module_22 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_20, x_main_module_21);
-auto x_main_module_23 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_22);
-auto x_main_module_24 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_23);
-auto x_main_module_25 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_24, x_main_module_17);
-auto x_main_module_26 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,192,27,27]}")), x_main_module_16);
-auto x_main_module_27 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_25, x_main_module_26);
-auto x_main_module_28 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_27);
-auto x_main_module_29 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_28);
-auto x_main_module_30 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_29, x_main_module_15);
-auto x_main_module_31 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,384,13,13]}")), x_main_module_14);
-auto x_main_module_32 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_30, x_main_module_31);
-auto x_main_module_33 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_32);
-auto x_main_module_34 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_33, x_main_module_13);
-auto x_main_module_35 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")), x_main_module_12);
-auto x_main_module_36 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_34, x_main_module_35);
-auto x_main_module_37 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_36);
-auto x_main_module_38 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_37, x_main_module_11);
-auto x_main_module_39 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")), x_main_module_10);
-auto x_main_module_40 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_38, x_main_module_39);
-auto x_main_module_41 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_40);
-auto x_main_module_42 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_41);
-auto x_main_module_43 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), x_main_module_42);
-auto x_main_module_44 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_43);
-auto x_main_module_45 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_9);
-auto x_main_module_46 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_44, x_main_module_45);
-auto x_main_module_47 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), x_main_module_8);
-auto x_main_module_48 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), x_main_module_2);
-auto x_main_module_49 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_47, x_main_module_48);
-auto x_main_module_50 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_46, x_main_module_49);
-auto x_main_module_51 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_50);
-auto x_main_module_52 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_51);
-auto x_main_module_53 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_7);
-auto x_main_module_54 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_52, x_main_module_53);
-auto x_main_module_55 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), x_main_module_6);
-auto x_main_module_56 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), x_main_module_1);
-auto x_main_module_57 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_55, x_main_module_56);
-auto x_main_module_58 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_54, x_main_module_57);
-auto x_main_module_59 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_58);
-auto x_main_module_60 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_5);
-auto x_main_module_61 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_59, x_main_module_60);
-auto x_main_module_62 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_4);
-auto x_main_module_63 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_0);
-auto x_main_module_64 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_62, x_main_module_63);
-auto x_main_module_65 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_61, x_main_module_64);
-mmain->add_return({x_main_module_65});
-
+    migraphx::module_ref mmain = p.get_main_module();
+    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+    auto x_main_module_1       = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 1)));
+    auto x_main_module_2       = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 2)));
+    auto x_0                   = mmain->add_parameter(
+        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
+    auto x_main_module_4 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 3));
+    auto x_main_module_5 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 4096}}, 4));
+    auto x_main_module_6 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 5));
+    auto x_main_module_7 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 4096}}, 6));
+    auto x_main_module_8 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 7));
+    auto x_main_module_9 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 9216}}, 8));
+    auto x_main_module_10 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 9));
+    auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 10));
+    auto x_main_module_12 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 11));
+    auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 384, 3, 3}}, 12));
+    auto x_main_module_14 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13));
+    auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 192, 3, 3}}, 14));
+    auto x_main_module_16 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 15));
+    auto x_main_module_17 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 64, 5, 5}}, 16));
+    auto x_main_module_18 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 17));
+    auto x_main_module_19 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 3, 11, 11}}, 18));
+    auto x_main_module_20 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
+                              "mode\":0,\"stride\":[4,4],\"use_dynamic_same_auto_pad\":0}")),
+        x_0,
+        x_main_module_19);
+    auto x_main_module_21 = mmain->add_instruction(
+        migraphx::make_op("broadcast",
+                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,64,55,55]}")),
+        x_main_module_18);
+    auto x_main_module_22 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_20, x_main_module_21);
+    auto x_main_module_23 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_22);
+    auto x_main_module_24 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        x_main_module_23);
+    auto x_main_module_25 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_24,
+        x_main_module_17);
+    auto x_main_module_26 = mmain->add_instruction(
+        migraphx::make_op("broadcast",
+                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,192,27,27]}")),
+        x_main_module_16);
+    auto x_main_module_27 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_25, x_main_module_26);
+    auto x_main_module_28 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_27);
+    auto x_main_module_29 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        x_main_module_28);
+    auto x_main_module_30 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_29,
+        x_main_module_15);
+    auto x_main_module_31 = mmain->add_instruction(
+        migraphx::make_op("broadcast",
+                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,384,13,13]}")),
+        x_main_module_14);
+    auto x_main_module_32 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_30, x_main_module_31);
+    auto x_main_module_33 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_32);
+    auto x_main_module_34 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_33,
+        x_main_module_13);
+    auto x_main_module_35 = mmain->add_instruction(
+        migraphx::make_op("broadcast",
+                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")),
+        x_main_module_12);
+    auto x_main_module_36 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_34, x_main_module_35);
+    auto x_main_module_37 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_36);
+    auto x_main_module_38 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_37,
+        x_main_module_11);
+    auto x_main_module_39 = mmain->add_instruction(
+        migraphx::make_op("broadcast",
+                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")),
+        x_main_module_10);
+    auto x_main_module_40 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_38, x_main_module_39);
+    auto x_main_module_41 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_40);
+    auto x_main_module_42 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        x_main_module_41);
+    auto x_main_module_43 = mmain->add_instruction(
+        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), x_main_module_42);
+    auto x_main_module_44 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_43);
+    auto x_main_module_45 = mmain->add_instruction(
+        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
+        x_main_module_9);
+    auto x_main_module_46 =
+        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_44, x_main_module_45);
+    auto x_main_module_47 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
+        x_main_module_8);
+    auto x_main_module_48 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
+        x_main_module_2);
+    auto x_main_module_49 =
+        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_47, x_main_module_48);
+    auto x_main_module_50 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_46, x_main_module_49);
+    auto x_main_module_51 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_50);
+    auto x_main_module_52 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_51);
+    auto x_main_module_53 = mmain->add_instruction(
+        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
+        x_main_module_7);
+    auto x_main_module_54 =
+        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_52, x_main_module_53);
+    auto x_main_module_55 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
+        x_main_module_6);
+    auto x_main_module_56 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
+        x_main_module_1);
+    auto x_main_module_57 =
+        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_55, x_main_module_56);
+    auto x_main_module_58 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_54, x_main_module_57);
+    auto x_main_module_59 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_58);
+    auto x_main_module_60 = mmain->add_instruction(
+        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
+        x_main_module_5);
+    auto x_main_module_61 =
+        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_59, x_main_module_60);
+    auto x_main_module_62 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        x_main_module_4);
+    auto x_main_module_63 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        x_main_module_0);
+    auto x_main_module_64 =
+        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_62, x_main_module_63);
+    auto x_main_module_65 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_61, x_main_module_64);
+    mmain->add_return({x_main_module_65});
 
     return p;
 }

--- a/src/driver/alexnet.cpp
+++ b/src/driver/alexnet.cpp
@@ -33,75 +33,188 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program alexnet(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-migraphx::module_ref mmain = p.get_main_module();
-auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-auto x_main_module_1 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 1)));
-auto x_main_module_2 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 2)));
-auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
-auto x_main_module_4 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 3));
-auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 4096}}, 4));
-auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 5));
-auto x_main_module_7 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 4096}}, 6));
-auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 7));
-auto x_main_module_9 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 9216}}, 8));
-auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 9));
-auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 10));
-auto x_main_module_12 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 11));
-auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 384, 3, 3}}, 12));
-auto x_main_module_14 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13));
-auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 192, 3, 3}}, 14));
-auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 15));
-auto x_main_module_17 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 64, 5, 5}}, 16));
-auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 17));
-auto x_main_module_19 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 3, 11, 11}}, 18));
-auto x_main_module_20 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[4,4],\"use_dynamic_same_auto_pad\":0}")), x_0, x_main_module_19); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_21 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,64,55,55]}")), x_main_module_18); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_22 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_20, x_main_module_21);
-auto x_main_module_23 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_22);
-auto x_main_module_24 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_23); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_25 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_24, x_main_module_17); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_26 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,192,27,27]}")), x_main_module_16); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_27 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_25, x_main_module_26);
-auto x_main_module_28 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_27);
-auto x_main_module_29 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_28); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_30 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_29, x_main_module_15); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_31 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,384,13,13]}")), x_main_module_14); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_32 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_30, x_main_module_31);
-auto x_main_module_33 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_32);
-auto x_main_module_34 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_33, x_main_module_13); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_35 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")), x_main_module_12); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_36 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_34, x_main_module_35);
-auto x_main_module_37 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_36);
-auto x_main_module_38 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_37, x_main_module_11); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_39 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")), x_main_module_10); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_40 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_38, x_main_module_39);
-auto x_main_module_41 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_40);
-auto x_main_module_42 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_41); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_43 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), x_main_module_42); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_44 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_43);
-auto x_main_module_45 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_9); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_46 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_44, x_main_module_45);
-auto x_main_module_47 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), x_main_module_8); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_48 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), x_main_module_2); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_49 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_47, x_main_module_48);
-auto x_main_module_50 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_46, x_main_module_49);
-auto x_main_module_51 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_50);
-auto x_main_module_52 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_51);
-auto x_main_module_53 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_7); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_54 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_52, x_main_module_53);
-auto x_main_module_55 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), x_main_module_6); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_56 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), x_main_module_1); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_57 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_55, x_main_module_56);
-auto x_main_module_58 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_54, x_main_module_57);
-auto x_main_module_59 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_58);
-auto x_main_module_60 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_5); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_61 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_59, x_main_module_60);
-auto x_main_module_62 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_4); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_63 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_0); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_64 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_62, x_main_module_63);
-auto x_main_module_65 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_61, x_main_module_64);
-mmain->add_return({x_main_module_65});
-
+    migraphx::module_ref mmain = p.get_main_module();
+    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+    auto x_main_module_1       = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 1)));
+    auto x_main_module_2       = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 2)));
+    auto x_0                   = mmain->add_parameter(
+        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
+    auto x_main_module_4 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 3));
+    auto x_main_module_5 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 4096}}, 4));
+    auto x_main_module_6 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 5));
+    auto x_main_module_7 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 4096}}, 6));
+    auto x_main_module_8 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 7));
+    auto x_main_module_9 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 9216}}, 8));
+    auto x_main_module_10 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 9));
+    auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 10));
+    auto x_main_module_12 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 11));
+    auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 384, 3, 3}}, 12));
+    auto x_main_module_14 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13));
+    auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 192, 3, 3}}, 14));
+    auto x_main_module_16 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 15));
+    auto x_main_module_17 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 64, 5, 5}}, 16));
+    auto x_main_module_18 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 17));
+    auto x_main_module_19 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 3, 11, 11}}, 18));
+    auto x_main_module_20 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
+                              "mode\":0,\"stride\":[4,4],\"use_dynamic_same_auto_pad\":0}")),
+        x_0,
+        x_main_module_19); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_21 = mmain->add_instruction(
+        migraphx::make_op("broadcast",
+                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,64,55,55]}")),
+        x_main_module_18); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_22 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_20, x_main_module_21);
+    auto x_main_module_23 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_22);
+    auto x_main_module_24 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        x_main_module_23); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_25 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_24,
+        x_main_module_17); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_26 = mmain->add_instruction(
+        migraphx::make_op("broadcast",
+                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,192,27,27]}")),
+        x_main_module_16); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_27 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_25, x_main_module_26);
+    auto x_main_module_28 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_27);
+    auto x_main_module_29 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        x_main_module_28); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_30 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_29,
+        x_main_module_15); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_31 = mmain->add_instruction(
+        migraphx::make_op("broadcast",
+                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,384,13,13]}")),
+        x_main_module_14); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_32 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_30, x_main_module_31);
+    auto x_main_module_33 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_32);
+    auto x_main_module_34 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_33,
+        x_main_module_13); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_35 = mmain->add_instruction(
+        migraphx::make_op("broadcast",
+                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")),
+        x_main_module_12); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_36 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_34, x_main_module_35);
+    auto x_main_module_37 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_36);
+    auto x_main_module_38 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_37,
+        x_main_module_11); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_39 = mmain->add_instruction(
+        migraphx::make_op("broadcast",
+                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")),
+        x_main_module_10); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_40 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_38, x_main_module_39);
+    auto x_main_module_41 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_40);
+    auto x_main_module_42 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        x_main_module_41); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_43 = mmain->add_instruction(
+        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_42); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_44 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_43);
+    auto x_main_module_45 = mmain->add_instruction(
+        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
+        x_main_module_9); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_46 =
+        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_44, x_main_module_45);
+    auto x_main_module_47 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
+        x_main_module_8); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_48 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
+        x_main_module_2); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_49 =
+        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_47, x_main_module_48);
+    auto x_main_module_50 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_46, x_main_module_49);
+    auto x_main_module_51 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_50);
+    auto x_main_module_52 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_51);
+    auto x_main_module_53 = mmain->add_instruction(
+        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
+        x_main_module_7); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_54 =
+        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_52, x_main_module_53);
+    auto x_main_module_55 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
+        x_main_module_6); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_56 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
+        x_main_module_1); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_57 =
+        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_55, x_main_module_56);
+    auto x_main_module_58 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_54, x_main_module_57);
+    auto x_main_module_59 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_58);
+    auto x_main_module_60 = mmain->add_instruction(
+        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
+        x_main_module_5); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_61 =
+        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_59, x_main_module_60);
+    auto x_main_module_62 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        x_main_module_4); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_63 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        x_main_module_0); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_64 =
+        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_62, x_main_module_63);
+    auto x_main_module_65 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_61, x_main_module_64);
+    mmain->add_return({x_main_module_65});
 
     return p;
 }

--- a/src/driver/alexnet.cpp
+++ b/src/driver/alexnet.cpp
@@ -33,190 +33,75 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program alexnet(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-    migraphx::module_ref mmain = p.get_main_module();
-    auto _x_main_module_0      = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-    auto _x_main_module_1      = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 1)));
-    auto _x_main_module_2      = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 2)));
-    auto _x_0                  = mmain->add_parameter(
-        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
-    auto _x_main_module_4 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 3));
-    auto _x_main_module_5 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 4096}}, 4));
-    auto _x_main_module_6 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 5));
-    auto _x_main_module_7 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 4096}}, 6));
-    auto _x_main_module_8 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 7));
-    auto _x_main_module_9 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 9216}}, 8));
-    auto _x_main_module_10 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 9));
-    auto _x_main_module_11 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 10));
-    auto _x_main_module_12 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 11));
-    auto _x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 384, 3, 3}}, 12));
-    auto _x_main_module_14 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13));
-    auto _x_main_module_15 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 192, 3, 3}}, 14));
-    auto _x_main_module_16 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 15));
-    auto _x_main_module_17 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 64, 5, 5}}, 16));
-    auto _x_main_module_18 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 17));
-    auto _x_main_module_19 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 3, 11, 11}}, 18));
-    auto _x_main_module_20 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
-                              "mode\":0,\"stride\":[4,4],\"use_dynamic_same_auto_pad\":0}")),
-        _x_0,
-        _x_main_module_19);
-    auto _x_main_module_21 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,64,55,55]}")),
-        _x_main_module_18);
-    auto _x_main_module_22 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_20, _x_main_module_21);
-    auto _x_main_module_23 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_22);
-    auto _x_main_module_24 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        _x_main_module_23);
-    auto _x_main_module_25 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_24,
-        _x_main_module_17);
-    auto _x_main_module_26 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,192,27,27]}")),
-        _x_main_module_16);
-    auto _x_main_module_27 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_25, _x_main_module_26);
-    auto _x_main_module_28 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_27);
-    auto _x_main_module_29 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        _x_main_module_28);
-    auto _x_main_module_30 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_29,
-        _x_main_module_15);
-    auto _x_main_module_31 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,384,13,13]}")),
-        _x_main_module_14);
-    auto _x_main_module_32 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_30, _x_main_module_31);
-    auto _x_main_module_33 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_32);
-    auto _x_main_module_34 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_33,
-        _x_main_module_13);
-    auto _x_main_module_35 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")),
-        _x_main_module_12);
-    auto _x_main_module_36 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_34, _x_main_module_35);
-    auto _x_main_module_37 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_36);
-    auto _x_main_module_38 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_37,
-        _x_main_module_11);
-    auto _x_main_module_39 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")),
-        _x_main_module_10);
-    auto _x_main_module_40 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_38, _x_main_module_39);
-    auto _x_main_module_41 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_40);
-    auto _x_main_module_42 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        _x_main_module_41);
-    auto _x_main_module_43 = mmain->add_instruction(
-        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_42);
-    auto _x_main_module_44 =
-        mmain->add_instruction(migraphx::make_op("identity"), _x_main_module_43);
-    auto _x_main_module_45 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
-        _x_main_module_9);
-    auto _x_main_module_46 =
-        mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_44, _x_main_module_45);
-    auto _x_main_module_47 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
-        _x_main_module_8);
-    auto _x_main_module_48 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
-        _x_main_module_2);
-    auto _x_main_module_49 =
-        mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_47, _x_main_module_48);
-    auto _x_main_module_50 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_46, _x_main_module_49);
-    auto _x_main_module_51 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_50);
-    auto _x_main_module_52 =
-        mmain->add_instruction(migraphx::make_op("identity"), _x_main_module_51);
-    auto _x_main_module_53 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
-        _x_main_module_7);
-    auto _x_main_module_54 =
-        mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_52, _x_main_module_53);
-    auto _x_main_module_55 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
-        _x_main_module_6);
-    auto _x_main_module_56 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
-        _x_main_module_1);
-    auto _x_main_module_57 =
-        mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_55, _x_main_module_56);
-    auto _x_main_module_58 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_54, _x_main_module_57);
-    auto _x_main_module_59 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_58);
-    auto _x_main_module_60 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
-        _x_main_module_5);
-    auto _x_main_module_61 =
-        mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_59, _x_main_module_60);
-    auto _x_main_module_62 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        _x_main_module_4);
-    auto _x_main_module_63 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        _x_main_module_0);
-    auto _x_main_module_64 =
-        mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_62, _x_main_module_63);
-    auto _x_main_module_65 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_61, _x_main_module_64);
-    mmain->add_return({_x_main_module_65});
+migraphx::module_ref mmain = p.get_main_module();
+auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+auto x_main_module_1 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 1)));
+auto x_main_module_2 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 2)));
+auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
+auto x_main_module_4 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 3));
+auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 4096}}, 4));
+auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 5));
+auto x_main_module_7 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 4096}}, 6));
+auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 7));
+auto x_main_module_9 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 9216}}, 8));
+auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 9));
+auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 10));
+auto x_main_module_12 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 11));
+auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 384, 3, 3}}, 12));
+auto x_main_module_14 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13));
+auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 192, 3, 3}}, 14));
+auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 15));
+auto x_main_module_17 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 64, 5, 5}}, 16));
+auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 17));
+auto x_main_module_19 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 3, 11, 11}}, 18));
+auto x_main_module_20 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[4,4],\"use_dynamic_same_auto_pad\":0}")), x_0, x_main_module_19);
+auto x_main_module_21 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,64,55,55]}")), x_main_module_18);
+auto x_main_module_22 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_20, x_main_module_21);
+auto x_main_module_23 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_22);
+auto x_main_module_24 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_23);
+auto x_main_module_25 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_24, x_main_module_17);
+auto x_main_module_26 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,192,27,27]}")), x_main_module_16);
+auto x_main_module_27 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_25, x_main_module_26);
+auto x_main_module_28 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_27);
+auto x_main_module_29 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_28);
+auto x_main_module_30 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_29, x_main_module_15);
+auto x_main_module_31 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,384,13,13]}")), x_main_module_14);
+auto x_main_module_32 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_30, x_main_module_31);
+auto x_main_module_33 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_32);
+auto x_main_module_34 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_33, x_main_module_13);
+auto x_main_module_35 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")), x_main_module_12);
+auto x_main_module_36 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_34, x_main_module_35);
+auto x_main_module_37 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_36);
+auto x_main_module_38 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_37, x_main_module_11);
+auto x_main_module_39 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")), x_main_module_10);
+auto x_main_module_40 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_38, x_main_module_39);
+auto x_main_module_41 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_40);
+auto x_main_module_42 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_41);
+auto x_main_module_43 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), x_main_module_42);
+auto x_main_module_44 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_43);
+auto x_main_module_45 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_9);
+auto x_main_module_46 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_44, x_main_module_45);
+auto x_main_module_47 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), x_main_module_8);
+auto x_main_module_48 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), x_main_module_2);
+auto x_main_module_49 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_47, x_main_module_48);
+auto x_main_module_50 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_46, x_main_module_49);
+auto x_main_module_51 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_50);
+auto x_main_module_52 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_51);
+auto x_main_module_53 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_7);
+auto x_main_module_54 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_52, x_main_module_53);
+auto x_main_module_55 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), x_main_module_6);
+auto x_main_module_56 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), x_main_module_1);
+auto x_main_module_57 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_55, x_main_module_56);
+auto x_main_module_58 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_54, x_main_module_57);
+auto x_main_module_59 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_58);
+auto x_main_module_60 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_5);
+auto x_main_module_61 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_59, x_main_module_60);
+auto x_main_module_62 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_4);
+auto x_main_module_63 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_0);
+auto x_main_module_64 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_62, x_main_module_63);
+auto x_main_module_65 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_61, x_main_module_64);
+mmain->add_return({x_main_module_65});
+
 
     return p;
 }

--- a/src/driver/alexnet.cpp
+++ b/src/driver/alexnet.cpp
@@ -27,194 +27,81 @@
 #include <migraphx/generate.hpp>
 #include <migraphx/json.hpp>
 #include "models.hpp"
-
 namespace migraphx {
 namespace driver {
 inline namespace MIGRAPHX_INLINE_NS {
-
 migraphx::program alexnet(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-    migraphx::module_ref mmain = p.get_main_module();
-    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-    auto x_main_module_1       = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 1)));
-    auto x_main_module_2       = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 2)));
-    auto x_input_1             = mmain->add_parameter(
-        "input.1", migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
-    auto x_main_module_4 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 4096}}, 3));
-    auto x_main_module_5 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 4));
-    auto x_main_module_6 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 9216}}, 5));
-    auto x_main_module_7 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 6));
-    auto x_main_module_8 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 4096}}, 7));
-    auto x_main_module_9 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 8));
-    auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 384, 3, 3}}, 9));
-    auto x_main_module_11 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 10));
-    auto x_main_module_12 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 192, 3, 3}}, 11));
-    auto x_main_module_13 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 12));
-    auto x_main_module_14 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 64, 5, 5}}, 13));
-    auto x_main_module_15 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 14));
-    auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 15));
-    auto x_main_module_17 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 16));
-    auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 3, 11, 11}}, 17));
-    auto x_main_module_19 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 18));
-    auto x_main_module_20 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[4,4]}")),
-        x_input_1,
-        x_main_module_18);
-    auto x_main_module_21 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,55,55]}")),
-        x_main_module_19);
-    auto x_main_module_22 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_20, x_main_module_21);
-    auto x_main_module_23 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_22);
-    auto x_main_module_24 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}")),
-        x_main_module_23);
-    auto x_main_module_25 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[1,1]}")),
-        x_main_module_24,
-        x_main_module_14);
-    auto x_main_module_26 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,27,27]}")),
-        x_main_module_15);
-    auto x_main_module_27 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_25, x_main_module_26);
-    auto x_main_module_28 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_27);
-    auto x_main_module_29 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}")),
-        x_main_module_28);
-    auto x_main_module_30 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_29,
-        x_main_module_12);
-    auto x_main_module_31 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,384,13,13]}")),
-        x_main_module_13);
-    auto x_main_module_32 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_30, x_main_module_31);
-    auto x_main_module_33 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_32);
-    auto x_main_module_34 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_33,
-        x_main_module_10);
-    auto x_main_module_35 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,13,13]}")),
-        x_main_module_11);
-    auto x_main_module_36 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_34, x_main_module_35);
-    auto x_main_module_37 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_36);
-    auto x_main_module_38 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_37,
-        x_main_module_16);
-    auto x_main_module_39 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,13,13]}")),
-        x_main_module_17);
-    auto x_main_module_40 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_38, x_main_module_39);
-    auto x_main_module_41 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_40);
-    auto x_main_module_42 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}")),
-        x_main_module_41);
-    auto x_main_module_43 = mmain->add_instruction(
-        migraphx::make_op("reshape", migraphx::from_json_string("{dims:[1,9216]}")),
-        x_main_module_42);
-    auto x_main_module_44 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{permutation:[1,0]}")),
-        x_main_module_6);
-    auto x_main_module_45 =
-        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_43, x_main_module_44);
-    auto x_main_module_46 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{out_lens:[1,4096]}")),
-        x_main_module_7);
-    auto x_main_module_47 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{out_lens:[1,4096]}")),
-        x_main_module_2);
-    auto x_main_module_48 =
-        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_46, x_main_module_47);
-    auto x_main_module_49 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_45, x_main_module_48);
-    auto x_main_module_50 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_49);
-    auto x_main_module_51 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{permutation:[1,0]}")),
-        x_main_module_4);
-    auto x_main_module_52 =
-        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_50, x_main_module_51);
-    auto x_main_module_53 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{out_lens:[1,4096]}")),
-        x_main_module_5);
-    auto x_main_module_54 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{out_lens:[1,4096]}")),
-        x_main_module_1);
-    auto x_main_module_55 =
-        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_53, x_main_module_54);
-    auto x_main_module_56 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_52, x_main_module_55);
-    auto x_main_module_57 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_56);
-    auto x_main_module_58 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{permutation:[1,0]}")),
-        x_main_module_8);
-    auto x_main_module_59 =
-        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_57, x_main_module_58);
-    auto x_main_module_60 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{out_lens:[1,1000]}")),
-        x_main_module_9);
-    auto x_main_module_61 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{out_lens:[1,1000]}")),
-        x_main_module_0);
-    auto x_main_module_62 =
-        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_60, x_main_module_61);
-    auto x_main_module_63 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_59, x_main_module_62);
-    mmain->add_return({x_main_module_63});
+migraphx::module_ref mmain = p.get_main_module();
+auto _x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+auto _x_main_module_1 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 1)));
+auto _x_main_module_2 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 2)));
+auto _x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
+auto _x_main_module_4 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 3));
+auto _x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 4096}}, 4));
+auto _x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 5));
+auto _x_main_module_7 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 4096}}, 6));
+auto _x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 7));
+auto _x_main_module_9 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 9216}}, 8));
+auto _x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 9));
+auto _x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 10));
+auto _x_main_module_12 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 11));
+auto _x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 384, 3, 3}}, 12));
+auto _x_main_module_14 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13));
+auto _x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 192, 3, 3}}, 14));
+auto _x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 15));
+auto _x_main_module_17 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 64, 5, 5}}, 16));
+auto _x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 17));
+auto _x_main_module_19 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 3, 11, 11}}, 18));
+auto _x_main_module_20 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[4,4],\"use_dynamic_same_auto_pad\":0}")), _x_0, _x_main_module_19);
+auto _x_main_module_21 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,64,55,55]}")), _x_main_module_18);
+auto _x_main_module_22 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_20, _x_main_module_21);
+auto _x_main_module_23 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_22);
+auto _x_main_module_24 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), _x_main_module_23);
+auto _x_main_module_25 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_24, _x_main_module_17);
+auto _x_main_module_26 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,192,27,27]}")), _x_main_module_16);
+auto _x_main_module_27 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_25, _x_main_module_26);
+auto _x_main_module_28 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_27);
+auto _x_main_module_29 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), _x_main_module_28);
+auto _x_main_module_30 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_29, _x_main_module_15);
+auto _x_main_module_31 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,384,13,13]}")), _x_main_module_14);
+auto _x_main_module_32 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_30, _x_main_module_31);
+auto _x_main_module_33 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_32);
+auto _x_main_module_34 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_33, _x_main_module_13);
+auto _x_main_module_35 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")), _x_main_module_12);
+auto _x_main_module_36 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_34, _x_main_module_35);
+auto _x_main_module_37 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_36);
+auto _x_main_module_38 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_37, _x_main_module_11);
+auto _x_main_module_39 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")), _x_main_module_10);
+auto _x_main_module_40 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_38, _x_main_module_39);
+auto _x_main_module_41 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_40);
+auto _x_main_module_42 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), _x_main_module_41);
+auto _x_main_module_43 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_42);
+auto _x_main_module_44 = mmain->add_instruction(migraphx::make_op("identity"), _x_main_module_43);
+auto _x_main_module_45 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), _x_main_module_9);
+auto _x_main_module_46 = mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_44, _x_main_module_45);
+auto _x_main_module_47 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), _x_main_module_8);
+auto _x_main_module_48 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), _x_main_module_2);
+auto _x_main_module_49 = mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_47, _x_main_module_48);
+auto _x_main_module_50 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_46, _x_main_module_49);
+auto _x_main_module_51 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_50);
+auto _x_main_module_52 = mmain->add_instruction(migraphx::make_op("identity"), _x_main_module_51);
+auto _x_main_module_53 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), _x_main_module_7);
+auto _x_main_module_54 = mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_52, _x_main_module_53);
+auto _x_main_module_55 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), _x_main_module_6);
+auto _x_main_module_56 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), _x_main_module_1);
+auto _x_main_module_57 = mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_55, _x_main_module_56);
+auto _x_main_module_58 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_54, _x_main_module_57);
+auto _x_main_module_59 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_58);
+auto _x_main_module_60 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), _x_main_module_5);
+auto _x_main_module_61 = mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_59, _x_main_module_60);
+auto _x_main_module_62 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), _x_main_module_4);
+auto _x_main_module_63 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), _x_main_module_0);
+auto _x_main_module_64 = mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_62, _x_main_module_63);
+auto _x_main_module_65 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_61, _x_main_module_64);
+mmain->add_return({_x_main_module_65});
+
 
     return p;
 }

--- a/src/driver/alexnet.cpp
+++ b/src/driver/alexnet.cpp
@@ -33,75 +33,190 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program alexnet(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-migraphx::module_ref mmain = p.get_main_module();
-auto _x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-auto _x_main_module_1 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 1)));
-auto _x_main_module_2 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 2)));
-auto _x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
-auto _x_main_module_4 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 3));
-auto _x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 4096}}, 4));
-auto _x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 5));
-auto _x_main_module_7 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 4096}}, 6));
-auto _x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 7));
-auto _x_main_module_9 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 9216}}, 8));
-auto _x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 9));
-auto _x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 10));
-auto _x_main_module_12 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 11));
-auto _x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 384, 3, 3}}, 12));
-auto _x_main_module_14 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13));
-auto _x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 192, 3, 3}}, 14));
-auto _x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 15));
-auto _x_main_module_17 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 64, 5, 5}}, 16));
-auto _x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 17));
-auto _x_main_module_19 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 3, 11, 11}}, 18));
-auto _x_main_module_20 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[4,4],\"use_dynamic_same_auto_pad\":0}")), _x_0, _x_main_module_19);
-auto _x_main_module_21 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,64,55,55]}")), _x_main_module_18);
-auto _x_main_module_22 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_20, _x_main_module_21);
-auto _x_main_module_23 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_22);
-auto _x_main_module_24 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), _x_main_module_23);
-auto _x_main_module_25 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_24, _x_main_module_17);
-auto _x_main_module_26 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,192,27,27]}")), _x_main_module_16);
-auto _x_main_module_27 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_25, _x_main_module_26);
-auto _x_main_module_28 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_27);
-auto _x_main_module_29 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), _x_main_module_28);
-auto _x_main_module_30 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_29, _x_main_module_15);
-auto _x_main_module_31 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,384,13,13]}")), _x_main_module_14);
-auto _x_main_module_32 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_30, _x_main_module_31);
-auto _x_main_module_33 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_32);
-auto _x_main_module_34 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_33, _x_main_module_13);
-auto _x_main_module_35 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")), _x_main_module_12);
-auto _x_main_module_36 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_34, _x_main_module_35);
-auto _x_main_module_37 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_36);
-auto _x_main_module_38 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_37, _x_main_module_11);
-auto _x_main_module_39 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")), _x_main_module_10);
-auto _x_main_module_40 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_38, _x_main_module_39);
-auto _x_main_module_41 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_40);
-auto _x_main_module_42 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), _x_main_module_41);
-auto _x_main_module_43 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_42);
-auto _x_main_module_44 = mmain->add_instruction(migraphx::make_op("identity"), _x_main_module_43);
-auto _x_main_module_45 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), _x_main_module_9);
-auto _x_main_module_46 = mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_44, _x_main_module_45);
-auto _x_main_module_47 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), _x_main_module_8);
-auto _x_main_module_48 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), _x_main_module_2);
-auto _x_main_module_49 = mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_47, _x_main_module_48);
-auto _x_main_module_50 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_46, _x_main_module_49);
-auto _x_main_module_51 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_50);
-auto _x_main_module_52 = mmain->add_instruction(migraphx::make_op("identity"), _x_main_module_51);
-auto _x_main_module_53 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), _x_main_module_7);
-auto _x_main_module_54 = mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_52, _x_main_module_53);
-auto _x_main_module_55 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), _x_main_module_6);
-auto _x_main_module_56 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), _x_main_module_1);
-auto _x_main_module_57 = mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_55, _x_main_module_56);
-auto _x_main_module_58 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_54, _x_main_module_57);
-auto _x_main_module_59 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_58);
-auto _x_main_module_60 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), _x_main_module_5);
-auto _x_main_module_61 = mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_59, _x_main_module_60);
-auto _x_main_module_62 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), _x_main_module_4);
-auto _x_main_module_63 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), _x_main_module_0);
-auto _x_main_module_64 = mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_62, _x_main_module_63);
-auto _x_main_module_65 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_61, _x_main_module_64);
-mmain->add_return({_x_main_module_65});
-
+    migraphx::module_ref mmain = p.get_main_module();
+    auto _x_main_module_0      = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+    auto _x_main_module_1      = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 1)));
+    auto _x_main_module_2      = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 2)));
+    auto _x_0                  = mmain->add_parameter(
+        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
+    auto _x_main_module_4 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 3));
+    auto _x_main_module_5 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 4096}}, 4));
+    auto _x_main_module_6 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 5));
+    auto _x_main_module_7 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 4096}}, 6));
+    auto _x_main_module_8 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 7));
+    auto _x_main_module_9 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 9216}}, 8));
+    auto _x_main_module_10 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 9));
+    auto _x_main_module_11 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 10));
+    auto _x_main_module_12 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 11));
+    auto _x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 384, 3, 3}}, 12));
+    auto _x_main_module_14 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13));
+    auto _x_main_module_15 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 192, 3, 3}}, 14));
+    auto _x_main_module_16 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 15));
+    auto _x_main_module_17 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 64, 5, 5}}, 16));
+    auto _x_main_module_18 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 17));
+    auto _x_main_module_19 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 3, 11, 11}}, 18));
+    auto _x_main_module_20 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
+                              "mode\":0,\"stride\":[4,4],\"use_dynamic_same_auto_pad\":0}")),
+        _x_0,
+        _x_main_module_19);
+    auto _x_main_module_21 = mmain->add_instruction(
+        migraphx::make_op("broadcast",
+                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,64,55,55]}")),
+        _x_main_module_18);
+    auto _x_main_module_22 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_20, _x_main_module_21);
+    auto _x_main_module_23 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_22);
+    auto _x_main_module_24 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        _x_main_module_23);
+    auto _x_main_module_25 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_24,
+        _x_main_module_17);
+    auto _x_main_module_26 = mmain->add_instruction(
+        migraphx::make_op("broadcast",
+                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,192,27,27]}")),
+        _x_main_module_16);
+    auto _x_main_module_27 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_25, _x_main_module_26);
+    auto _x_main_module_28 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_27);
+    auto _x_main_module_29 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        _x_main_module_28);
+    auto _x_main_module_30 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_29,
+        _x_main_module_15);
+    auto _x_main_module_31 = mmain->add_instruction(
+        migraphx::make_op("broadcast",
+                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,384,13,13]}")),
+        _x_main_module_14);
+    auto _x_main_module_32 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_30, _x_main_module_31);
+    auto _x_main_module_33 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_32);
+    auto _x_main_module_34 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_33,
+        _x_main_module_13);
+    auto _x_main_module_35 = mmain->add_instruction(
+        migraphx::make_op("broadcast",
+                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")),
+        _x_main_module_12);
+    auto _x_main_module_36 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_34, _x_main_module_35);
+    auto _x_main_module_37 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_36);
+    auto _x_main_module_38 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_37,
+        _x_main_module_11);
+    auto _x_main_module_39 = mmain->add_instruction(
+        migraphx::make_op("broadcast",
+                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")),
+        _x_main_module_10);
+    auto _x_main_module_40 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_38, _x_main_module_39);
+    auto _x_main_module_41 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_40);
+    auto _x_main_module_42 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        _x_main_module_41);
+    auto _x_main_module_43 = mmain->add_instruction(
+        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_42);
+    auto _x_main_module_44 =
+        mmain->add_instruction(migraphx::make_op("identity"), _x_main_module_43);
+    auto _x_main_module_45 = mmain->add_instruction(
+        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
+        _x_main_module_9);
+    auto _x_main_module_46 =
+        mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_44, _x_main_module_45);
+    auto _x_main_module_47 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
+        _x_main_module_8);
+    auto _x_main_module_48 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
+        _x_main_module_2);
+    auto _x_main_module_49 =
+        mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_47, _x_main_module_48);
+    auto _x_main_module_50 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_46, _x_main_module_49);
+    auto _x_main_module_51 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_50);
+    auto _x_main_module_52 =
+        mmain->add_instruction(migraphx::make_op("identity"), _x_main_module_51);
+    auto _x_main_module_53 = mmain->add_instruction(
+        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
+        _x_main_module_7);
+    auto _x_main_module_54 =
+        mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_52, _x_main_module_53);
+    auto _x_main_module_55 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
+        _x_main_module_6);
+    auto _x_main_module_56 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
+        _x_main_module_1);
+    auto _x_main_module_57 =
+        mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_55, _x_main_module_56);
+    auto _x_main_module_58 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_54, _x_main_module_57);
+    auto _x_main_module_59 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_58);
+    auto _x_main_module_60 = mmain->add_instruction(
+        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
+        _x_main_module_5);
+    auto _x_main_module_61 =
+        mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_59, _x_main_module_60);
+    auto _x_main_module_62 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        _x_main_module_4);
+    auto _x_main_module_63 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        _x_main_module_0);
+    auto _x_main_module_64 =
+        mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_62, _x_main_module_63);
+    auto _x_main_module_65 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_61, _x_main_module_64);
+    mmain->add_return({_x_main_module_65});
 
     return p;
 }

--- a/src/driver/alexnet.cpp
+++ b/src/driver/alexnet.cpp
@@ -32,75 +32,160 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program alexnet(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-migraphx::module_ref mmain = p.get_main_module();
-auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-auto x_main_module_1 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 1)));
-auto x_main_module_2 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 2)));
-auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
-auto x_main_module_4 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 3));
-auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 4096}}, 4));
-auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 5));
-auto x_main_module_7 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 4096}}, 6));
-auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 7));
-auto x_main_module_9 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 9216}}, 8));
-auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 9));
-auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 10));
-auto x_main_module_12 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 11));
-auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 384, 3, 3}}, 12));
-auto x_main_module_14 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13));
-auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 192, 3, 3}}, 14));
-auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 15));
-auto x_main_module_17 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 64, 5, 5}}, 16));
-auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 17));
-auto x_main_module_19 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 3, 11, 11}}, 18));
-auto x_main_module_20 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[4,4],use_dynamic_same_auto_pad:0}"), x_0, x_main_module_19);
-auto x_main_module_21 = mmain->add_instruction(migraphx::make_json_op("broadcast", "{axis:1,out_lens:[1,64,55,55]}"), x_main_module_18);
-auto x_main_module_22 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_20, x_main_module_21);
-auto x_main_module_23 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_22);
-auto x_main_module_24 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"), x_main_module_23);
-auto x_main_module_25 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_24, x_main_module_17);
-auto x_main_module_26 = mmain->add_instruction(migraphx::make_json_op("broadcast", "{axis:1,out_lens:[1,192,27,27]}"), x_main_module_16);
-auto x_main_module_27 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_25, x_main_module_26);
-auto x_main_module_28 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_27);
-auto x_main_module_29 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"), x_main_module_28);
-auto x_main_module_30 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_29, x_main_module_15);
-auto x_main_module_31 = mmain->add_instruction(migraphx::make_json_op("broadcast", "{axis:1,out_lens:[1,384,13,13]}"), x_main_module_14);
-auto x_main_module_32 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_30, x_main_module_31);
-auto x_main_module_33 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_32);
-auto x_main_module_34 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_33, x_main_module_13);
-auto x_main_module_35 = mmain->add_instruction(migraphx::make_json_op("broadcast", "{axis:1,out_lens:[1,256,13,13]}"), x_main_module_12);
-auto x_main_module_36 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_34, x_main_module_35);
-auto x_main_module_37 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_36);
-auto x_main_module_38 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_37, x_main_module_11);
-auto x_main_module_39 = mmain->add_instruction(migraphx::make_json_op("broadcast", "{axis:1,out_lens:[1,256,13,13]}"), x_main_module_10);
-auto x_main_module_40 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_38, x_main_module_39);
-auto x_main_module_41 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_40);
-auto x_main_module_42 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"), x_main_module_41);
-auto x_main_module_43 = mmain->add_instruction(migraphx::make_json_op("flatten", "{axis:1}"), x_main_module_42);
-auto x_main_module_44 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_43);
-auto x_main_module_45 = mmain->add_instruction(migraphx::make_json_op("transpose", "{permutation:[1,0]}"), x_main_module_9);
-auto x_main_module_46 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_44, x_main_module_45);
-auto x_main_module_47 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,4096]}"), x_main_module_8);
-auto x_main_module_48 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,4096]}"), x_main_module_2);
-auto x_main_module_49 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_47, x_main_module_48);
-auto x_main_module_50 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_46, x_main_module_49);
-auto x_main_module_51 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_50);
-auto x_main_module_52 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_51);
-auto x_main_module_53 = mmain->add_instruction(migraphx::make_json_op("transpose", "{permutation:[1,0]}"), x_main_module_7);
-auto x_main_module_54 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_52, x_main_module_53);
-auto x_main_module_55 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,4096]}"), x_main_module_6);
-auto x_main_module_56 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,4096]}"), x_main_module_1);
-auto x_main_module_57 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_55, x_main_module_56);
-auto x_main_module_58 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_54, x_main_module_57);
-auto x_main_module_59 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_58);
-auto x_main_module_60 = mmain->add_instruction(migraphx::make_json_op("transpose", "{permutation:[1,0]}"), x_main_module_5);
-auto x_main_module_61 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_59, x_main_module_60);
-auto x_main_module_62 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_4);
-auto x_main_module_63 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_0);
-auto x_main_module_64 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_62, x_main_module_63);
-auto x_main_module_65 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_61, x_main_module_64);
-mmain->add_return({x_main_module_65});
-
+    migraphx::module_ref mmain = p.get_main_module();
+    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+    auto x_main_module_1       = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 1)));
+    auto x_main_module_2       = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 2)));
+    auto x_0                   = mmain->add_parameter(
+        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
+    auto x_main_module_4 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 3));
+    auto x_main_module_5 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 4096}}, 4));
+    auto x_main_module_6 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 5));
+    auto x_main_module_7 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 4096}}, 6));
+    auto x_main_module_8 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 7));
+    auto x_main_module_9 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 9216}}, 8));
+    auto x_main_module_10 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 9));
+    auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 10));
+    auto x_main_module_12 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 11));
+    auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 384, 3, 3}}, 12));
+    auto x_main_module_14 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13));
+    auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 192, 3, 3}}, 14));
+    auto x_main_module_16 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 15));
+    auto x_main_module_17 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 64, 5, 5}}, 16));
+    auto x_main_module_18 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 17));
+    auto x_main_module_19 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 3, 11, 11}}, 18));
+    auto x_main_module_20 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[4,"
+                               "4],use_dynamic_same_auto_pad:0}"),
+        x_0,
+        x_main_module_19);
+    auto x_main_module_21 = mmain->add_instruction(
+        migraphx::make_json_op("broadcast", "{axis:1,out_lens:[1,64,55,55]}"), x_main_module_18);
+    auto x_main_module_22 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_20, x_main_module_21);
+    auto x_main_module_23 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_22);
+    auto x_main_module_24 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"),
+        x_main_module_23);
+    auto x_main_module_25 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_24,
+        x_main_module_17);
+    auto x_main_module_26 = mmain->add_instruction(
+        migraphx::make_json_op("broadcast", "{axis:1,out_lens:[1,192,27,27]}"), x_main_module_16);
+    auto x_main_module_27 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_25, x_main_module_26);
+    auto x_main_module_28 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_27);
+    auto x_main_module_29 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"),
+        x_main_module_28);
+    auto x_main_module_30 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_29,
+        x_main_module_15);
+    auto x_main_module_31 = mmain->add_instruction(
+        migraphx::make_json_op("broadcast", "{axis:1,out_lens:[1,384,13,13]}"), x_main_module_14);
+    auto x_main_module_32 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_30, x_main_module_31);
+    auto x_main_module_33 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_32);
+    auto x_main_module_34 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_33,
+        x_main_module_13);
+    auto x_main_module_35 = mmain->add_instruction(
+        migraphx::make_json_op("broadcast", "{axis:1,out_lens:[1,256,13,13]}"), x_main_module_12);
+    auto x_main_module_36 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_34, x_main_module_35);
+    auto x_main_module_37 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_36);
+    auto x_main_module_38 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_37,
+        x_main_module_11);
+    auto x_main_module_39 = mmain->add_instruction(
+        migraphx::make_json_op("broadcast", "{axis:1,out_lens:[1,256,13,13]}"), x_main_module_10);
+    auto x_main_module_40 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_38, x_main_module_39);
+    auto x_main_module_41 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_40);
+    auto x_main_module_42 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"),
+        x_main_module_41);
+    auto x_main_module_43 =
+        mmain->add_instruction(migraphx::make_json_op("flatten", "{axis:1}"), x_main_module_42);
+    auto x_main_module_44 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_43);
+    auto x_main_module_45 = mmain->add_instruction(
+        migraphx::make_json_op("transpose", "{permutation:[1,0]}"), x_main_module_9);
+    auto x_main_module_46 =
+        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_44, x_main_module_45);
+    auto x_main_module_47 = mmain->add_instruction(
+        migraphx::make_json_op("multibroadcast", "{out_lens:[1,4096]}"), x_main_module_8);
+    auto x_main_module_48 = mmain->add_instruction(
+        migraphx::make_json_op("multibroadcast", "{out_lens:[1,4096]}"), x_main_module_2);
+    auto x_main_module_49 =
+        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_47, x_main_module_48);
+    auto x_main_module_50 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_46, x_main_module_49);
+    auto x_main_module_51 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_50);
+    auto x_main_module_52 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_51);
+    auto x_main_module_53 = mmain->add_instruction(
+        migraphx::make_json_op("transpose", "{permutation:[1,0]}"), x_main_module_7);
+    auto x_main_module_54 =
+        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_52, x_main_module_53);
+    auto x_main_module_55 = mmain->add_instruction(
+        migraphx::make_json_op("multibroadcast", "{out_lens:[1,4096]}"), x_main_module_6);
+    auto x_main_module_56 = mmain->add_instruction(
+        migraphx::make_json_op("multibroadcast", "{out_lens:[1,4096]}"), x_main_module_1);
+    auto x_main_module_57 =
+        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_55, x_main_module_56);
+    auto x_main_module_58 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_54, x_main_module_57);
+    auto x_main_module_59 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_58);
+    auto x_main_module_60 = mmain->add_instruction(
+        migraphx::make_json_op("transpose", "{permutation:[1,0]}"), x_main_module_5);
+    auto x_main_module_61 =
+        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_59, x_main_module_60);
+    auto x_main_module_62 = mmain->add_instruction(
+        migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_4);
+    auto x_main_module_63 = mmain->add_instruction(
+        migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_0);
+    auto x_main_module_64 =
+        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_62, x_main_module_63);
+    auto x_main_module_65 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_61, x_main_module_64);
+    mmain->add_return({x_main_module_65});
 
     return p;
 }

--- a/src/driver/alexnet.cpp
+++ b/src/driver/alexnet.cpp
@@ -33,187 +33,75 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program alexnet(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-    migraphx::module_ref mmain = p.get_main_module();
-    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-    auto x_main_module_1       = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 1)));
-    auto x_main_module_2       = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 2)));
-    auto x_0                   = mmain->add_parameter(
-        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
-    auto x_main_module_4 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 3));
-    auto x_main_module_5 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 4096}}, 4));
-    auto x_main_module_6 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 5));
-    auto x_main_module_7 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 4096}}, 6));
-    auto x_main_module_8 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 7));
-    auto x_main_module_9 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 9216}}, 8));
-    auto x_main_module_10 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 9));
-    auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 10));
-    auto x_main_module_12 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 11));
-    auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 384, 3, 3}}, 12));
-    auto x_main_module_14 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13));
-    auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 192, 3, 3}}, 14));
-    auto x_main_module_16 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 15));
-    auto x_main_module_17 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 64, 5, 5}}, 16));
-    auto x_main_module_18 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 17));
-    auto x_main_module_19 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 3, 11, 11}}, 18));
-    auto x_main_module_20 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
-                              "mode\":0,\"stride\":[4,4],\"use_dynamic_same_auto_pad\":0}")),
-        x_0,
-        x_main_module_19);
-    auto x_main_module_21 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,64,55,55]}")),
-        x_main_module_18);
-    auto x_main_module_22 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_20, x_main_module_21);
-    auto x_main_module_23 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_22);
-    auto x_main_module_24 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        x_main_module_23);
-    auto x_main_module_25 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_24,
-        x_main_module_17);
-    auto x_main_module_26 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,192,27,27]}")),
-        x_main_module_16);
-    auto x_main_module_27 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_25, x_main_module_26);
-    auto x_main_module_28 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_27);
-    auto x_main_module_29 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        x_main_module_28);
-    auto x_main_module_30 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_29,
-        x_main_module_15);
-    auto x_main_module_31 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,384,13,13]}")),
-        x_main_module_14);
-    auto x_main_module_32 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_30, x_main_module_31);
-    auto x_main_module_33 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_32);
-    auto x_main_module_34 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_33,
-        x_main_module_13);
-    auto x_main_module_35 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")),
-        x_main_module_12);
-    auto x_main_module_36 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_34, x_main_module_35);
-    auto x_main_module_37 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_36);
-    auto x_main_module_38 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_37,
-        x_main_module_11);
-    auto x_main_module_39 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")),
-        x_main_module_10);
-    auto x_main_module_40 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_38, x_main_module_39);
-    auto x_main_module_41 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_40);
-    auto x_main_module_42 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        x_main_module_41);
-    auto x_main_module_43 = mmain->add_instruction(
-        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), x_main_module_42);
-    auto x_main_module_44 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_43);
-    auto x_main_module_45 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
-        x_main_module_9);
-    auto x_main_module_46 =
-        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_44, x_main_module_45);
-    auto x_main_module_47 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
-        x_main_module_8);
-    auto x_main_module_48 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
-        x_main_module_2);
-    auto x_main_module_49 =
-        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_47, x_main_module_48);
-    auto x_main_module_50 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_46, x_main_module_49);
-    auto x_main_module_51 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_50);
-    auto x_main_module_52 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_51);
-    auto x_main_module_53 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
-        x_main_module_7);
-    auto x_main_module_54 =
-        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_52, x_main_module_53);
-    auto x_main_module_55 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
-        x_main_module_6);
-    auto x_main_module_56 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")),
-        x_main_module_1);
-    auto x_main_module_57 =
-        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_55, x_main_module_56);
-    auto x_main_module_58 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_54, x_main_module_57);
-    auto x_main_module_59 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_58);
-    auto x_main_module_60 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
-        x_main_module_5);
-    auto x_main_module_61 =
-        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_59, x_main_module_60);
-    auto x_main_module_62 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        x_main_module_4);
-    auto x_main_module_63 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        x_main_module_0);
-    auto x_main_module_64 =
-        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_62, x_main_module_63);
-    auto x_main_module_65 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_61, x_main_module_64);
-    mmain->add_return({x_main_module_65});
+migraphx::module_ref mmain = p.get_main_module();
+auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+auto x_main_module_1 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 1)));
+auto x_main_module_2 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 2)));
+auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
+auto x_main_module_4 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 3));
+auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 4096}}, 4));
+auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 5));
+auto x_main_module_7 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 4096}}, 6));
+auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096}}, 7));
+auto x_main_module_9 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {4096, 9216}}, 8));
+auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 9));
+auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 10));
+auto x_main_module_12 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 11));
+auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 384, 3, 3}}, 12));
+auto x_main_module_14 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13));
+auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 192, 3, 3}}, 14));
+auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 15));
+auto x_main_module_17 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 64, 5, 5}}, 16));
+auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 17));
+auto x_main_module_19 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 3, 11, 11}}, 18));
+auto x_main_module_20 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[4,4],\"use_dynamic_same_auto_pad\":0}")), x_0, x_main_module_19); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_21 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,64,55,55]}")), x_main_module_18); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_22 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_20, x_main_module_21);
+auto x_main_module_23 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_22);
+auto x_main_module_24 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_23); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_25 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_24, x_main_module_17); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_26 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,192,27,27]}")), x_main_module_16); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_27 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_25, x_main_module_26);
+auto x_main_module_28 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_27);
+auto x_main_module_29 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_28); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_30 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_29, x_main_module_15); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_31 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,384,13,13]}")), x_main_module_14); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_32 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_30, x_main_module_31);
+auto x_main_module_33 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_32);
+auto x_main_module_34 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_33, x_main_module_13); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_35 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")), x_main_module_12); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_36 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_34, x_main_module_35);
+auto x_main_module_37 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_36);
+auto x_main_module_38 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_37, x_main_module_11); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_39 = mmain->add_instruction(migraphx::make_op("broadcast", migraphx::from_json_string("{\"axis\":1,\"out_lens\":[1,256,13,13]}")), x_main_module_10); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_40 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_38, x_main_module_39);
+auto x_main_module_41 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_40);
+auto x_main_module_42 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_41); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_43 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), x_main_module_42); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_44 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_43);
+auto x_main_module_45 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_9); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_46 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_44, x_main_module_45);
+auto x_main_module_47 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), x_main_module_8); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_48 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), x_main_module_2); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_49 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_47, x_main_module_48);
+auto x_main_module_50 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_46, x_main_module_49);
+auto x_main_module_51 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_50);
+auto x_main_module_52 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_51);
+auto x_main_module_53 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_7); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_54 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_52, x_main_module_53);
+auto x_main_module_55 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), x_main_module_6); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_56 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,4096]}")), x_main_module_1); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_57 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_55, x_main_module_56);
+auto x_main_module_58 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_54, x_main_module_57);
+auto x_main_module_59 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_58);
+auto x_main_module_60 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_5); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_61 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_59, x_main_module_60);
+auto x_main_module_62 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_4); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_63 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_0); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_64 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_62, x_main_module_63);
+auto x_main_module_65 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_61, x_main_module_64);
+mmain->add_return({x_main_module_65});
+
 
     return p;
 }

--- a/src/driver/inceptionv3.cpp
+++ b/src/driver/inceptionv3.cpp
@@ -25,7 +25,6 @@
 #include <migraphx/make_op.hpp>
 #include <migraphx/program.hpp>
 #include <migraphx/generate.hpp>
-#include <migraphx/json.hpp>
 #include "models.hpp"
 namespace migraphx {
 namespace driver {
@@ -33,2832 +32,802 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program inceptionv3(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-    migraphx::module_ref mmain = p.get_main_module();
-    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-    auto x_0                   = mmain->add_parameter(
-        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 299, 299}});
-    auto x_main_module_2 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
-    auto x_main_module_3 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
-    auto x_main_module_4 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 3)));
-    auto x_main_module_5 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 4));
-    auto x_main_module_6 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 5));
-    auto x_main_module_7  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 6)));
-    auto x_main_module_8  = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 2048, 1, 1}}, 7));
-    auto x_main_module_9  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 8)));
-    auto x_main_module_10 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 9));
-    auto x_main_module_11 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 10));
-    auto x_main_module_12 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 11)));
-    auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 12));
-    auto x_main_module_14 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13)));
-    auto x_main_module_15 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 14));
-    auto x_main_module_16 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 15));
-    auto x_main_module_17 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 16)));
-    auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 17));
-    auto x_main_module_19 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 18)));
-    auto x_main_module_20 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 19));
-    auto x_main_module_21 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 20));
-    auto x_main_module_22 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 21)));
-    auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 22));
-    auto x_main_module_24 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 23)));
-    auto x_main_module_25 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 24));
-    auto x_main_module_26 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 25));
-    auto x_main_module_27 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 26)));
-    auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {448, 2048, 1, 1}}, 27));
-    auto x_main_module_29 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 28)));
-    auto x_main_module_30 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 29)));
-    auto x_main_module_31 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 30));
-    auto x_main_module_32 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 31)));
-    auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 32));
-    auto x_main_module_34 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 33)));
-    auto x_main_module_35 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 34)));
-    auto x_main_module_36 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 35));
-    auto x_main_module_37 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 36)));
-    auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 37));
-    auto x_main_module_39 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 38)));
-    auto x_main_module_40 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 39));
-    auto x_main_module_41 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 40));
-    auto x_main_module_42 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 41)));
-    auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 2048, 1, 1}}, 42));
-    auto x_main_module_44 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 43)));
-    auto x_main_module_45 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 44));
-    auto x_main_module_46 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 45));
-    auto x_main_module_47 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 46)));
-    auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {320, 2048, 1, 1}}, 47));
-    auto x_main_module_49 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 48)));
-    auto x_main_module_50 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 49));
-    auto x_main_module_51 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 50));
-    auto x_main_module_52 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 51)));
-    auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 1280, 1, 1}}, 52));
-    auto x_main_module_54 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 53)));
-    auto x_main_module_55 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 54));
-    auto x_main_module_56 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 55));
-    auto x_main_module_57 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 56)));
-    auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 57));
-    auto x_main_module_59 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 58)));
-    auto x_main_module_60 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 59));
-    auto x_main_module_61 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 60));
-    auto x_main_module_62 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 61)));
-    auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 62));
-    auto x_main_module_64 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 63)));
-    auto x_main_module_65 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 64));
-    auto x_main_module_66 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 65));
-    auto x_main_module_67 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 66)));
-    auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 67));
-    auto x_main_module_69 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 68)));
-    auto x_main_module_70 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 69));
-    auto x_main_module_71 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 70));
-    auto x_main_module_72 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 71)));
-    auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {448, 1280, 1, 1}}, 72));
-    auto x_main_module_74 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 73)));
-    auto x_main_module_75 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 74));
-    auto x_main_module_76 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 75));
-    auto x_main_module_77 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 76)));
-    auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 77));
-    auto x_main_module_79 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 78)));
-    auto x_main_module_80 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 79));
-    auto x_main_module_81 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 80));
-    auto x_main_module_82 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 81)));
-    auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 82));
-    auto x_main_module_84 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 83)));
-    auto x_main_module_85 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 84));
-    auto x_main_module_86 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 85));
-    auto x_main_module_87 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 86)));
-    auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 1280, 1, 1}}, 87));
-    auto x_main_module_89 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 88)));
-    auto x_main_module_90 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 89));
-    auto x_main_module_91 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 90));
-    auto x_main_module_92 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 91)));
-    auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {320, 1280, 1, 1}}, 92));
-    auto x_main_module_94 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 93)));
-    auto x_main_module_95 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 94));
-    auto x_main_module_96 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 95));
-    auto x_main_module_97  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 96)));
-    auto x_main_module_98  = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 3, 3}}, 97));
-    auto x_main_module_99  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 98)));
-    auto x_main_module_100 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 99));
-    auto x_main_module_101 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 100));
-    auto x_main_module_102 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 101)));
-    auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 102));
-    auto x_main_module_104 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 103)));
-    auto x_main_module_105 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 104));
-    auto x_main_module_106 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 105));
-    auto x_main_module_107 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 106)));
-    auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 107));
-    auto x_main_module_109 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 108)));
-    auto x_main_module_110 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 109));
-    auto x_main_module_111 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 110));
-    auto x_main_module_112 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 111)));
-    auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 112));
-    auto x_main_module_114 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 113)));
-    auto x_main_module_115 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 114));
-    auto x_main_module_116 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 115));
-    auto x_main_module_117 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 116)));
-    auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {320, 192, 3, 3}}, 117));
-    auto x_main_module_119 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 118)));
-    auto x_main_module_120 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 119));
-    auto x_main_module_121 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 120));
-    auto x_main_module_122 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 121)));
-    auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 122));
-    auto x_main_module_124 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 123)));
-    auto x_main_module_125 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 124));
-    auto x_main_module_126 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 125));
-    auto x_main_module_127 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 126)));
-    auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 127));
-    auto x_main_module_129 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 128)));
-    auto x_main_module_130 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 129));
-    auto x_main_module_131 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 130));
-    auto x_main_module_132 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 131)));
-    auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 132));
-    auto x_main_module_134 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 133)));
-    auto x_main_module_135 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 134));
-    auto x_main_module_136 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 135));
-    auto x_main_module_137 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 136)));
-    auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 137));
-    auto x_main_module_139 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 138)));
-    auto x_main_module_140 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 139));
-    auto x_main_module_141 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 140));
-    auto x_main_module_142 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 141)));
-    auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 142));
-    auto x_main_module_144 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 143)));
-    auto x_main_module_145 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 144));
-    auto x_main_module_146 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 145));
-    auto x_main_module_147 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 146)));
-    auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 147));
-    auto x_main_module_149 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 148)));
-    auto x_main_module_150 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 149));
-    auto x_main_module_151 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 150));
-    auto x_main_module_152 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 151)));
-    auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 152));
-    auto x_main_module_154 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 153)));
-    auto x_main_module_155 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 154));
-    auto x_main_module_156 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 155));
-    auto x_main_module_157 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 156)));
-    auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 157));
-    auto x_main_module_159 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 158)));
-    auto x_main_module_160 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 159));
-    auto x_main_module_161 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 160));
-    auto x_main_module_162 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 161)));
-    auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 162));
-    auto x_main_module_164 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 163)));
-    auto x_main_module_165 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 164));
-    auto x_main_module_166 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 165));
-    auto x_main_module_167 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 166)));
-    auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 167));
-    auto x_main_module_169 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 168)));
-    auto x_main_module_170 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 169));
-    auto x_main_module_171 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 170));
-    auto x_main_module_172 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 171)));
-    auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 172));
-    auto x_main_module_174 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 173)));
-    auto x_main_module_175 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 174));
-    auto x_main_module_176 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 175));
-    auto x_main_module_177 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 176)));
-    auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 177));
-    auto x_main_module_179 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 178)));
-    auto x_main_module_180 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 179));
-    auto x_main_module_181 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 180));
-    auto x_main_module_182 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 181)));
-    auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 182));
-    auto x_main_module_184 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 183)));
-    auto x_main_module_185 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 184));
-    auto x_main_module_186 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 185));
-    auto x_main_module_187 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 186)));
-    auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 187));
-    auto x_main_module_189 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 188)));
-    auto x_main_module_190 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 189));
-    auto x_main_module_191 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 190));
-    auto x_main_module_192 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 191)));
-    auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 192));
-    auto x_main_module_194 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 193)));
-    auto x_main_module_195 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 194));
-    auto x_main_module_196 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 195));
-    auto x_main_module_197 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 196)));
-    auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 197));
-    auto x_main_module_199 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 198)));
-    auto x_main_module_200 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 199));
-    auto x_main_module_201 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 200));
-    auto x_main_module_202 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 201)));
-    auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 202));
-    auto x_main_module_204 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 203)));
-    auto x_main_module_205 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 204));
-    auto x_main_module_206 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 205));
-    auto x_main_module_207 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 206)));
-    auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 207));
-    auto x_main_module_209 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 208)));
-    auto x_main_module_210 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 209));
-    auto x_main_module_211 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 210));
-    auto x_main_module_212 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 211)));
-    auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 212));
-    auto x_main_module_214 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 213)));
-    auto x_main_module_215 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 214));
-    auto x_main_module_216 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 215));
-    auto x_main_module_217 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 216)));
-    auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 217));
-    auto x_main_module_219 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 218)));
-    auto x_main_module_220 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 219));
-    auto x_main_module_221 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 220));
-    auto x_main_module_222 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 221)));
-    auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 222));
-    auto x_main_module_224 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 223)));
-    auto x_main_module_225 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 224));
-    auto x_main_module_226 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 225));
-    auto x_main_module_227 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 226)));
-    auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 227));
-    auto x_main_module_229 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 228)));
-    auto x_main_module_230 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 229));
-    auto x_main_module_231 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 230));
-    auto x_main_module_232 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 231)));
-    auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 232));
-    auto x_main_module_234 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 233)));
-    auto x_main_module_235 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 234));
-    auto x_main_module_236 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 235));
-    auto x_main_module_237 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 236)));
-    auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 237));
-    auto x_main_module_239 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 238)));
-    auto x_main_module_240 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 239));
-    auto x_main_module_241 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 240));
-    auto x_main_module_242 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 241)));
-    auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 242));
-    auto x_main_module_244 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 243)));
-    auto x_main_module_245 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 244));
-    auto x_main_module_246 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 245));
-    auto x_main_module_247 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 246)));
-    auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 247));
-    auto x_main_module_249 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 248)));
-    auto x_main_module_250 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 249));
-    auto x_main_module_251 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 250));
-    auto x_main_module_252 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 251)));
-    auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 252));
-    auto x_main_module_254 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 253)));
-    auto x_main_module_255 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 254));
-    auto x_main_module_256 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 255));
-    auto x_main_module_257 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 256)));
-    auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 257));
-    auto x_main_module_259 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 258)));
-    auto x_main_module_260 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 259));
-    auto x_main_module_261 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 260));
-    auto x_main_module_262 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 261)));
-    auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 262));
-    auto x_main_module_264 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 263)));
-    auto x_main_module_265 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 264));
-    auto x_main_module_266 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 265));
-    auto x_main_module_267 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 266)));
-    auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 267));
-    auto x_main_module_269 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 268)));
-    auto x_main_module_270 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 269));
-    auto x_main_module_271 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 270));
-    auto x_main_module_272 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 271)));
-    auto x_main_module_273 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 272));
-    auto x_main_module_274 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 273)));
-    auto x_main_module_275 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 274));
-    auto x_main_module_276 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 275));
-    auto x_main_module_277 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 276)));
-    auto x_main_module_278 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 277));
-    auto x_main_module_279 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 278)));
-    auto x_main_module_280 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 279));
-    auto x_main_module_281 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 280));
-    auto x_main_module_282 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 281)));
-    auto x_main_module_283 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 128, 1, 7}}, 282));
-    auto x_main_module_284 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 283)));
-    auto x_main_module_285 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 284));
-    auto x_main_module_286 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 285));
-    auto x_main_module_287 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 286)));
-    auto x_main_module_288 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 287));
-    auto x_main_module_289 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 288)));
-    auto x_main_module_290 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 289));
-    auto x_main_module_291 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 290));
-    auto x_main_module_292 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 291)));
-    auto x_main_module_293 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 292));
-    auto x_main_module_294 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 293)));
-    auto x_main_module_295 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 294));
-    auto x_main_module_296 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 295));
-    auto x_main_module_297 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 296)));
-    auto x_main_module_298 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 297));
-    auto x_main_module_299 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 298)));
-    auto x_main_module_300 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 299));
-    auto x_main_module_301 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 300));
-    auto x_main_module_302 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 301)));
-    auto x_main_module_303 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 302));
-    auto x_main_module_304 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 303)));
-    auto x_main_module_305 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 304));
-    auto x_main_module_306 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 305));
-    auto x_main_module_307 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 306)));
-    auto x_main_module_308 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 128, 7, 1}}, 307));
-    auto x_main_module_309 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 308)));
-    auto x_main_module_310 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 309));
-    auto x_main_module_311 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 310));
-    auto x_main_module_312 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 311)));
-    auto x_main_module_313 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 312));
-    auto x_main_module_314 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 313)));
-    auto x_main_module_315 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 314));
-    auto x_main_module_316 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 315));
-    auto x_main_module_317 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 316)));
-    auto x_main_module_318 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 317));
-    auto x_main_module_319 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 318)));
-    auto x_main_module_320 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 319));
-    auto x_main_module_321 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 320));
-    auto x_main_module_322 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 321)));
-    auto x_main_module_323 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 322));
-    auto x_main_module_324 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 323)));
-    auto x_main_module_325 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 324));
-    auto x_main_module_326 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 325));
-    auto x_main_module_327 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 326)));
-    auto x_main_module_328 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 327));
-    auto x_main_module_329 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 328)));
-    auto x_main_module_330 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 329));
-    auto x_main_module_331 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 330));
-    auto x_main_module_332 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 331)));
-    auto x_main_module_333 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 332));
-    auto x_main_module_334 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 333)));
-    auto x_main_module_335 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 334));
-    auto x_main_module_336 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 335));
-    auto x_main_module_337 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 336)));
-    auto x_main_module_338 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 337));
-    auto x_main_module_339 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 338)));
-    auto x_main_module_340 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 339));
-    auto x_main_module_341 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 340));
-    auto x_main_module_342 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 341)));
-    auto x_main_module_343 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 288, 3, 3}}, 342));
-    auto x_main_module_344 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 343)));
-    auto x_main_module_345 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 344));
-    auto x_main_module_346 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 345));
-    auto x_main_module_347 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 346)));
-    auto x_main_module_348 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 347));
-    auto x_main_module_349 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 348)));
-    auto x_main_module_350 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 349));
-    auto x_main_module_351 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 350));
-    auto x_main_module_352 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 351)));
-    auto x_main_module_353 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 352));
-    auto x_main_module_354 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 353)));
-    auto x_main_module_355 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 354));
-    auto x_main_module_356 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 355));
-    auto x_main_module_357 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 356)));
-    auto x_main_module_358 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 357));
-    auto x_main_module_359 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 358)));
-    auto x_main_module_360 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 359));
-    auto x_main_module_361 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 360));
-    auto x_main_module_362 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 361)));
-    auto x_main_module_363 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 362));
-    auto x_main_module_364 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 363)));
-    auto x_main_module_365 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 364));
-    auto x_main_module_366 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 365));
-    auto x_main_module_367 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 366)));
-    auto x_main_module_368 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 367));
-    auto x_main_module_369 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 368)));
-    auto x_main_module_370 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 369));
-    auto x_main_module_371 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 370));
-    auto x_main_module_372 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 371)));
-    auto x_main_module_373 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {48, 288, 1, 1}}, 372));
-    auto x_main_module_374 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 373)));
-    auto x_main_module_375 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 374));
-    auto x_main_module_376 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 375));
-    auto x_main_module_377 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 376)));
-    auto x_main_module_378 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 377));
-    auto x_main_module_379 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 378)));
-    auto x_main_module_380 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 379));
-    auto x_main_module_381 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 380));
-    auto x_main_module_382 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 381)));
-    auto x_main_module_383 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 382));
-    auto x_main_module_384 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 383)));
-    auto x_main_module_385 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 384));
-    auto x_main_module_386 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 385));
-    auto x_main_module_387 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 386)));
-    auto x_main_module_388 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 387));
-    auto x_main_module_389 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 388)));
-    auto x_main_module_390 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 389));
-    auto x_main_module_391 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 390));
-    auto x_main_module_392 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 391)));
-    auto x_main_module_393 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 392));
-    auto x_main_module_394 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 393)));
-    auto x_main_module_395 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 394));
-    auto x_main_module_396 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 395));
-    auto x_main_module_397 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 396)));
-    auto x_main_module_398 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 397));
-    auto x_main_module_399 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 398)));
-    auto x_main_module_400 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 399));
-    auto x_main_module_401 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 400));
-    auto x_main_module_402 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 401)));
-    auto x_main_module_403 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 402));
-    auto x_main_module_404 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 403)));
-    auto x_main_module_405 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 404));
-    auto x_main_module_406 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 405));
-    auto x_main_module_407 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 406)));
-    auto x_main_module_408 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {48, 256, 1, 1}}, 407));
-    auto x_main_module_409 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 408)));
-    auto x_main_module_410 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 409));
-    auto x_main_module_411 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 410));
-    auto x_main_module_412 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 411)));
-    auto x_main_module_413 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 412));
-    auto x_main_module_414 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 413)));
-    auto x_main_module_415 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 414));
-    auto x_main_module_416 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 415));
-    auto x_main_module_417 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 416)));
-    auto x_main_module_418 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {32, 192, 1, 1}}, 417));
-    auto x_main_module_419 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 418)));
-    auto x_main_module_420 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 419));
-    auto x_main_module_421 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 420));
-    auto x_main_module_422 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 421)));
-    auto x_main_module_423 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 422));
-    auto x_main_module_424 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 423)));
-    auto x_main_module_425 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 424));
-    auto x_main_module_426 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 425));
-    auto x_main_module_427 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 426)));
-    auto x_main_module_428 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 427));
-    auto x_main_module_429 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 428)));
-    auto x_main_module_430 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 429));
-    auto x_main_module_431 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 430));
-    auto x_main_module_432 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 431)));
-    auto x_main_module_433 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 432));
-    auto x_main_module_434 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 433)));
-    auto x_main_module_435 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 434));
-    auto x_main_module_436 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 435));
-    auto x_main_module_437 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 436)));
-    auto x_main_module_438 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 437));
-    auto x_main_module_439 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 438)));
-    auto x_main_module_440 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 439));
-    auto x_main_module_441 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 440));
-    auto x_main_module_442 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 441)));
-    auto x_main_module_443 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {48, 192, 1, 1}}, 442));
-    auto x_main_module_444 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 443)));
-    auto x_main_module_445 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 444));
-    auto x_main_module_446 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 445));
-    auto x_main_module_447 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 446)));
-    auto x_main_module_448 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 447));
-    auto x_main_module_449 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 448)));
-    auto x_main_module_450 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 449));
-    auto x_main_module_451 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 450));
-    auto x_main_module_452 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 451)));
-    auto x_main_module_453 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 80, 3, 3}}, 452));
-    auto x_main_module_454 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 453)));
-    auto x_main_module_455 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 454));
-    auto x_main_module_456 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 455));
-    auto x_main_module_457 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 456)));
-    auto x_main_module_458 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {80, 64, 1, 1}}, 457));
-    auto x_main_module_459 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 458)));
-    auto x_main_module_460 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 459));
-    auto x_main_module_461 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 460));
-    auto x_main_module_462 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 461)));
-    auto x_main_module_463 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 32, 3, 3}}, 462));
-    auto x_main_module_464 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 463)));
-    auto x_main_module_465 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 464));
-    auto x_main_module_466 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 465));
-    auto x_main_module_467 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 466)));
-    auto x_main_module_468 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {32, 32, 3, 3}}, 467));
-    auto x_main_module_469 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 468)));
-    auto x_main_module_470 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 469));
-    auto x_main_module_471 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 470));
-    auto x_main_module_472 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 471)));
-    auto x_main_module_473 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {32, 3, 3, 3}}, 472));
-    auto x_main_module_474 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_0,
-        x_main_module_473); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_475 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_474,
-        x_main_module_472,
-        x_main_module_471,
-        x_main_module_470,
-        x_main_module_469); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_476 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_475);
-    auto x_main_module_477 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_476,
-        x_main_module_468); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_478 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_477,
-        x_main_module_467,
-        x_main_module_466,
-        x_main_module_465,
-        x_main_module_464); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_479 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_478);
-    auto x_main_module_480 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_479,
-        x_main_module_463); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_481 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_480,
-        x_main_module_462,
-        x_main_module_461,
-        x_main_module_460,
-        x_main_module_459); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_482 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_481);
-    auto x_main_module_483 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        x_main_module_482); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_484 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_483,
-        x_main_module_458); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_485 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_484,
-        x_main_module_457,
-        x_main_module_456,
-        x_main_module_455,
-        x_main_module_454); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_486 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_485);
-    auto x_main_module_487 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_486,
-        x_main_module_453); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_488 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_487,
-        x_main_module_452,
-        x_main_module_451,
-        x_main_module_450,
-        x_main_module_449); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_489 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_488);
-    auto x_main_module_490 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        x_main_module_489); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_491 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_490,
-        x_main_module_448); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_492 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_491,
-        x_main_module_447,
-        x_main_module_446,
-        x_main_module_445,
-        x_main_module_444); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_493 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_492);
-    auto x_main_module_494 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_490,
-        x_main_module_443); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_495 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_494,
-        x_main_module_442,
-        x_main_module_441,
-        x_main_module_440,
-        x_main_module_439); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_496 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_495);
-    auto x_main_module_497 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_496,
-        x_main_module_438); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_498 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_497,
-        x_main_module_437,
-        x_main_module_436,
-        x_main_module_435,
-        x_main_module_434); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_499 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_498);
-    auto x_main_module_500 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_490,
-        x_main_module_433); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_501 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_500,
-        x_main_module_432,
-        x_main_module_431,
-        x_main_module_430,
-        x_main_module_429); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_502 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_501);
-    auto x_main_module_503 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_502,
-        x_main_module_428); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_504 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_503,
-        x_main_module_427,
-        x_main_module_426,
-        x_main_module_425,
-        x_main_module_424); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_505 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_504);
-    auto x_main_module_506 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_505,
-        x_main_module_423); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_507 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_506,
-        x_main_module_422,
-        x_main_module_421,
-        x_main_module_420,
-        x_main_module_419); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_508 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_507);
-    auto x_main_module_509 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_490); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_510 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_509,
-        x_main_module_418); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_511 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_510,
-        x_main_module_417,
-        x_main_module_416,
-        x_main_module_415,
-        x_main_module_414); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_512 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_511);
-    auto x_main_module_513 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_493,
-        x_main_module_499,
-        x_main_module_508,
-        x_main_module_512); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_514 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_513,
-        x_main_module_413); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_515 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_514,
-        x_main_module_412,
-        x_main_module_411,
-        x_main_module_410,
-        x_main_module_409); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_516 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_515);
-    auto x_main_module_517 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_513,
-        x_main_module_408); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_518 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_517,
-        x_main_module_407,
-        x_main_module_406,
-        x_main_module_405,
-        x_main_module_404); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_519 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_518);
-    auto x_main_module_520 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_519,
-        x_main_module_403); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_521 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_520,
-        x_main_module_402,
-        x_main_module_401,
-        x_main_module_400,
-        x_main_module_399); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_522 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_521);
-    auto x_main_module_523 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_513,
-        x_main_module_398); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_524 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_523,
-        x_main_module_397,
-        x_main_module_396,
-        x_main_module_395,
-        x_main_module_394); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_525 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_524);
-    auto x_main_module_526 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_525,
-        x_main_module_393); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_527 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_526,
-        x_main_module_392,
-        x_main_module_391,
-        x_main_module_390,
-        x_main_module_389); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_528 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_527);
-    auto x_main_module_529 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_528,
-        x_main_module_388); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_530 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_529,
-        x_main_module_387,
-        x_main_module_386,
-        x_main_module_385,
-        x_main_module_384); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_531 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_530);
-    auto x_main_module_532 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_513); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_533 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_532,
-        x_main_module_383); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_534 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_533,
-        x_main_module_382,
-        x_main_module_381,
-        x_main_module_380,
-        x_main_module_379); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_535 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_534);
-    auto x_main_module_536 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_516,
-        x_main_module_522,
-        x_main_module_531,
-        x_main_module_535); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_537 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_536,
-        x_main_module_378); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_538 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_537,
-        x_main_module_377,
-        x_main_module_376,
-        x_main_module_375,
-        x_main_module_374); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_539 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_538);
-    auto x_main_module_540 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_536,
-        x_main_module_373); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_541 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_540,
-        x_main_module_372,
-        x_main_module_371,
-        x_main_module_370,
-        x_main_module_369); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_542 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_541);
-    auto x_main_module_543 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_542,
-        x_main_module_368); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_544 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_543,
-        x_main_module_367,
-        x_main_module_366,
-        x_main_module_365,
-        x_main_module_364); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_545 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_544);
-    auto x_main_module_546 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_536,
-        x_main_module_363); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_547 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_546,
-        x_main_module_362,
-        x_main_module_361,
-        x_main_module_360,
-        x_main_module_359); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_548 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_547);
-    auto x_main_module_549 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_548,
-        x_main_module_358); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_550 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_549,
-        x_main_module_357,
-        x_main_module_356,
-        x_main_module_355,
-        x_main_module_354); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_551 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_550);
-    auto x_main_module_552 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_551,
-        x_main_module_353); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_553 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_552,
-        x_main_module_352,
-        x_main_module_351,
-        x_main_module_350,
-        x_main_module_349); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_554 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_553);
-    auto x_main_module_555 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_536); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_556 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_555,
-        x_main_module_348); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_557 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_556,
-        x_main_module_347,
-        x_main_module_346,
-        x_main_module_345,
-        x_main_module_344); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_558 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_557);
-    auto x_main_module_559 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_539,
-        x_main_module_545,
-        x_main_module_554,
-        x_main_module_558); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_560 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_559,
-        x_main_module_343); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_561 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_560,
-        x_main_module_342,
-        x_main_module_341,
-        x_main_module_340,
-        x_main_module_339); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_562 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_561);
-    auto x_main_module_563 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_559,
-        x_main_module_338); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_564 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_563,
-        x_main_module_337,
-        x_main_module_336,
-        x_main_module_335,
-        x_main_module_334); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_565 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_564);
-    auto x_main_module_566 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_565,
-        x_main_module_333); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_567 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_566,
-        x_main_module_332,
-        x_main_module_331,
-        x_main_module_330,
-        x_main_module_329); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_568 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_567);
-    auto x_main_module_569 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_568,
-        x_main_module_328); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_570 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_569,
-        x_main_module_327,
-        x_main_module_326,
-        x_main_module_325,
-        x_main_module_324); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_571 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_570);
-    auto x_main_module_572 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        x_main_module_559); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_573 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_562,
-        x_main_module_571,
-        x_main_module_572); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_574 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_573,
-        x_main_module_323); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_575 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_574,
-        x_main_module_322,
-        x_main_module_321,
-        x_main_module_320,
-        x_main_module_319); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_576 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_575);
-    auto x_main_module_577 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_573,
-        x_main_module_318); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_578 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_577,
-        x_main_module_317,
-        x_main_module_316,
-        x_main_module_315,
-        x_main_module_314); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_579 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_578);
-    auto x_main_module_580 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_579,
-        x_main_module_313); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_581 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_580,
-        x_main_module_312,
-        x_main_module_311,
-        x_main_module_310,
-        x_main_module_309); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_582 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_581);
-    auto x_main_module_583 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_582,
-        x_main_module_308); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_584 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_583,
-        x_main_module_307,
-        x_main_module_306,
-        x_main_module_305,
-        x_main_module_304); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_585 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_584);
-    auto x_main_module_586 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_573,
-        x_main_module_303); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_587 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_586,
-        x_main_module_302,
-        x_main_module_301,
-        x_main_module_300,
-        x_main_module_299); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_588 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_587);
-    auto x_main_module_589 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_588,
-        x_main_module_298); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_590 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_589,
-        x_main_module_297,
-        x_main_module_296,
-        x_main_module_295,
-        x_main_module_294); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_591 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_590);
-    auto x_main_module_592 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_591,
-        x_main_module_293); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_593 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_592,
-        x_main_module_292,
-        x_main_module_291,
-        x_main_module_290,
-        x_main_module_289); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_594 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_593);
-    auto x_main_module_595 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_594,
-        x_main_module_288); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_596 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_595,
-        x_main_module_287,
-        x_main_module_286,
-        x_main_module_285,
-        x_main_module_284); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_597 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_596);
-    auto x_main_module_598 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_597,
-        x_main_module_283); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_599 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_598,
-        x_main_module_282,
-        x_main_module_281,
-        x_main_module_280,
-        x_main_module_279); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_600 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_599);
-    auto x_main_module_601 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_573); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_602 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_601,
-        x_main_module_278); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_603 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_602,
-        x_main_module_277,
-        x_main_module_276,
-        x_main_module_275,
-        x_main_module_274); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_604 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_603);
-    auto x_main_module_605 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_576,
-        x_main_module_585,
-        x_main_module_600,
-        x_main_module_604); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_606 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_605,
-        x_main_module_273); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_607 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_606,
-        x_main_module_272,
-        x_main_module_271,
-        x_main_module_270,
-        x_main_module_269); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_608 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_607);
-    auto x_main_module_609 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_605,
-        x_main_module_268); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_610 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_609,
-        x_main_module_267,
-        x_main_module_266,
-        x_main_module_265,
-        x_main_module_264); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_611 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_610);
-    auto x_main_module_612 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_611,
-        x_main_module_263); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_613 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_612,
-        x_main_module_262,
-        x_main_module_261,
-        x_main_module_260,
-        x_main_module_259); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_614 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_613);
-    auto x_main_module_615 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_614,
-        x_main_module_258); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_616 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_615,
-        x_main_module_257,
-        x_main_module_256,
-        x_main_module_255,
-        x_main_module_254); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_617 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_616);
-    auto x_main_module_618 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_605,
-        x_main_module_253); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_619 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_618,
-        x_main_module_252,
-        x_main_module_251,
-        x_main_module_250,
-        x_main_module_249); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_620 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_619);
-    auto x_main_module_621 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_620,
-        x_main_module_248); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_622 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_621,
-        x_main_module_247,
-        x_main_module_246,
-        x_main_module_245,
-        x_main_module_244); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_623 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_622);
-    auto x_main_module_624 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_623,
-        x_main_module_243); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_625 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_624,
-        x_main_module_242,
-        x_main_module_241,
-        x_main_module_240,
-        x_main_module_239); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_626 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_625);
-    auto x_main_module_627 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_626,
-        x_main_module_238); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_628 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_627,
-        x_main_module_237,
-        x_main_module_236,
-        x_main_module_235,
-        x_main_module_234); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_629 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_628);
-    auto x_main_module_630 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_629,
-        x_main_module_233); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_631 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_630,
-        x_main_module_232,
-        x_main_module_231,
-        x_main_module_230,
-        x_main_module_229); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_632 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_631);
-    auto x_main_module_633 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_605); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_634 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_633,
-        x_main_module_228); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_635 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_634,
-        x_main_module_227,
-        x_main_module_226,
-        x_main_module_225,
-        x_main_module_224); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_636 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_635);
-    auto x_main_module_637 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_608,
-        x_main_module_617,
-        x_main_module_632,
-        x_main_module_636); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_638 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_637,
-        x_main_module_223); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_639 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_638,
-        x_main_module_222,
-        x_main_module_221,
-        x_main_module_220,
-        x_main_module_219); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_640 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_639);
-    auto x_main_module_641 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_637,
-        x_main_module_218); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_642 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_641,
-        x_main_module_217,
-        x_main_module_216,
-        x_main_module_215,
-        x_main_module_214); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_643 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_642);
-    auto x_main_module_644 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_643,
-        x_main_module_213); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_645 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_644,
-        x_main_module_212,
-        x_main_module_211,
-        x_main_module_210,
-        x_main_module_209); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_646 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_645);
-    auto x_main_module_647 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_646,
-        x_main_module_208); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_648 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_647,
-        x_main_module_207,
-        x_main_module_206,
-        x_main_module_205,
-        x_main_module_204); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_649 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_648);
-    auto x_main_module_650 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_637,
-        x_main_module_203); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_651 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_650,
-        x_main_module_202,
-        x_main_module_201,
-        x_main_module_200,
-        x_main_module_199); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_652 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_651);
-    auto x_main_module_653 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_652,
-        x_main_module_198); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_654 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_653,
-        x_main_module_197,
-        x_main_module_196,
-        x_main_module_195,
-        x_main_module_194); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_655 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_654);
-    auto x_main_module_656 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_655,
-        x_main_module_193); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_657 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_656,
-        x_main_module_192,
-        x_main_module_191,
-        x_main_module_190,
-        x_main_module_189); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_658 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_657);
-    auto x_main_module_659 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_658,
-        x_main_module_188); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_660 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_659,
-        x_main_module_187,
-        x_main_module_186,
-        x_main_module_185,
-        x_main_module_184); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_661 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_660);
-    auto x_main_module_662 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_661,
-        x_main_module_183); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_663 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_662,
-        x_main_module_182,
-        x_main_module_181,
-        x_main_module_180,
-        x_main_module_179); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_664 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_663);
-    auto x_main_module_665 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_637); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_666 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_665,
-        x_main_module_178); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_667 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_666,
-        x_main_module_177,
-        x_main_module_176,
-        x_main_module_175,
-        x_main_module_174); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_668 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_667);
-    auto x_main_module_669 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_640,
-        x_main_module_649,
-        x_main_module_664,
-        x_main_module_668); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_670 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_669,
-        x_main_module_173); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_671 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_670,
-        x_main_module_172,
-        x_main_module_171,
-        x_main_module_170,
-        x_main_module_169); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_672 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_671);
-    auto x_main_module_673 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_669,
-        x_main_module_168); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_674 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_673,
-        x_main_module_167,
-        x_main_module_166,
-        x_main_module_165,
-        x_main_module_164); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_675 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_674);
-    auto x_main_module_676 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_675,
-        x_main_module_163); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_677 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_676,
-        x_main_module_162,
-        x_main_module_161,
-        x_main_module_160,
-        x_main_module_159); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_678 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_677);
-    auto x_main_module_679 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_678,
-        x_main_module_158); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_680 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_679,
-        x_main_module_157,
-        x_main_module_156,
-        x_main_module_155,
-        x_main_module_154); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_681 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_680);
-    auto x_main_module_682 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_669,
-        x_main_module_153); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_683 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_682,
-        x_main_module_152,
-        x_main_module_151,
-        x_main_module_150,
-        x_main_module_149); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_684 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_683);
-    auto x_main_module_685 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_684,
-        x_main_module_148); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_686 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_685,
-        x_main_module_147,
-        x_main_module_146,
-        x_main_module_145,
-        x_main_module_144); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_687 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_686);
-    auto x_main_module_688 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_687,
-        x_main_module_143); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_689 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_688,
-        x_main_module_142,
-        x_main_module_141,
-        x_main_module_140,
-        x_main_module_139); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_690 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_689);
-    auto x_main_module_691 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_690,
-        x_main_module_138); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_692 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_691,
-        x_main_module_137,
-        x_main_module_136,
-        x_main_module_135,
-        x_main_module_134); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_693 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_692);
-    auto x_main_module_694 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_693,
-        x_main_module_133); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_695 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_694,
-        x_main_module_132,
-        x_main_module_131,
-        x_main_module_130,
-        x_main_module_129); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_696 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_695);
-    auto x_main_module_697 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_669); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_698 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_697,
-        x_main_module_128); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_699 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_698,
-        x_main_module_127,
-        x_main_module_126,
-        x_main_module_125,
-        x_main_module_124); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_700 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_699);
-    auto x_main_module_701 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_672,
-        x_main_module_681,
-        x_main_module_696,
-        x_main_module_700); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_702 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_701,
-        x_main_module_123); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_703 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_702,
-        x_main_module_122,
-        x_main_module_121,
-        x_main_module_120,
-        x_main_module_119); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_704 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_703);
-    auto x_main_module_705 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_704,
-        x_main_module_118); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_706 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_705,
-        x_main_module_117,
-        x_main_module_116,
-        x_main_module_115,
-        x_main_module_114); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_707 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_706);
-    auto x_main_module_708 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_701,
-        x_main_module_113); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_709 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_708,
-        x_main_module_112,
-        x_main_module_111,
-        x_main_module_110,
-        x_main_module_109); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_710 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_709);
-    auto x_main_module_711 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_710,
-        x_main_module_108); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_712 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_711,
-        x_main_module_107,
-        x_main_module_106,
-        x_main_module_105,
-        x_main_module_104); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_713 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_712);
-    auto x_main_module_714 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_713,
-        x_main_module_103); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_715 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_714,
-        x_main_module_102,
-        x_main_module_101,
-        x_main_module_100,
-        x_main_module_99); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_716 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_715);
-    auto x_main_module_717 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_716,
-        x_main_module_98); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_718 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_717,
-        x_main_module_97,
-        x_main_module_96,
-        x_main_module_95,
-        x_main_module_94); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_719 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_718);
-    auto x_main_module_720 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        x_main_module_701); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_721 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_707,
-        x_main_module_719,
-        x_main_module_720); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_722 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_721,
-        x_main_module_93); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_723 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_722,
-        x_main_module_92,
-        x_main_module_91,
-        x_main_module_90,
-        x_main_module_89); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_724 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_723);
-    auto x_main_module_725 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_721,
-        x_main_module_88); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_726 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_725,
-        x_main_module_87,
-        x_main_module_86,
-        x_main_module_85,
-        x_main_module_84); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_727 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_726);
-    auto x_main_module_728 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_727,
-        x_main_module_83); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_729 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_728,
-        x_main_module_82,
-        x_main_module_81,
-        x_main_module_80,
-        x_main_module_79); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_730 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_729);
-    auto x_main_module_731 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_727,
-        x_main_module_78); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_732 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_731,
-        x_main_module_77,
-        x_main_module_76,
-        x_main_module_75,
-        x_main_module_74); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_733 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_732);
-    auto x_main_module_734 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_730,
-        x_main_module_733); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_735 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_721,
-        x_main_module_73); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_736 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_735,
-        x_main_module_72,
-        x_main_module_71,
-        x_main_module_70,
-        x_main_module_69); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_737 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_736);
-    auto x_main_module_738 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_737,
-        x_main_module_68); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_739 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_738,
-        x_main_module_67,
-        x_main_module_66,
-        x_main_module_65,
-        x_main_module_64); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_740 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_739);
-    auto x_main_module_741 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_740,
-        x_main_module_63); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_742 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_741,
-        x_main_module_62,
-        x_main_module_61,
-        x_main_module_60,
-        x_main_module_59); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_743 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_742);
-    auto x_main_module_744 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_740,
-        x_main_module_58); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_745 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_744,
-        x_main_module_57,
-        x_main_module_56,
-        x_main_module_55,
-        x_main_module_54); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_746 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_745);
-    auto x_main_module_747 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_743,
-        x_main_module_746); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_748 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_721); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_749 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_748,
-        x_main_module_53); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_750 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_749,
-        x_main_module_52,
-        x_main_module_51,
-        x_main_module_50,
-        x_main_module_49); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_751 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_750);
-    auto x_main_module_752 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_724,
-        x_main_module_734,
-        x_main_module_747,
-        x_main_module_751); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_753 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_752,
-        x_main_module_48); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_754 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_753,
-        x_main_module_47,
-        x_main_module_46,
-        x_main_module_45,
-        x_main_module_44); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_755 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_754);
-    auto x_main_module_756 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_752,
-        x_main_module_43); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_757 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_756,
-        x_main_module_42,
-        x_main_module_41,
-        x_main_module_40,
-        x_main_module_39); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_758 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_757);
-    auto x_main_module_759 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_758,
-        x_main_module_38); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_760 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_759,
-        x_main_module_37,
-        x_main_module_36,
-        x_main_module_35,
-        x_main_module_34); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_761 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_760);
-    auto x_main_module_762 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_758,
-        x_main_module_33); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_763 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_762,
-        x_main_module_32,
-        x_main_module_31,
-        x_main_module_30,
-        x_main_module_29); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_764 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_763);
-    auto x_main_module_765 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_761,
-        x_main_module_764); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_766 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_752,
-        x_main_module_28); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_767 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_766,
-        x_main_module_27,
-        x_main_module_26,
-        x_main_module_25,
-        x_main_module_24); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_768 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_767);
-    auto x_main_module_769 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_768,
-        x_main_module_23); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_770 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_769,
-        x_main_module_22,
-        x_main_module_21,
-        x_main_module_20,
-        x_main_module_19); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_771 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_770);
-    auto x_main_module_772 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_771,
-        x_main_module_18); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_773 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_772,
-        x_main_module_17,
-        x_main_module_16,
-        x_main_module_15,
-        x_main_module_14); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_774 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_773);
-    auto x_main_module_775 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_771,
-        x_main_module_13); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_776 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_775,
-        x_main_module_12,
-        x_main_module_11,
-        x_main_module_10,
-        x_main_module_9); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_777 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_776);
-    auto x_main_module_778 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_774,
-        x_main_module_777); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_779 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_752); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_780 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_779,
-        x_main_module_8); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_781 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_780,
-        x_main_module_7,
-        x_main_module_6,
-        x_main_module_5,
-        x_main_module_4); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_782 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_781);
-    auto x_main_module_783 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_755,
-        x_main_module_765,
-        x_main_module_778,
-        x_main_module_782); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_784 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[8,8],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[0,0,0,0],\"stride\":[8,8]}")),
-        x_main_module_783); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_785 =
-        mmain->add_instruction(migraphx::make_op("identity"), x_main_module_784);
-    auto x_main_module_786 = mmain->add_instruction(
-        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_785); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_787 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
-        x_main_module_3); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_788 =
-        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_786, x_main_module_787);
-    auto x_main_module_789 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        x_main_module_2); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_790 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        x_main_module_0); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_791 =
-        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_789, x_main_module_790);
-    auto x_main_module_792 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_788, x_main_module_791);
-    mmain->add_return({x_main_module_792});
+migraphx::module_ref mmain = p.get_main_module();
+auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 299, 299}});
+auto x_main_module_2 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
+auto x_main_module_3 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
+auto x_main_module_4 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 3)));
+auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 4));
+auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 5));
+auto x_main_module_7 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 6)));
+auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 2048, 1, 1}}, 7));
+auto x_main_module_9 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 8)));
+auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 9));
+auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 10));
+auto x_main_module_12 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 11)));
+auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 12));
+auto x_main_module_14 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13)));
+auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 14));
+auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 15));
+auto x_main_module_17 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 16)));
+auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 17));
+auto x_main_module_19 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 18)));
+auto x_main_module_20 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 19));
+auto x_main_module_21 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 20));
+auto x_main_module_22 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 21)));
+auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 22));
+auto x_main_module_24 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 23)));
+auto x_main_module_25 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 24));
+auto x_main_module_26 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 25));
+auto x_main_module_27 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 26)));
+auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448, 2048, 1, 1}}, 27));
+auto x_main_module_29 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 28)));
+auto x_main_module_30 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 29)));
+auto x_main_module_31 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 30));
+auto x_main_module_32 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 31)));
+auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 32));
+auto x_main_module_34 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 33)));
+auto x_main_module_35 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 34)));
+auto x_main_module_36 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 35));
+auto x_main_module_37 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 36)));
+auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 37));
+auto x_main_module_39 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 38)));
+auto x_main_module_40 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 39));
+auto x_main_module_41 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 40));
+auto x_main_module_42 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 41)));
+auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 2048, 1, 1}}, 42));
+auto x_main_module_44 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 43)));
+auto x_main_module_45 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 44));
+auto x_main_module_46 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 45));
+auto x_main_module_47 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 46)));
+auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 2048, 1, 1}}, 47));
+auto x_main_module_49 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 48)));
+auto x_main_module_50 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 49));
+auto x_main_module_51 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 50));
+auto x_main_module_52 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 51)));
+auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 1280, 1, 1}}, 52));
+auto x_main_module_54 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 53)));
+auto x_main_module_55 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 54));
+auto x_main_module_56 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 55));
+auto x_main_module_57 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 56)));
+auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 57));
+auto x_main_module_59 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 58)));
+auto x_main_module_60 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 59));
+auto x_main_module_61 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 60));
+auto x_main_module_62 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 61)));
+auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 62));
+auto x_main_module_64 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 63)));
+auto x_main_module_65 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 64));
+auto x_main_module_66 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 65));
+auto x_main_module_67 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 66)));
+auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 67));
+auto x_main_module_69 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 68)));
+auto x_main_module_70 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 69));
+auto x_main_module_71 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 70));
+auto x_main_module_72 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 71)));
+auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448, 1280, 1, 1}}, 72));
+auto x_main_module_74 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 73)));
+auto x_main_module_75 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 74));
+auto x_main_module_76 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 75));
+auto x_main_module_77 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 76)));
+auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 77));
+auto x_main_module_79 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 78)));
+auto x_main_module_80 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 79));
+auto x_main_module_81 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 80));
+auto x_main_module_82 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 81)));
+auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 82));
+auto x_main_module_84 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 83)));
+auto x_main_module_85 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 84));
+auto x_main_module_86 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 85));
+auto x_main_module_87 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 86)));
+auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 1280, 1, 1}}, 87));
+auto x_main_module_89 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 88)));
+auto x_main_module_90 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 89));
+auto x_main_module_91 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 90));
+auto x_main_module_92 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 91)));
+auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 1280, 1, 1}}, 92));
+auto x_main_module_94 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 93)));
+auto x_main_module_95 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 94));
+auto x_main_module_96 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 95));
+auto x_main_module_97 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 96)));
+auto x_main_module_98 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 3, 3}}, 97));
+auto x_main_module_99 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 98)));
+auto x_main_module_100 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 99));
+auto x_main_module_101 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 100));
+auto x_main_module_102 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 101)));
+auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 102));
+auto x_main_module_104 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 103)));
+auto x_main_module_105 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 104));
+auto x_main_module_106 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 105));
+auto x_main_module_107 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 106)));
+auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 107));
+auto x_main_module_109 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 108)));
+auto x_main_module_110 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 109));
+auto x_main_module_111 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 110));
+auto x_main_module_112 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 111)));
+auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 112));
+auto x_main_module_114 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 113)));
+auto x_main_module_115 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 114));
+auto x_main_module_116 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 115));
+auto x_main_module_117 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 116)));
+auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 192, 3, 3}}, 117));
+auto x_main_module_119 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 118)));
+auto x_main_module_120 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 119));
+auto x_main_module_121 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 120));
+auto x_main_module_122 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 121)));
+auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 122));
+auto x_main_module_124 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 123)));
+auto x_main_module_125 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 124));
+auto x_main_module_126 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 125));
+auto x_main_module_127 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 126)));
+auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 127));
+auto x_main_module_129 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 128)));
+auto x_main_module_130 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 129));
+auto x_main_module_131 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 130));
+auto x_main_module_132 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 131)));
+auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 132));
+auto x_main_module_134 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 133)));
+auto x_main_module_135 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 134));
+auto x_main_module_136 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 135));
+auto x_main_module_137 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 136)));
+auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 137));
+auto x_main_module_139 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 138)));
+auto x_main_module_140 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 139));
+auto x_main_module_141 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 140));
+auto x_main_module_142 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 141)));
+auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 142));
+auto x_main_module_144 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 143)));
+auto x_main_module_145 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 144));
+auto x_main_module_146 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 145));
+auto x_main_module_147 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 146)));
+auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 147));
+auto x_main_module_149 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 148)));
+auto x_main_module_150 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 149));
+auto x_main_module_151 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 150));
+auto x_main_module_152 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 151)));
+auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 152));
+auto x_main_module_154 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 153)));
+auto x_main_module_155 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 154));
+auto x_main_module_156 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 155));
+auto x_main_module_157 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 156)));
+auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 157));
+auto x_main_module_159 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 158)));
+auto x_main_module_160 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 159));
+auto x_main_module_161 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 160));
+auto x_main_module_162 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 161)));
+auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 162));
+auto x_main_module_164 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 163)));
+auto x_main_module_165 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 164));
+auto x_main_module_166 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 165));
+auto x_main_module_167 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 166)));
+auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 167));
+auto x_main_module_169 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 168)));
+auto x_main_module_170 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 169));
+auto x_main_module_171 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 170));
+auto x_main_module_172 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 171)));
+auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 172));
+auto x_main_module_174 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 173)));
+auto x_main_module_175 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 174));
+auto x_main_module_176 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 175));
+auto x_main_module_177 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 176)));
+auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 177));
+auto x_main_module_179 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 178)));
+auto x_main_module_180 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 179));
+auto x_main_module_181 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 180));
+auto x_main_module_182 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 181)));
+auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 182));
+auto x_main_module_184 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 183)));
+auto x_main_module_185 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 184));
+auto x_main_module_186 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 185));
+auto x_main_module_187 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 186)));
+auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 187));
+auto x_main_module_189 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 188)));
+auto x_main_module_190 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 189));
+auto x_main_module_191 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 190));
+auto x_main_module_192 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 191)));
+auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 192));
+auto x_main_module_194 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 193)));
+auto x_main_module_195 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 194));
+auto x_main_module_196 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 195));
+auto x_main_module_197 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 196)));
+auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 197));
+auto x_main_module_199 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 198)));
+auto x_main_module_200 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 199));
+auto x_main_module_201 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 200));
+auto x_main_module_202 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 201)));
+auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 202));
+auto x_main_module_204 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 203)));
+auto x_main_module_205 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 204));
+auto x_main_module_206 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 205));
+auto x_main_module_207 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 206)));
+auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 207));
+auto x_main_module_209 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 208)));
+auto x_main_module_210 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 209));
+auto x_main_module_211 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 210));
+auto x_main_module_212 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 211)));
+auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 212));
+auto x_main_module_214 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 213)));
+auto x_main_module_215 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 214));
+auto x_main_module_216 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 215));
+auto x_main_module_217 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 216)));
+auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 217));
+auto x_main_module_219 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 218)));
+auto x_main_module_220 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 219));
+auto x_main_module_221 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 220));
+auto x_main_module_222 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 221)));
+auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 222));
+auto x_main_module_224 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 223)));
+auto x_main_module_225 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 224));
+auto x_main_module_226 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 225));
+auto x_main_module_227 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 226)));
+auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 227));
+auto x_main_module_229 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 228)));
+auto x_main_module_230 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 229));
+auto x_main_module_231 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 230));
+auto x_main_module_232 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 231)));
+auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 232));
+auto x_main_module_234 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 233)));
+auto x_main_module_235 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 234));
+auto x_main_module_236 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 235));
+auto x_main_module_237 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 236)));
+auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 237));
+auto x_main_module_239 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 238)));
+auto x_main_module_240 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 239));
+auto x_main_module_241 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 240));
+auto x_main_module_242 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 241)));
+auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 242));
+auto x_main_module_244 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 243)));
+auto x_main_module_245 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 244));
+auto x_main_module_246 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 245));
+auto x_main_module_247 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 246)));
+auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 247));
+auto x_main_module_249 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 248)));
+auto x_main_module_250 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 249));
+auto x_main_module_251 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 250));
+auto x_main_module_252 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 251)));
+auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 252));
+auto x_main_module_254 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 253)));
+auto x_main_module_255 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 254));
+auto x_main_module_256 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 255));
+auto x_main_module_257 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 256)));
+auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 257));
+auto x_main_module_259 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 258)));
+auto x_main_module_260 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 259));
+auto x_main_module_261 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 260));
+auto x_main_module_262 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 261)));
+auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 262));
+auto x_main_module_264 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 263)));
+auto x_main_module_265 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 264));
+auto x_main_module_266 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 265));
+auto x_main_module_267 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 266)));
+auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 267));
+auto x_main_module_269 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 268)));
+auto x_main_module_270 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 269));
+auto x_main_module_271 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 270));
+auto x_main_module_272 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 271)));
+auto x_main_module_273 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 272));
+auto x_main_module_274 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 273)));
+auto x_main_module_275 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 274));
+auto x_main_module_276 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 275));
+auto x_main_module_277 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 276)));
+auto x_main_module_278 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 277));
+auto x_main_module_279 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 278)));
+auto x_main_module_280 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 279));
+auto x_main_module_281 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 280));
+auto x_main_module_282 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 281)));
+auto x_main_module_283 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 128, 1, 7}}, 282));
+auto x_main_module_284 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 283)));
+auto x_main_module_285 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 284));
+auto x_main_module_286 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 285));
+auto x_main_module_287 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 286)));
+auto x_main_module_288 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 287));
+auto x_main_module_289 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 288)));
+auto x_main_module_290 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 289));
+auto x_main_module_291 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 290));
+auto x_main_module_292 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 291)));
+auto x_main_module_293 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 292));
+auto x_main_module_294 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 293)));
+auto x_main_module_295 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 294));
+auto x_main_module_296 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 295));
+auto x_main_module_297 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 296)));
+auto x_main_module_298 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 297));
+auto x_main_module_299 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 298)));
+auto x_main_module_300 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 299));
+auto x_main_module_301 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 300));
+auto x_main_module_302 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 301)));
+auto x_main_module_303 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 302));
+auto x_main_module_304 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 303)));
+auto x_main_module_305 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 304));
+auto x_main_module_306 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 305));
+auto x_main_module_307 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 306)));
+auto x_main_module_308 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 128, 7, 1}}, 307));
+auto x_main_module_309 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 308)));
+auto x_main_module_310 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 309));
+auto x_main_module_311 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 310));
+auto x_main_module_312 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 311)));
+auto x_main_module_313 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 312));
+auto x_main_module_314 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 313)));
+auto x_main_module_315 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 314));
+auto x_main_module_316 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 315));
+auto x_main_module_317 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 316)));
+auto x_main_module_318 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 317));
+auto x_main_module_319 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 318)));
+auto x_main_module_320 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 319));
+auto x_main_module_321 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 320));
+auto x_main_module_322 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 321)));
+auto x_main_module_323 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 322));
+auto x_main_module_324 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 323)));
+auto x_main_module_325 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 324));
+auto x_main_module_326 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 325));
+auto x_main_module_327 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 326)));
+auto x_main_module_328 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 327));
+auto x_main_module_329 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 328)));
+auto x_main_module_330 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 329));
+auto x_main_module_331 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 330));
+auto x_main_module_332 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 331)));
+auto x_main_module_333 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 332));
+auto x_main_module_334 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 333)));
+auto x_main_module_335 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 334));
+auto x_main_module_336 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 335));
+auto x_main_module_337 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 336)));
+auto x_main_module_338 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 337));
+auto x_main_module_339 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 338)));
+auto x_main_module_340 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 339));
+auto x_main_module_341 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 340));
+auto x_main_module_342 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 341)));
+auto x_main_module_343 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 288, 3, 3}}, 342));
+auto x_main_module_344 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 343)));
+auto x_main_module_345 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 344));
+auto x_main_module_346 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 345));
+auto x_main_module_347 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 346)));
+auto x_main_module_348 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 347));
+auto x_main_module_349 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 348)));
+auto x_main_module_350 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 349));
+auto x_main_module_351 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 350));
+auto x_main_module_352 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 351)));
+auto x_main_module_353 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 352));
+auto x_main_module_354 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 353)));
+auto x_main_module_355 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 354));
+auto x_main_module_356 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 355));
+auto x_main_module_357 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 356)));
+auto x_main_module_358 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 357));
+auto x_main_module_359 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 358)));
+auto x_main_module_360 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 359));
+auto x_main_module_361 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 360));
+auto x_main_module_362 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 361)));
+auto x_main_module_363 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 362));
+auto x_main_module_364 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 363)));
+auto x_main_module_365 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 364));
+auto x_main_module_366 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 365));
+auto x_main_module_367 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 366)));
+auto x_main_module_368 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 367));
+auto x_main_module_369 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 368)));
+auto x_main_module_370 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 369));
+auto x_main_module_371 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 370));
+auto x_main_module_372 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 371)));
+auto x_main_module_373 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 288, 1, 1}}, 372));
+auto x_main_module_374 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 373)));
+auto x_main_module_375 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 374));
+auto x_main_module_376 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 375));
+auto x_main_module_377 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 376)));
+auto x_main_module_378 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 377));
+auto x_main_module_379 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 378)));
+auto x_main_module_380 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 379));
+auto x_main_module_381 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 380));
+auto x_main_module_382 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 381)));
+auto x_main_module_383 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 382));
+auto x_main_module_384 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 383)));
+auto x_main_module_385 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 384));
+auto x_main_module_386 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 385));
+auto x_main_module_387 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 386)));
+auto x_main_module_388 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 387));
+auto x_main_module_389 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 388)));
+auto x_main_module_390 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 389));
+auto x_main_module_391 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 390));
+auto x_main_module_392 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 391)));
+auto x_main_module_393 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 392));
+auto x_main_module_394 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 393)));
+auto x_main_module_395 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 394));
+auto x_main_module_396 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 395));
+auto x_main_module_397 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 396)));
+auto x_main_module_398 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 397));
+auto x_main_module_399 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 398)));
+auto x_main_module_400 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 399));
+auto x_main_module_401 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 400));
+auto x_main_module_402 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 401)));
+auto x_main_module_403 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 402));
+auto x_main_module_404 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 403)));
+auto x_main_module_405 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 404));
+auto x_main_module_406 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 405));
+auto x_main_module_407 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 406)));
+auto x_main_module_408 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 256, 1, 1}}, 407));
+auto x_main_module_409 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 408)));
+auto x_main_module_410 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 409));
+auto x_main_module_411 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 410));
+auto x_main_module_412 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 411)));
+auto x_main_module_413 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 412));
+auto x_main_module_414 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 413)));
+auto x_main_module_415 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 414));
+auto x_main_module_416 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 415));
+auto x_main_module_417 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 416)));
+auto x_main_module_418 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 192, 1, 1}}, 417));
+auto x_main_module_419 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 418)));
+auto x_main_module_420 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 419));
+auto x_main_module_421 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 420));
+auto x_main_module_422 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 421)));
+auto x_main_module_423 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 422));
+auto x_main_module_424 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 423)));
+auto x_main_module_425 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 424));
+auto x_main_module_426 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 425));
+auto x_main_module_427 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 426)));
+auto x_main_module_428 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 427));
+auto x_main_module_429 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 428)));
+auto x_main_module_430 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 429));
+auto x_main_module_431 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 430));
+auto x_main_module_432 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 431)));
+auto x_main_module_433 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 432));
+auto x_main_module_434 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 433)));
+auto x_main_module_435 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 434));
+auto x_main_module_436 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 435));
+auto x_main_module_437 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 436)));
+auto x_main_module_438 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 437));
+auto x_main_module_439 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 438)));
+auto x_main_module_440 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 439));
+auto x_main_module_441 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 440));
+auto x_main_module_442 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 441)));
+auto x_main_module_443 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 192, 1, 1}}, 442));
+auto x_main_module_444 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 443)));
+auto x_main_module_445 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 444));
+auto x_main_module_446 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 445));
+auto x_main_module_447 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 446)));
+auto x_main_module_448 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 447));
+auto x_main_module_449 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 448)));
+auto x_main_module_450 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 449));
+auto x_main_module_451 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 450));
+auto x_main_module_452 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 451)));
+auto x_main_module_453 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 80, 3, 3}}, 452));
+auto x_main_module_454 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 453)));
+auto x_main_module_455 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 454));
+auto x_main_module_456 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 455));
+auto x_main_module_457 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 456)));
+auto x_main_module_458 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80, 64, 1, 1}}, 457));
+auto x_main_module_459 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 458)));
+auto x_main_module_460 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 459));
+auto x_main_module_461 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 460));
+auto x_main_module_462 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 461)));
+auto x_main_module_463 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 32, 3, 3}}, 462));
+auto x_main_module_464 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 463)));
+auto x_main_module_465 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 464));
+auto x_main_module_466 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 465));
+auto x_main_module_467 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 466)));
+auto x_main_module_468 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 32, 3, 3}}, 467));
+auto x_main_module_469 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 468)));
+auto x_main_module_470 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 469));
+auto x_main_module_471 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 470));
+auto x_main_module_472 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 471)));
+auto x_main_module_473 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 3, 3, 3}}, 472));
+auto x_main_module_474 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_0, x_main_module_473);
+auto x_main_module_475 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_474, x_main_module_472, x_main_module_471, x_main_module_470, x_main_module_469);
+auto x_main_module_476 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_475);
+auto x_main_module_477 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_476, x_main_module_468);
+auto x_main_module_478 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_477, x_main_module_467, x_main_module_466, x_main_module_465, x_main_module_464);
+auto x_main_module_479 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_478);
+auto x_main_module_480 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_479, x_main_module_463);
+auto x_main_module_481 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_480, x_main_module_462, x_main_module_461, x_main_module_460, x_main_module_459);
+auto x_main_module_482 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_481);
+auto x_main_module_483 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"), x_main_module_482);
+auto x_main_module_484 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_483, x_main_module_458);
+auto x_main_module_485 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_484, x_main_module_457, x_main_module_456, x_main_module_455, x_main_module_454);
+auto x_main_module_486 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_485);
+auto x_main_module_487 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_486, x_main_module_453);
+auto x_main_module_488 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_487, x_main_module_452, x_main_module_451, x_main_module_450, x_main_module_449);
+auto x_main_module_489 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_488);
+auto x_main_module_490 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"), x_main_module_489);
+auto x_main_module_491 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_490, x_main_module_448);
+auto x_main_module_492 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_491, x_main_module_447, x_main_module_446, x_main_module_445, x_main_module_444);
+auto x_main_module_493 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_492);
+auto x_main_module_494 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_490, x_main_module_443);
+auto x_main_module_495 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_494, x_main_module_442, x_main_module_441, x_main_module_440, x_main_module_439);
+auto x_main_module_496 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_495);
+auto x_main_module_497 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_496, x_main_module_438);
+auto x_main_module_498 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_497, x_main_module_437, x_main_module_436, x_main_module_435, x_main_module_434);
+auto x_main_module_499 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_498);
+auto x_main_module_500 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_490, x_main_module_433);
+auto x_main_module_501 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_500, x_main_module_432, x_main_module_431, x_main_module_430, x_main_module_429);
+auto x_main_module_502 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_501);
+auto x_main_module_503 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_502, x_main_module_428);
+auto x_main_module_504 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_503, x_main_module_427, x_main_module_426, x_main_module_425, x_main_module_424);
+auto x_main_module_505 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_504);
+auto x_main_module_506 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_505, x_main_module_423);
+auto x_main_module_507 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_506, x_main_module_422, x_main_module_421, x_main_module_420, x_main_module_419);
+auto x_main_module_508 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_507);
+auto x_main_module_509 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_490);
+auto x_main_module_510 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_509, x_main_module_418);
+auto x_main_module_511 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_510, x_main_module_417, x_main_module_416, x_main_module_415, x_main_module_414);
+auto x_main_module_512 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_511);
+auto x_main_module_513 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_493, x_main_module_499, x_main_module_508, x_main_module_512);
+auto x_main_module_514 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_513, x_main_module_413);
+auto x_main_module_515 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_514, x_main_module_412, x_main_module_411, x_main_module_410, x_main_module_409);
+auto x_main_module_516 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_515);
+auto x_main_module_517 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_513, x_main_module_408);
+auto x_main_module_518 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_517, x_main_module_407, x_main_module_406, x_main_module_405, x_main_module_404);
+auto x_main_module_519 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_518);
+auto x_main_module_520 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_519, x_main_module_403);
+auto x_main_module_521 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_520, x_main_module_402, x_main_module_401, x_main_module_400, x_main_module_399);
+auto x_main_module_522 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_521);
+auto x_main_module_523 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_513, x_main_module_398);
+auto x_main_module_524 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_523, x_main_module_397, x_main_module_396, x_main_module_395, x_main_module_394);
+auto x_main_module_525 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_524);
+auto x_main_module_526 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_525, x_main_module_393);
+auto x_main_module_527 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_526, x_main_module_392, x_main_module_391, x_main_module_390, x_main_module_389);
+auto x_main_module_528 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_527);
+auto x_main_module_529 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_528, x_main_module_388);
+auto x_main_module_530 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_529, x_main_module_387, x_main_module_386, x_main_module_385, x_main_module_384);
+auto x_main_module_531 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_530);
+auto x_main_module_532 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_513);
+auto x_main_module_533 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_532, x_main_module_383);
+auto x_main_module_534 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_533, x_main_module_382, x_main_module_381, x_main_module_380, x_main_module_379);
+auto x_main_module_535 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_534);
+auto x_main_module_536 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_516, x_main_module_522, x_main_module_531, x_main_module_535);
+auto x_main_module_537 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_536, x_main_module_378);
+auto x_main_module_538 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_537, x_main_module_377, x_main_module_376, x_main_module_375, x_main_module_374);
+auto x_main_module_539 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_538);
+auto x_main_module_540 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_536, x_main_module_373);
+auto x_main_module_541 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_540, x_main_module_372, x_main_module_371, x_main_module_370, x_main_module_369);
+auto x_main_module_542 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_541);
+auto x_main_module_543 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_542, x_main_module_368);
+auto x_main_module_544 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_543, x_main_module_367, x_main_module_366, x_main_module_365, x_main_module_364);
+auto x_main_module_545 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_544);
+auto x_main_module_546 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_536, x_main_module_363);
+auto x_main_module_547 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_546, x_main_module_362, x_main_module_361, x_main_module_360, x_main_module_359);
+auto x_main_module_548 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_547);
+auto x_main_module_549 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_548, x_main_module_358);
+auto x_main_module_550 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_549, x_main_module_357, x_main_module_356, x_main_module_355, x_main_module_354);
+auto x_main_module_551 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_550);
+auto x_main_module_552 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_551, x_main_module_353);
+auto x_main_module_553 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_552, x_main_module_352, x_main_module_351, x_main_module_350, x_main_module_349);
+auto x_main_module_554 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_553);
+auto x_main_module_555 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_536);
+auto x_main_module_556 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_555, x_main_module_348);
+auto x_main_module_557 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_556, x_main_module_347, x_main_module_346, x_main_module_345, x_main_module_344);
+auto x_main_module_558 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_557);
+auto x_main_module_559 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_539, x_main_module_545, x_main_module_554, x_main_module_558);
+auto x_main_module_560 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_559, x_main_module_343);
+auto x_main_module_561 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_560, x_main_module_342, x_main_module_341, x_main_module_340, x_main_module_339);
+auto x_main_module_562 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_561);
+auto x_main_module_563 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_559, x_main_module_338);
+auto x_main_module_564 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_563, x_main_module_337, x_main_module_336, x_main_module_335, x_main_module_334);
+auto x_main_module_565 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_564);
+auto x_main_module_566 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_565, x_main_module_333);
+auto x_main_module_567 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_566, x_main_module_332, x_main_module_331, x_main_module_330, x_main_module_329);
+auto x_main_module_568 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_567);
+auto x_main_module_569 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_568, x_main_module_328);
+auto x_main_module_570 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_569, x_main_module_327, x_main_module_326, x_main_module_325, x_main_module_324);
+auto x_main_module_571 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_570);
+auto x_main_module_572 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"), x_main_module_559);
+auto x_main_module_573 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_562, x_main_module_571, x_main_module_572);
+auto x_main_module_574 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_573, x_main_module_323);
+auto x_main_module_575 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_574, x_main_module_322, x_main_module_321, x_main_module_320, x_main_module_319);
+auto x_main_module_576 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_575);
+auto x_main_module_577 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_573, x_main_module_318);
+auto x_main_module_578 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_577, x_main_module_317, x_main_module_316, x_main_module_315, x_main_module_314);
+auto x_main_module_579 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_578);
+auto x_main_module_580 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_579, x_main_module_313);
+auto x_main_module_581 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_580, x_main_module_312, x_main_module_311, x_main_module_310, x_main_module_309);
+auto x_main_module_582 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_581);
+auto x_main_module_583 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_582, x_main_module_308);
+auto x_main_module_584 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_583, x_main_module_307, x_main_module_306, x_main_module_305, x_main_module_304);
+auto x_main_module_585 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_584);
+auto x_main_module_586 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_573, x_main_module_303);
+auto x_main_module_587 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_586, x_main_module_302, x_main_module_301, x_main_module_300, x_main_module_299);
+auto x_main_module_588 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_587);
+auto x_main_module_589 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_588, x_main_module_298);
+auto x_main_module_590 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_589, x_main_module_297, x_main_module_296, x_main_module_295, x_main_module_294);
+auto x_main_module_591 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_590);
+auto x_main_module_592 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_591, x_main_module_293);
+auto x_main_module_593 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_592, x_main_module_292, x_main_module_291, x_main_module_290, x_main_module_289);
+auto x_main_module_594 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_593);
+auto x_main_module_595 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_594, x_main_module_288);
+auto x_main_module_596 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_595, x_main_module_287, x_main_module_286, x_main_module_285, x_main_module_284);
+auto x_main_module_597 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_596);
+auto x_main_module_598 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_597, x_main_module_283);
+auto x_main_module_599 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_598, x_main_module_282, x_main_module_281, x_main_module_280, x_main_module_279);
+auto x_main_module_600 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_599);
+auto x_main_module_601 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_573);
+auto x_main_module_602 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_601, x_main_module_278);
+auto x_main_module_603 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_602, x_main_module_277, x_main_module_276, x_main_module_275, x_main_module_274);
+auto x_main_module_604 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_603);
+auto x_main_module_605 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_576, x_main_module_585, x_main_module_600, x_main_module_604);
+auto x_main_module_606 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_605, x_main_module_273);
+auto x_main_module_607 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_606, x_main_module_272, x_main_module_271, x_main_module_270, x_main_module_269);
+auto x_main_module_608 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_607);
+auto x_main_module_609 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_605, x_main_module_268);
+auto x_main_module_610 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_609, x_main_module_267, x_main_module_266, x_main_module_265, x_main_module_264);
+auto x_main_module_611 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_610);
+auto x_main_module_612 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_611, x_main_module_263);
+auto x_main_module_613 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_612, x_main_module_262, x_main_module_261, x_main_module_260, x_main_module_259);
+auto x_main_module_614 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_613);
+auto x_main_module_615 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_614, x_main_module_258);
+auto x_main_module_616 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_615, x_main_module_257, x_main_module_256, x_main_module_255, x_main_module_254);
+auto x_main_module_617 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_616);
+auto x_main_module_618 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_605, x_main_module_253);
+auto x_main_module_619 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_618, x_main_module_252, x_main_module_251, x_main_module_250, x_main_module_249);
+auto x_main_module_620 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_619);
+auto x_main_module_621 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_620, x_main_module_248);
+auto x_main_module_622 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_621, x_main_module_247, x_main_module_246, x_main_module_245, x_main_module_244);
+auto x_main_module_623 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_622);
+auto x_main_module_624 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_623, x_main_module_243);
+auto x_main_module_625 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_624, x_main_module_242, x_main_module_241, x_main_module_240, x_main_module_239);
+auto x_main_module_626 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_625);
+auto x_main_module_627 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_626, x_main_module_238);
+auto x_main_module_628 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_627, x_main_module_237, x_main_module_236, x_main_module_235, x_main_module_234);
+auto x_main_module_629 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_628);
+auto x_main_module_630 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_629, x_main_module_233);
+auto x_main_module_631 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_630, x_main_module_232, x_main_module_231, x_main_module_230, x_main_module_229);
+auto x_main_module_632 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_631);
+auto x_main_module_633 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_605);
+auto x_main_module_634 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_633, x_main_module_228);
+auto x_main_module_635 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_634, x_main_module_227, x_main_module_226, x_main_module_225, x_main_module_224);
+auto x_main_module_636 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_635);
+auto x_main_module_637 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_608, x_main_module_617, x_main_module_632, x_main_module_636);
+auto x_main_module_638 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_637, x_main_module_223);
+auto x_main_module_639 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_638, x_main_module_222, x_main_module_221, x_main_module_220, x_main_module_219);
+auto x_main_module_640 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_639);
+auto x_main_module_641 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_637, x_main_module_218);
+auto x_main_module_642 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_641, x_main_module_217, x_main_module_216, x_main_module_215, x_main_module_214);
+auto x_main_module_643 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_642);
+auto x_main_module_644 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_643, x_main_module_213);
+auto x_main_module_645 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_644, x_main_module_212, x_main_module_211, x_main_module_210, x_main_module_209);
+auto x_main_module_646 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_645);
+auto x_main_module_647 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_646, x_main_module_208);
+auto x_main_module_648 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_647, x_main_module_207, x_main_module_206, x_main_module_205, x_main_module_204);
+auto x_main_module_649 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_648);
+auto x_main_module_650 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_637, x_main_module_203);
+auto x_main_module_651 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_650, x_main_module_202, x_main_module_201, x_main_module_200, x_main_module_199);
+auto x_main_module_652 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_651);
+auto x_main_module_653 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_652, x_main_module_198);
+auto x_main_module_654 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_653, x_main_module_197, x_main_module_196, x_main_module_195, x_main_module_194);
+auto x_main_module_655 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_654);
+auto x_main_module_656 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_655, x_main_module_193);
+auto x_main_module_657 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_656, x_main_module_192, x_main_module_191, x_main_module_190, x_main_module_189);
+auto x_main_module_658 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_657);
+auto x_main_module_659 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_658, x_main_module_188);
+auto x_main_module_660 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_659, x_main_module_187, x_main_module_186, x_main_module_185, x_main_module_184);
+auto x_main_module_661 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_660);
+auto x_main_module_662 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_661, x_main_module_183);
+auto x_main_module_663 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_662, x_main_module_182, x_main_module_181, x_main_module_180, x_main_module_179);
+auto x_main_module_664 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_663);
+auto x_main_module_665 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_637);
+auto x_main_module_666 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_665, x_main_module_178);
+auto x_main_module_667 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_666, x_main_module_177, x_main_module_176, x_main_module_175, x_main_module_174);
+auto x_main_module_668 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_667);
+auto x_main_module_669 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_640, x_main_module_649, x_main_module_664, x_main_module_668);
+auto x_main_module_670 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_669, x_main_module_173);
+auto x_main_module_671 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_670, x_main_module_172, x_main_module_171, x_main_module_170, x_main_module_169);
+auto x_main_module_672 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_671);
+auto x_main_module_673 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_669, x_main_module_168);
+auto x_main_module_674 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_673, x_main_module_167, x_main_module_166, x_main_module_165, x_main_module_164);
+auto x_main_module_675 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_674);
+auto x_main_module_676 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_675, x_main_module_163);
+auto x_main_module_677 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_676, x_main_module_162, x_main_module_161, x_main_module_160, x_main_module_159);
+auto x_main_module_678 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_677);
+auto x_main_module_679 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_678, x_main_module_158);
+auto x_main_module_680 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_679, x_main_module_157, x_main_module_156, x_main_module_155, x_main_module_154);
+auto x_main_module_681 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_680);
+auto x_main_module_682 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_669, x_main_module_153);
+auto x_main_module_683 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_682, x_main_module_152, x_main_module_151, x_main_module_150, x_main_module_149);
+auto x_main_module_684 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_683);
+auto x_main_module_685 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_684, x_main_module_148);
+auto x_main_module_686 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_685, x_main_module_147, x_main_module_146, x_main_module_145, x_main_module_144);
+auto x_main_module_687 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_686);
+auto x_main_module_688 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_687, x_main_module_143);
+auto x_main_module_689 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_688, x_main_module_142, x_main_module_141, x_main_module_140, x_main_module_139);
+auto x_main_module_690 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_689);
+auto x_main_module_691 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_690, x_main_module_138);
+auto x_main_module_692 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_691, x_main_module_137, x_main_module_136, x_main_module_135, x_main_module_134);
+auto x_main_module_693 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_692);
+auto x_main_module_694 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_693, x_main_module_133);
+auto x_main_module_695 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_694, x_main_module_132, x_main_module_131, x_main_module_130, x_main_module_129);
+auto x_main_module_696 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_695);
+auto x_main_module_697 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_669);
+auto x_main_module_698 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_697, x_main_module_128);
+auto x_main_module_699 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_698, x_main_module_127, x_main_module_126, x_main_module_125, x_main_module_124);
+auto x_main_module_700 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_699);
+auto x_main_module_701 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_672, x_main_module_681, x_main_module_696, x_main_module_700);
+auto x_main_module_702 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_701, x_main_module_123);
+auto x_main_module_703 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_702, x_main_module_122, x_main_module_121, x_main_module_120, x_main_module_119);
+auto x_main_module_704 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_703);
+auto x_main_module_705 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_704, x_main_module_118);
+auto x_main_module_706 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_705, x_main_module_117, x_main_module_116, x_main_module_115, x_main_module_114);
+auto x_main_module_707 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_706);
+auto x_main_module_708 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_701, x_main_module_113);
+auto x_main_module_709 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_708, x_main_module_112, x_main_module_111, x_main_module_110, x_main_module_109);
+auto x_main_module_710 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_709);
+auto x_main_module_711 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_710, x_main_module_108);
+auto x_main_module_712 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_711, x_main_module_107, x_main_module_106, x_main_module_105, x_main_module_104);
+auto x_main_module_713 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_712);
+auto x_main_module_714 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_713, x_main_module_103);
+auto x_main_module_715 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_714, x_main_module_102, x_main_module_101, x_main_module_100, x_main_module_99);
+auto x_main_module_716 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_715);
+auto x_main_module_717 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_716, x_main_module_98);
+auto x_main_module_718 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_717, x_main_module_97, x_main_module_96, x_main_module_95, x_main_module_94);
+auto x_main_module_719 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_718);
+auto x_main_module_720 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"), x_main_module_701);
+auto x_main_module_721 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_707, x_main_module_719, x_main_module_720);
+auto x_main_module_722 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_721, x_main_module_93);
+auto x_main_module_723 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_722, x_main_module_92, x_main_module_91, x_main_module_90, x_main_module_89);
+auto x_main_module_724 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_723);
+auto x_main_module_725 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_721, x_main_module_88);
+auto x_main_module_726 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_725, x_main_module_87, x_main_module_86, x_main_module_85, x_main_module_84);
+auto x_main_module_727 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_726);
+auto x_main_module_728 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,1,0,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_727, x_main_module_83);
+auto x_main_module_729 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_728, x_main_module_82, x_main_module_81, x_main_module_80, x_main_module_79);
+auto x_main_module_730 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_729);
+auto x_main_module_731 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,0,1,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_727, x_main_module_78);
+auto x_main_module_732 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_731, x_main_module_77, x_main_module_76, x_main_module_75, x_main_module_74);
+auto x_main_module_733 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_732);
+auto x_main_module_734 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_730, x_main_module_733);
+auto x_main_module_735 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_721, x_main_module_73);
+auto x_main_module_736 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_735, x_main_module_72, x_main_module_71, x_main_module_70, x_main_module_69);
+auto x_main_module_737 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_736);
+auto x_main_module_738 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_737, x_main_module_68);
+auto x_main_module_739 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_738, x_main_module_67, x_main_module_66, x_main_module_65, x_main_module_64);
+auto x_main_module_740 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_739);
+auto x_main_module_741 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,1,0,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_740, x_main_module_63);
+auto x_main_module_742 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_741, x_main_module_62, x_main_module_61, x_main_module_60, x_main_module_59);
+auto x_main_module_743 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_742);
+auto x_main_module_744 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,0,1,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_740, x_main_module_58);
+auto x_main_module_745 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_744, x_main_module_57, x_main_module_56, x_main_module_55, x_main_module_54);
+auto x_main_module_746 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_745);
+auto x_main_module_747 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_743, x_main_module_746);
+auto x_main_module_748 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_721);
+auto x_main_module_749 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_748, x_main_module_53);
+auto x_main_module_750 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_749, x_main_module_52, x_main_module_51, x_main_module_50, x_main_module_49);
+auto x_main_module_751 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_750);
+auto x_main_module_752 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_724, x_main_module_734, x_main_module_747, x_main_module_751);
+auto x_main_module_753 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_752, x_main_module_48);
+auto x_main_module_754 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_753, x_main_module_47, x_main_module_46, x_main_module_45, x_main_module_44);
+auto x_main_module_755 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_754);
+auto x_main_module_756 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_752, x_main_module_43);
+auto x_main_module_757 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_756, x_main_module_42, x_main_module_41, x_main_module_40, x_main_module_39);
+auto x_main_module_758 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_757);
+auto x_main_module_759 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,1,0,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_758, x_main_module_38);
+auto x_main_module_760 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_759, x_main_module_37, x_main_module_36, x_main_module_35, x_main_module_34);
+auto x_main_module_761 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_760);
+auto x_main_module_762 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,0,1,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_758, x_main_module_33);
+auto x_main_module_763 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_762, x_main_module_32, x_main_module_31, x_main_module_30, x_main_module_29);
+auto x_main_module_764 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_763);
+auto x_main_module_765 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_761, x_main_module_764);
+auto x_main_module_766 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_752, x_main_module_28);
+auto x_main_module_767 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_766, x_main_module_27, x_main_module_26, x_main_module_25, x_main_module_24);
+auto x_main_module_768 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_767);
+auto x_main_module_769 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_768, x_main_module_23);
+auto x_main_module_770 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_769, x_main_module_22, x_main_module_21, x_main_module_20, x_main_module_19);
+auto x_main_module_771 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_770);
+auto x_main_module_772 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,1,0,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_771, x_main_module_18);
+auto x_main_module_773 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_772, x_main_module_17, x_main_module_16, x_main_module_15, x_main_module_14);
+auto x_main_module_774 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_773);
+auto x_main_module_775 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,0,1,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_771, x_main_module_13);
+auto x_main_module_776 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_775, x_main_module_12, x_main_module_11, x_main_module_10, x_main_module_9);
+auto x_main_module_777 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_776);
+auto x_main_module_778 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_774, x_main_module_777);
+auto x_main_module_779 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_752);
+auto x_main_module_780 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_779, x_main_module_8);
+auto x_main_module_781 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_780, x_main_module_7, x_main_module_6, x_main_module_5, x_main_module_4);
+auto x_main_module_782 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_781);
+auto x_main_module_783 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_755, x_main_module_765, x_main_module_778, x_main_module_782);
+auto x_main_module_784 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[8,8],lp_order:2,mode:0,padding:[0,0,0,0],stride:[8,8]}"), x_main_module_783);
+auto x_main_module_785 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_784);
+auto x_main_module_786 = mmain->add_instruction(migraphx::make_json_op("flatten", "{axis:1}"), x_main_module_785);
+auto x_main_module_787 = mmain->add_instruction(migraphx::make_json_op("transpose", "{permutation:[1,0]}"), x_main_module_3);
+auto x_main_module_788 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_786, x_main_module_787);
+auto x_main_module_789 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_2);
+auto x_main_module_790 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_0);
+auto x_main_module_791 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_789, x_main_module_790);
+auto x_main_module_792 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_788, x_main_module_791);
+mmain->add_return({x_main_module_792});
+
 
     return p;
 }

--- a/src/driver/inceptionv3.cpp
+++ b/src/driver/inceptionv3.cpp
@@ -33,802 +33,2832 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program inceptionv3(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-migraphx::module_ref mmain = p.get_main_module();
-auto _x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-auto _x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 299, 299}});
-auto _x_main_module_2 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
-auto _x_main_module_3 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
-auto _x_main_module_4 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 3)));
-auto _x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 4));
-auto _x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 5));
-auto _x_main_module_7 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 6)));
-auto _x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 2048, 1, 1}}, 7));
-auto _x_main_module_9 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 8)));
-auto _x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 9));
-auto _x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 10));
-auto _x_main_module_12 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 11)));
-auto _x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 12));
-auto _x_main_module_14 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13)));
-auto _x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 14));
-auto _x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 15));
-auto _x_main_module_17 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 16)));
-auto _x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 17));
-auto _x_main_module_19 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 18)));
-auto _x_main_module_20 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 19));
-auto _x_main_module_21 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 20));
-auto _x_main_module_22 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 21)));
-auto _x_main_module_23 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 22));
-auto _x_main_module_24 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 23)));
-auto _x_main_module_25 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 24));
-auto _x_main_module_26 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 25));
-auto _x_main_module_27 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 26)));
-auto _x_main_module_28 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448, 2048, 1, 1}}, 27));
-auto _x_main_module_29 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 28)));
-auto _x_main_module_30 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 29)));
-auto _x_main_module_31 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 30));
-auto _x_main_module_32 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 31)));
-auto _x_main_module_33 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 32));
-auto _x_main_module_34 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 33)));
-auto _x_main_module_35 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 34)));
-auto _x_main_module_36 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 35));
-auto _x_main_module_37 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 36)));
-auto _x_main_module_38 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 37));
-auto _x_main_module_39 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 38)));
-auto _x_main_module_40 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 39));
-auto _x_main_module_41 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 40));
-auto _x_main_module_42 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 41)));
-auto _x_main_module_43 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 2048, 1, 1}}, 42));
-auto _x_main_module_44 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 43)));
-auto _x_main_module_45 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 44));
-auto _x_main_module_46 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 45));
-auto _x_main_module_47 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 46)));
-auto _x_main_module_48 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 2048, 1, 1}}, 47));
-auto _x_main_module_49 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 48)));
-auto _x_main_module_50 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 49));
-auto _x_main_module_51 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 50));
-auto _x_main_module_52 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 51)));
-auto _x_main_module_53 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 1280, 1, 1}}, 52));
-auto _x_main_module_54 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 53)));
-auto _x_main_module_55 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 54));
-auto _x_main_module_56 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 55));
-auto _x_main_module_57 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 56)));
-auto _x_main_module_58 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 57));
-auto _x_main_module_59 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 58)));
-auto _x_main_module_60 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 59));
-auto _x_main_module_61 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 60));
-auto _x_main_module_62 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 61)));
-auto _x_main_module_63 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 62));
-auto _x_main_module_64 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 63)));
-auto _x_main_module_65 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 64));
-auto _x_main_module_66 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 65));
-auto _x_main_module_67 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 66)));
-auto _x_main_module_68 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 67));
-auto _x_main_module_69 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 68)));
-auto _x_main_module_70 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 69));
-auto _x_main_module_71 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 70));
-auto _x_main_module_72 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 71)));
-auto _x_main_module_73 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448, 1280, 1, 1}}, 72));
-auto _x_main_module_74 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 73)));
-auto _x_main_module_75 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 74));
-auto _x_main_module_76 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 75));
-auto _x_main_module_77 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 76)));
-auto _x_main_module_78 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 77));
-auto _x_main_module_79 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 78)));
-auto _x_main_module_80 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 79));
-auto _x_main_module_81 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 80));
-auto _x_main_module_82 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 81)));
-auto _x_main_module_83 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 82));
-auto _x_main_module_84 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 83)));
-auto _x_main_module_85 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 84));
-auto _x_main_module_86 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 85));
-auto _x_main_module_87 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 86)));
-auto _x_main_module_88 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 1280, 1, 1}}, 87));
-auto _x_main_module_89 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 88)));
-auto _x_main_module_90 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 89));
-auto _x_main_module_91 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 90));
-auto _x_main_module_92 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 91)));
-auto _x_main_module_93 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 1280, 1, 1}}, 92));
-auto _x_main_module_94 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 93)));
-auto _x_main_module_95 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 94));
-auto _x_main_module_96 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 95));
-auto _x_main_module_97 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 96)));
-auto _x_main_module_98 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 3, 3}}, 97));
-auto _x_main_module_99 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 98)));
-auto _x_main_module_100 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 99));
-auto _x_main_module_101 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 100));
-auto _x_main_module_102 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 101)));
-auto _x_main_module_103 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 102));
-auto _x_main_module_104 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 103)));
-auto _x_main_module_105 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 104));
-auto _x_main_module_106 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 105));
-auto _x_main_module_107 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 106)));
-auto _x_main_module_108 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 107));
-auto _x_main_module_109 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 108)));
-auto _x_main_module_110 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 109));
-auto _x_main_module_111 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 110));
-auto _x_main_module_112 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 111)));
-auto _x_main_module_113 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 112));
-auto _x_main_module_114 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 113)));
-auto _x_main_module_115 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 114));
-auto _x_main_module_116 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 115));
-auto _x_main_module_117 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 116)));
-auto _x_main_module_118 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 192, 3, 3}}, 117));
-auto _x_main_module_119 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 118)));
-auto _x_main_module_120 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 119));
-auto _x_main_module_121 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 120));
-auto _x_main_module_122 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 121)));
-auto _x_main_module_123 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 122));
-auto _x_main_module_124 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 123)));
-auto _x_main_module_125 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 124));
-auto _x_main_module_126 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 125));
-auto _x_main_module_127 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 126)));
-auto _x_main_module_128 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 127));
-auto _x_main_module_129 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 128)));
-auto _x_main_module_130 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 129));
-auto _x_main_module_131 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 130));
-auto _x_main_module_132 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 131)));
-auto _x_main_module_133 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 132));
-auto _x_main_module_134 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 133)));
-auto _x_main_module_135 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 134));
-auto _x_main_module_136 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 135));
-auto _x_main_module_137 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 136)));
-auto _x_main_module_138 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 137));
-auto _x_main_module_139 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 138)));
-auto _x_main_module_140 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 139));
-auto _x_main_module_141 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 140));
-auto _x_main_module_142 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 141)));
-auto _x_main_module_143 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 142));
-auto _x_main_module_144 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 143)));
-auto _x_main_module_145 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 144));
-auto _x_main_module_146 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 145));
-auto _x_main_module_147 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 146)));
-auto _x_main_module_148 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 147));
-auto _x_main_module_149 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 148)));
-auto _x_main_module_150 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 149));
-auto _x_main_module_151 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 150));
-auto _x_main_module_152 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 151)));
-auto _x_main_module_153 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 152));
-auto _x_main_module_154 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 153)));
-auto _x_main_module_155 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 154));
-auto _x_main_module_156 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 155));
-auto _x_main_module_157 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 156)));
-auto _x_main_module_158 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 157));
-auto _x_main_module_159 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 158)));
-auto _x_main_module_160 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 159));
-auto _x_main_module_161 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 160));
-auto _x_main_module_162 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 161)));
-auto _x_main_module_163 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 162));
-auto _x_main_module_164 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 163)));
-auto _x_main_module_165 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 164));
-auto _x_main_module_166 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 165));
-auto _x_main_module_167 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 166)));
-auto _x_main_module_168 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 167));
-auto _x_main_module_169 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 168)));
-auto _x_main_module_170 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 169));
-auto _x_main_module_171 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 170));
-auto _x_main_module_172 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 171)));
-auto _x_main_module_173 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 172));
-auto _x_main_module_174 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 173)));
-auto _x_main_module_175 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 174));
-auto _x_main_module_176 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 175));
-auto _x_main_module_177 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 176)));
-auto _x_main_module_178 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 177));
-auto _x_main_module_179 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 178)));
-auto _x_main_module_180 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 179));
-auto _x_main_module_181 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 180));
-auto _x_main_module_182 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 181)));
-auto _x_main_module_183 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 182));
-auto _x_main_module_184 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 183)));
-auto _x_main_module_185 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 184));
-auto _x_main_module_186 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 185));
-auto _x_main_module_187 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 186)));
-auto _x_main_module_188 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 187));
-auto _x_main_module_189 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 188)));
-auto _x_main_module_190 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 189));
-auto _x_main_module_191 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 190));
-auto _x_main_module_192 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 191)));
-auto _x_main_module_193 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 192));
-auto _x_main_module_194 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 193)));
-auto _x_main_module_195 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 194));
-auto _x_main_module_196 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 195));
-auto _x_main_module_197 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 196)));
-auto _x_main_module_198 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 197));
-auto _x_main_module_199 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 198)));
-auto _x_main_module_200 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 199));
-auto _x_main_module_201 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 200));
-auto _x_main_module_202 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 201)));
-auto _x_main_module_203 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 202));
-auto _x_main_module_204 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 203)));
-auto _x_main_module_205 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 204));
-auto _x_main_module_206 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 205));
-auto _x_main_module_207 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 206)));
-auto _x_main_module_208 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 207));
-auto _x_main_module_209 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 208)));
-auto _x_main_module_210 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 209));
-auto _x_main_module_211 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 210));
-auto _x_main_module_212 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 211)));
-auto _x_main_module_213 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 212));
-auto _x_main_module_214 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 213)));
-auto _x_main_module_215 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 214));
-auto _x_main_module_216 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 215));
-auto _x_main_module_217 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 216)));
-auto _x_main_module_218 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 217));
-auto _x_main_module_219 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 218)));
-auto _x_main_module_220 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 219));
-auto _x_main_module_221 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 220));
-auto _x_main_module_222 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 221)));
-auto _x_main_module_223 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 222));
-auto _x_main_module_224 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 223)));
-auto _x_main_module_225 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 224));
-auto _x_main_module_226 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 225));
-auto _x_main_module_227 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 226)));
-auto _x_main_module_228 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 227));
-auto _x_main_module_229 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 228)));
-auto _x_main_module_230 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 229));
-auto _x_main_module_231 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 230));
-auto _x_main_module_232 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 231)));
-auto _x_main_module_233 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 232));
-auto _x_main_module_234 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 233)));
-auto _x_main_module_235 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 234));
-auto _x_main_module_236 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 235));
-auto _x_main_module_237 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 236)));
-auto _x_main_module_238 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 237));
-auto _x_main_module_239 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 238)));
-auto _x_main_module_240 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 239));
-auto _x_main_module_241 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 240));
-auto _x_main_module_242 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 241)));
-auto _x_main_module_243 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 242));
-auto _x_main_module_244 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 243)));
-auto _x_main_module_245 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 244));
-auto _x_main_module_246 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 245));
-auto _x_main_module_247 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 246)));
-auto _x_main_module_248 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 247));
-auto _x_main_module_249 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 248)));
-auto _x_main_module_250 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 249));
-auto _x_main_module_251 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 250));
-auto _x_main_module_252 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 251)));
-auto _x_main_module_253 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 252));
-auto _x_main_module_254 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 253)));
-auto _x_main_module_255 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 254));
-auto _x_main_module_256 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 255));
-auto _x_main_module_257 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 256)));
-auto _x_main_module_258 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 257));
-auto _x_main_module_259 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 258)));
-auto _x_main_module_260 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 259));
-auto _x_main_module_261 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 260));
-auto _x_main_module_262 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 261)));
-auto _x_main_module_263 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 262));
-auto _x_main_module_264 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 263)));
-auto _x_main_module_265 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 264));
-auto _x_main_module_266 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 265));
-auto _x_main_module_267 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 266)));
-auto _x_main_module_268 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 267));
-auto _x_main_module_269 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 268)));
-auto _x_main_module_270 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 269));
-auto _x_main_module_271 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 270));
-auto _x_main_module_272 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 271)));
-auto _x_main_module_273 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 272));
-auto _x_main_module_274 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 273)));
-auto _x_main_module_275 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 274));
-auto _x_main_module_276 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 275));
-auto _x_main_module_277 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 276)));
-auto _x_main_module_278 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 277));
-auto _x_main_module_279 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 278)));
-auto _x_main_module_280 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 279));
-auto _x_main_module_281 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 280));
-auto _x_main_module_282 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 281)));
-auto _x_main_module_283 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 128, 1, 7}}, 282));
-auto _x_main_module_284 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 283)));
-auto _x_main_module_285 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 284));
-auto _x_main_module_286 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 285));
-auto _x_main_module_287 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 286)));
-auto _x_main_module_288 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 287));
-auto _x_main_module_289 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 288)));
-auto _x_main_module_290 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 289));
-auto _x_main_module_291 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 290));
-auto _x_main_module_292 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 291)));
-auto _x_main_module_293 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 292));
-auto _x_main_module_294 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 293)));
-auto _x_main_module_295 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 294));
-auto _x_main_module_296 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 295));
-auto _x_main_module_297 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 296)));
-auto _x_main_module_298 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 297));
-auto _x_main_module_299 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 298)));
-auto _x_main_module_300 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 299));
-auto _x_main_module_301 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 300));
-auto _x_main_module_302 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 301)));
-auto _x_main_module_303 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 302));
-auto _x_main_module_304 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 303)));
-auto _x_main_module_305 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 304));
-auto _x_main_module_306 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 305));
-auto _x_main_module_307 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 306)));
-auto _x_main_module_308 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 128, 7, 1}}, 307));
-auto _x_main_module_309 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 308)));
-auto _x_main_module_310 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 309));
-auto _x_main_module_311 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 310));
-auto _x_main_module_312 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 311)));
-auto _x_main_module_313 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 312));
-auto _x_main_module_314 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 313)));
-auto _x_main_module_315 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 314));
-auto _x_main_module_316 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 315));
-auto _x_main_module_317 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 316)));
-auto _x_main_module_318 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 317));
-auto _x_main_module_319 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 318)));
-auto _x_main_module_320 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 319));
-auto _x_main_module_321 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 320));
-auto _x_main_module_322 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 321)));
-auto _x_main_module_323 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 322));
-auto _x_main_module_324 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 323)));
-auto _x_main_module_325 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 324));
-auto _x_main_module_326 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 325));
-auto _x_main_module_327 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 326)));
-auto _x_main_module_328 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 327));
-auto _x_main_module_329 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 328)));
-auto _x_main_module_330 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 329));
-auto _x_main_module_331 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 330));
-auto _x_main_module_332 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 331)));
-auto _x_main_module_333 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 332));
-auto _x_main_module_334 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 333)));
-auto _x_main_module_335 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 334));
-auto _x_main_module_336 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 335));
-auto _x_main_module_337 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 336)));
-auto _x_main_module_338 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 337));
-auto _x_main_module_339 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 338)));
-auto _x_main_module_340 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 339));
-auto _x_main_module_341 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 340));
-auto _x_main_module_342 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 341)));
-auto _x_main_module_343 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 288, 3, 3}}, 342));
-auto _x_main_module_344 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 343)));
-auto _x_main_module_345 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 344));
-auto _x_main_module_346 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 345));
-auto _x_main_module_347 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 346)));
-auto _x_main_module_348 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 347));
-auto _x_main_module_349 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 348)));
-auto _x_main_module_350 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 349));
-auto _x_main_module_351 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 350));
-auto _x_main_module_352 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 351)));
-auto _x_main_module_353 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 352));
-auto _x_main_module_354 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 353)));
-auto _x_main_module_355 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 354));
-auto _x_main_module_356 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 355));
-auto _x_main_module_357 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 356)));
-auto _x_main_module_358 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 357));
-auto _x_main_module_359 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 358)));
-auto _x_main_module_360 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 359));
-auto _x_main_module_361 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 360));
-auto _x_main_module_362 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 361)));
-auto _x_main_module_363 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 362));
-auto _x_main_module_364 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 363)));
-auto _x_main_module_365 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 364));
-auto _x_main_module_366 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 365));
-auto _x_main_module_367 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 366)));
-auto _x_main_module_368 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 367));
-auto _x_main_module_369 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 368)));
-auto _x_main_module_370 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 369));
-auto _x_main_module_371 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 370));
-auto _x_main_module_372 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 371)));
-auto _x_main_module_373 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 288, 1, 1}}, 372));
-auto _x_main_module_374 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 373)));
-auto _x_main_module_375 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 374));
-auto _x_main_module_376 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 375));
-auto _x_main_module_377 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 376)));
-auto _x_main_module_378 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 377));
-auto _x_main_module_379 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 378)));
-auto _x_main_module_380 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 379));
-auto _x_main_module_381 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 380));
-auto _x_main_module_382 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 381)));
-auto _x_main_module_383 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 382));
-auto _x_main_module_384 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 383)));
-auto _x_main_module_385 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 384));
-auto _x_main_module_386 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 385));
-auto _x_main_module_387 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 386)));
-auto _x_main_module_388 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 387));
-auto _x_main_module_389 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 388)));
-auto _x_main_module_390 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 389));
-auto _x_main_module_391 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 390));
-auto _x_main_module_392 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 391)));
-auto _x_main_module_393 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 392));
-auto _x_main_module_394 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 393)));
-auto _x_main_module_395 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 394));
-auto _x_main_module_396 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 395));
-auto _x_main_module_397 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 396)));
-auto _x_main_module_398 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 397));
-auto _x_main_module_399 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 398)));
-auto _x_main_module_400 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 399));
-auto _x_main_module_401 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 400));
-auto _x_main_module_402 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 401)));
-auto _x_main_module_403 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 402));
-auto _x_main_module_404 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 403)));
-auto _x_main_module_405 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 404));
-auto _x_main_module_406 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 405));
-auto _x_main_module_407 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 406)));
-auto _x_main_module_408 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 256, 1, 1}}, 407));
-auto _x_main_module_409 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 408)));
-auto _x_main_module_410 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 409));
-auto _x_main_module_411 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 410));
-auto _x_main_module_412 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 411)));
-auto _x_main_module_413 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 412));
-auto _x_main_module_414 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 413)));
-auto _x_main_module_415 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 414));
-auto _x_main_module_416 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 415));
-auto _x_main_module_417 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 416)));
-auto _x_main_module_418 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 192, 1, 1}}, 417));
-auto _x_main_module_419 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 418)));
-auto _x_main_module_420 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 419));
-auto _x_main_module_421 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 420));
-auto _x_main_module_422 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 421)));
-auto _x_main_module_423 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 422));
-auto _x_main_module_424 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 423)));
-auto _x_main_module_425 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 424));
-auto _x_main_module_426 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 425));
-auto _x_main_module_427 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 426)));
-auto _x_main_module_428 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 427));
-auto _x_main_module_429 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 428)));
-auto _x_main_module_430 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 429));
-auto _x_main_module_431 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 430));
-auto _x_main_module_432 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 431)));
-auto _x_main_module_433 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 432));
-auto _x_main_module_434 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 433)));
-auto _x_main_module_435 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 434));
-auto _x_main_module_436 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 435));
-auto _x_main_module_437 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 436)));
-auto _x_main_module_438 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 437));
-auto _x_main_module_439 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 438)));
-auto _x_main_module_440 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 439));
-auto _x_main_module_441 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 440));
-auto _x_main_module_442 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 441)));
-auto _x_main_module_443 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 192, 1, 1}}, 442));
-auto _x_main_module_444 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 443)));
-auto _x_main_module_445 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 444));
-auto _x_main_module_446 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 445));
-auto _x_main_module_447 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 446)));
-auto _x_main_module_448 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 447));
-auto _x_main_module_449 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 448)));
-auto _x_main_module_450 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 449));
-auto _x_main_module_451 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 450));
-auto _x_main_module_452 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 451)));
-auto _x_main_module_453 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 80, 3, 3}}, 452));
-auto _x_main_module_454 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 453)));
-auto _x_main_module_455 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 454));
-auto _x_main_module_456 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 455));
-auto _x_main_module_457 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 456)));
-auto _x_main_module_458 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80, 64, 1, 1}}, 457));
-auto _x_main_module_459 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 458)));
-auto _x_main_module_460 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 459));
-auto _x_main_module_461 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 460));
-auto _x_main_module_462 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 461)));
-auto _x_main_module_463 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 32, 3, 3}}, 462));
-auto _x_main_module_464 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 463)));
-auto _x_main_module_465 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 464));
-auto _x_main_module_466 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 465));
-auto _x_main_module_467 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 466)));
-auto _x_main_module_468 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 32, 3, 3}}, 467));
-auto _x_main_module_469 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 468)));
-auto _x_main_module_470 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 469));
-auto _x_main_module_471 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 470));
-auto _x_main_module_472 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 471)));
-auto _x_main_module_473 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 3, 3, 3}}, 472));
-auto _x_main_module_474 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_0, _x_main_module_473);
-auto _x_main_module_475 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_474, _x_main_module_472, _x_main_module_471, _x_main_module_470, _x_main_module_469);
-auto _x_main_module_476 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_475);
-auto _x_main_module_477 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_476, _x_main_module_468);
-auto _x_main_module_478 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_477, _x_main_module_467, _x_main_module_466, _x_main_module_465, _x_main_module_464);
-auto _x_main_module_479 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_478);
-auto _x_main_module_480 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_479, _x_main_module_463);
-auto _x_main_module_481 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_480, _x_main_module_462, _x_main_module_461, _x_main_module_460, _x_main_module_459);
-auto _x_main_module_482 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_481);
-auto _x_main_module_483 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), _x_main_module_482);
-auto _x_main_module_484 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_483, _x_main_module_458);
-auto _x_main_module_485 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_484, _x_main_module_457, _x_main_module_456, _x_main_module_455, _x_main_module_454);
-auto _x_main_module_486 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_485);
-auto _x_main_module_487 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_486, _x_main_module_453);
-auto _x_main_module_488 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_487, _x_main_module_452, _x_main_module_451, _x_main_module_450, _x_main_module_449);
-auto _x_main_module_489 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_488);
-auto _x_main_module_490 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), _x_main_module_489);
-auto _x_main_module_491 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_490, _x_main_module_448);
-auto _x_main_module_492 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_491, _x_main_module_447, _x_main_module_446, _x_main_module_445, _x_main_module_444);
-auto _x_main_module_493 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_492);
-auto _x_main_module_494 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_490, _x_main_module_443);
-auto _x_main_module_495 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_494, _x_main_module_442, _x_main_module_441, _x_main_module_440, _x_main_module_439);
-auto _x_main_module_496 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_495);
-auto _x_main_module_497 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_496, _x_main_module_438);
-auto _x_main_module_498 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_497, _x_main_module_437, _x_main_module_436, _x_main_module_435, _x_main_module_434);
-auto _x_main_module_499 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_498);
-auto _x_main_module_500 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_490, _x_main_module_433);
-auto _x_main_module_501 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_500, _x_main_module_432, _x_main_module_431, _x_main_module_430, _x_main_module_429);
-auto _x_main_module_502 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_501);
-auto _x_main_module_503 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_502, _x_main_module_428);
-auto _x_main_module_504 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_503, _x_main_module_427, _x_main_module_426, _x_main_module_425, _x_main_module_424);
-auto _x_main_module_505 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_504);
-auto _x_main_module_506 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_505, _x_main_module_423);
-auto _x_main_module_507 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_506, _x_main_module_422, _x_main_module_421, _x_main_module_420, _x_main_module_419);
-auto _x_main_module_508 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_507);
-auto _x_main_module_509 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_490);
-auto _x_main_module_510 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_509, _x_main_module_418);
-auto _x_main_module_511 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_510, _x_main_module_417, _x_main_module_416, _x_main_module_415, _x_main_module_414);
-auto _x_main_module_512 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_511);
-auto _x_main_module_513 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_493, _x_main_module_499, _x_main_module_508, _x_main_module_512);
-auto _x_main_module_514 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_513, _x_main_module_413);
-auto _x_main_module_515 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_514, _x_main_module_412, _x_main_module_411, _x_main_module_410, _x_main_module_409);
-auto _x_main_module_516 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_515);
-auto _x_main_module_517 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_513, _x_main_module_408);
-auto _x_main_module_518 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_517, _x_main_module_407, _x_main_module_406, _x_main_module_405, _x_main_module_404);
-auto _x_main_module_519 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_518);
-auto _x_main_module_520 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_519, _x_main_module_403);
-auto _x_main_module_521 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_520, _x_main_module_402, _x_main_module_401, _x_main_module_400, _x_main_module_399);
-auto _x_main_module_522 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_521);
-auto _x_main_module_523 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_513, _x_main_module_398);
-auto _x_main_module_524 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_523, _x_main_module_397, _x_main_module_396, _x_main_module_395, _x_main_module_394);
-auto _x_main_module_525 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_524);
-auto _x_main_module_526 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_525, _x_main_module_393);
-auto _x_main_module_527 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_526, _x_main_module_392, _x_main_module_391, _x_main_module_390, _x_main_module_389);
-auto _x_main_module_528 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_527);
-auto _x_main_module_529 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_528, _x_main_module_388);
-auto _x_main_module_530 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_529, _x_main_module_387, _x_main_module_386, _x_main_module_385, _x_main_module_384);
-auto _x_main_module_531 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_530);
-auto _x_main_module_532 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_513);
-auto _x_main_module_533 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_532, _x_main_module_383);
-auto _x_main_module_534 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_533, _x_main_module_382, _x_main_module_381, _x_main_module_380, _x_main_module_379);
-auto _x_main_module_535 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_534);
-auto _x_main_module_536 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_516, _x_main_module_522, _x_main_module_531, _x_main_module_535);
-auto _x_main_module_537 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_536, _x_main_module_378);
-auto _x_main_module_538 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_537, _x_main_module_377, _x_main_module_376, _x_main_module_375, _x_main_module_374);
-auto _x_main_module_539 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_538);
-auto _x_main_module_540 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_536, _x_main_module_373);
-auto _x_main_module_541 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_540, _x_main_module_372, _x_main_module_371, _x_main_module_370, _x_main_module_369);
-auto _x_main_module_542 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_541);
-auto _x_main_module_543 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_542, _x_main_module_368);
-auto _x_main_module_544 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_543, _x_main_module_367, _x_main_module_366, _x_main_module_365, _x_main_module_364);
-auto _x_main_module_545 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_544);
-auto _x_main_module_546 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_536, _x_main_module_363);
-auto _x_main_module_547 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_546, _x_main_module_362, _x_main_module_361, _x_main_module_360, _x_main_module_359);
-auto _x_main_module_548 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_547);
-auto _x_main_module_549 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_548, _x_main_module_358);
-auto _x_main_module_550 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_549, _x_main_module_357, _x_main_module_356, _x_main_module_355, _x_main_module_354);
-auto _x_main_module_551 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_550);
-auto _x_main_module_552 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_551, _x_main_module_353);
-auto _x_main_module_553 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_552, _x_main_module_352, _x_main_module_351, _x_main_module_350, _x_main_module_349);
-auto _x_main_module_554 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_553);
-auto _x_main_module_555 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_536);
-auto _x_main_module_556 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_555, _x_main_module_348);
-auto _x_main_module_557 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_556, _x_main_module_347, _x_main_module_346, _x_main_module_345, _x_main_module_344);
-auto _x_main_module_558 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_557);
-auto _x_main_module_559 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_539, _x_main_module_545, _x_main_module_554, _x_main_module_558);
-auto _x_main_module_560 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_559, _x_main_module_343);
-auto _x_main_module_561 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_560, _x_main_module_342, _x_main_module_341, _x_main_module_340, _x_main_module_339);
-auto _x_main_module_562 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_561);
-auto _x_main_module_563 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_559, _x_main_module_338);
-auto _x_main_module_564 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_563, _x_main_module_337, _x_main_module_336, _x_main_module_335, _x_main_module_334);
-auto _x_main_module_565 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_564);
-auto _x_main_module_566 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_565, _x_main_module_333);
-auto _x_main_module_567 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_566, _x_main_module_332, _x_main_module_331, _x_main_module_330, _x_main_module_329);
-auto _x_main_module_568 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_567);
-auto _x_main_module_569 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_568, _x_main_module_328);
-auto _x_main_module_570 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_569, _x_main_module_327, _x_main_module_326, _x_main_module_325, _x_main_module_324);
-auto _x_main_module_571 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_570);
-auto _x_main_module_572 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), _x_main_module_559);
-auto _x_main_module_573 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_562, _x_main_module_571, _x_main_module_572);
-auto _x_main_module_574 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_573, _x_main_module_323);
-auto _x_main_module_575 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_574, _x_main_module_322, _x_main_module_321, _x_main_module_320, _x_main_module_319);
-auto _x_main_module_576 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_575);
-auto _x_main_module_577 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_573, _x_main_module_318);
-auto _x_main_module_578 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_577, _x_main_module_317, _x_main_module_316, _x_main_module_315, _x_main_module_314);
-auto _x_main_module_579 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_578);
-auto _x_main_module_580 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_579, _x_main_module_313);
-auto _x_main_module_581 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_580, _x_main_module_312, _x_main_module_311, _x_main_module_310, _x_main_module_309);
-auto _x_main_module_582 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_581);
-auto _x_main_module_583 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_582, _x_main_module_308);
-auto _x_main_module_584 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_583, _x_main_module_307, _x_main_module_306, _x_main_module_305, _x_main_module_304);
-auto _x_main_module_585 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_584);
-auto _x_main_module_586 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_573, _x_main_module_303);
-auto _x_main_module_587 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_586, _x_main_module_302, _x_main_module_301, _x_main_module_300, _x_main_module_299);
-auto _x_main_module_588 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_587);
-auto _x_main_module_589 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_588, _x_main_module_298);
-auto _x_main_module_590 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_589, _x_main_module_297, _x_main_module_296, _x_main_module_295, _x_main_module_294);
-auto _x_main_module_591 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_590);
-auto _x_main_module_592 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_591, _x_main_module_293);
-auto _x_main_module_593 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_592, _x_main_module_292, _x_main_module_291, _x_main_module_290, _x_main_module_289);
-auto _x_main_module_594 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_593);
-auto _x_main_module_595 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_594, _x_main_module_288);
-auto _x_main_module_596 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_595, _x_main_module_287, _x_main_module_286, _x_main_module_285, _x_main_module_284);
-auto _x_main_module_597 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_596);
-auto _x_main_module_598 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_597, _x_main_module_283);
-auto _x_main_module_599 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_598, _x_main_module_282, _x_main_module_281, _x_main_module_280, _x_main_module_279);
-auto _x_main_module_600 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_599);
-auto _x_main_module_601 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_573);
-auto _x_main_module_602 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_601, _x_main_module_278);
-auto _x_main_module_603 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_602, _x_main_module_277, _x_main_module_276, _x_main_module_275, _x_main_module_274);
-auto _x_main_module_604 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_603);
-auto _x_main_module_605 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_576, _x_main_module_585, _x_main_module_600, _x_main_module_604);
-auto _x_main_module_606 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_605, _x_main_module_273);
-auto _x_main_module_607 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_606, _x_main_module_272, _x_main_module_271, _x_main_module_270, _x_main_module_269);
-auto _x_main_module_608 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_607);
-auto _x_main_module_609 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_605, _x_main_module_268);
-auto _x_main_module_610 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_609, _x_main_module_267, _x_main_module_266, _x_main_module_265, _x_main_module_264);
-auto _x_main_module_611 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_610);
-auto _x_main_module_612 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_611, _x_main_module_263);
-auto _x_main_module_613 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_612, _x_main_module_262, _x_main_module_261, _x_main_module_260, _x_main_module_259);
-auto _x_main_module_614 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_613);
-auto _x_main_module_615 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_614, _x_main_module_258);
-auto _x_main_module_616 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_615, _x_main_module_257, _x_main_module_256, _x_main_module_255, _x_main_module_254);
-auto _x_main_module_617 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_616);
-auto _x_main_module_618 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_605, _x_main_module_253);
-auto _x_main_module_619 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_618, _x_main_module_252, _x_main_module_251, _x_main_module_250, _x_main_module_249);
-auto _x_main_module_620 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_619);
-auto _x_main_module_621 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_620, _x_main_module_248);
-auto _x_main_module_622 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_621, _x_main_module_247, _x_main_module_246, _x_main_module_245, _x_main_module_244);
-auto _x_main_module_623 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_622);
-auto _x_main_module_624 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_623, _x_main_module_243);
-auto _x_main_module_625 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_624, _x_main_module_242, _x_main_module_241, _x_main_module_240, _x_main_module_239);
-auto _x_main_module_626 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_625);
-auto _x_main_module_627 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_626, _x_main_module_238);
-auto _x_main_module_628 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_627, _x_main_module_237, _x_main_module_236, _x_main_module_235, _x_main_module_234);
-auto _x_main_module_629 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_628);
-auto _x_main_module_630 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_629, _x_main_module_233);
-auto _x_main_module_631 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_630, _x_main_module_232, _x_main_module_231, _x_main_module_230, _x_main_module_229);
-auto _x_main_module_632 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_631);
-auto _x_main_module_633 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_605);
-auto _x_main_module_634 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_633, _x_main_module_228);
-auto _x_main_module_635 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_634, _x_main_module_227, _x_main_module_226, _x_main_module_225, _x_main_module_224);
-auto _x_main_module_636 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_635);
-auto _x_main_module_637 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_608, _x_main_module_617, _x_main_module_632, _x_main_module_636);
-auto _x_main_module_638 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_637, _x_main_module_223);
-auto _x_main_module_639 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_638, _x_main_module_222, _x_main_module_221, _x_main_module_220, _x_main_module_219);
-auto _x_main_module_640 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_639);
-auto _x_main_module_641 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_637, _x_main_module_218);
-auto _x_main_module_642 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_641, _x_main_module_217, _x_main_module_216, _x_main_module_215, _x_main_module_214);
-auto _x_main_module_643 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_642);
-auto _x_main_module_644 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_643, _x_main_module_213);
-auto _x_main_module_645 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_644, _x_main_module_212, _x_main_module_211, _x_main_module_210, _x_main_module_209);
-auto _x_main_module_646 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_645);
-auto _x_main_module_647 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_646, _x_main_module_208);
-auto _x_main_module_648 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_647, _x_main_module_207, _x_main_module_206, _x_main_module_205, _x_main_module_204);
-auto _x_main_module_649 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_648);
-auto _x_main_module_650 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_637, _x_main_module_203);
-auto _x_main_module_651 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_650, _x_main_module_202, _x_main_module_201, _x_main_module_200, _x_main_module_199);
-auto _x_main_module_652 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_651);
-auto _x_main_module_653 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_652, _x_main_module_198);
-auto _x_main_module_654 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_653, _x_main_module_197, _x_main_module_196, _x_main_module_195, _x_main_module_194);
-auto _x_main_module_655 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_654);
-auto _x_main_module_656 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_655, _x_main_module_193);
-auto _x_main_module_657 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_656, _x_main_module_192, _x_main_module_191, _x_main_module_190, _x_main_module_189);
-auto _x_main_module_658 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_657);
-auto _x_main_module_659 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_658, _x_main_module_188);
-auto _x_main_module_660 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_659, _x_main_module_187, _x_main_module_186, _x_main_module_185, _x_main_module_184);
-auto _x_main_module_661 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_660);
-auto _x_main_module_662 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_661, _x_main_module_183);
-auto _x_main_module_663 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_662, _x_main_module_182, _x_main_module_181, _x_main_module_180, _x_main_module_179);
-auto _x_main_module_664 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_663);
-auto _x_main_module_665 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_637);
-auto _x_main_module_666 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_665, _x_main_module_178);
-auto _x_main_module_667 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_666, _x_main_module_177, _x_main_module_176, _x_main_module_175, _x_main_module_174);
-auto _x_main_module_668 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_667);
-auto _x_main_module_669 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_640, _x_main_module_649, _x_main_module_664, _x_main_module_668);
-auto _x_main_module_670 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_669, _x_main_module_173);
-auto _x_main_module_671 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_670, _x_main_module_172, _x_main_module_171, _x_main_module_170, _x_main_module_169);
-auto _x_main_module_672 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_671);
-auto _x_main_module_673 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_669, _x_main_module_168);
-auto _x_main_module_674 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_673, _x_main_module_167, _x_main_module_166, _x_main_module_165, _x_main_module_164);
-auto _x_main_module_675 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_674);
-auto _x_main_module_676 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_675, _x_main_module_163);
-auto _x_main_module_677 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_676, _x_main_module_162, _x_main_module_161, _x_main_module_160, _x_main_module_159);
-auto _x_main_module_678 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_677);
-auto _x_main_module_679 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_678, _x_main_module_158);
-auto _x_main_module_680 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_679, _x_main_module_157, _x_main_module_156, _x_main_module_155, _x_main_module_154);
-auto _x_main_module_681 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_680);
-auto _x_main_module_682 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_669, _x_main_module_153);
-auto _x_main_module_683 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_682, _x_main_module_152, _x_main_module_151, _x_main_module_150, _x_main_module_149);
-auto _x_main_module_684 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_683);
-auto _x_main_module_685 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_684, _x_main_module_148);
-auto _x_main_module_686 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_685, _x_main_module_147, _x_main_module_146, _x_main_module_145, _x_main_module_144);
-auto _x_main_module_687 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_686);
-auto _x_main_module_688 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_687, _x_main_module_143);
-auto _x_main_module_689 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_688, _x_main_module_142, _x_main_module_141, _x_main_module_140, _x_main_module_139);
-auto _x_main_module_690 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_689);
-auto _x_main_module_691 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_690, _x_main_module_138);
-auto _x_main_module_692 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_691, _x_main_module_137, _x_main_module_136, _x_main_module_135, _x_main_module_134);
-auto _x_main_module_693 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_692);
-auto _x_main_module_694 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_693, _x_main_module_133);
-auto _x_main_module_695 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_694, _x_main_module_132, _x_main_module_131, _x_main_module_130, _x_main_module_129);
-auto _x_main_module_696 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_695);
-auto _x_main_module_697 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_669);
-auto _x_main_module_698 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_697, _x_main_module_128);
-auto _x_main_module_699 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_698, _x_main_module_127, _x_main_module_126, _x_main_module_125, _x_main_module_124);
-auto _x_main_module_700 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_699);
-auto _x_main_module_701 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_672, _x_main_module_681, _x_main_module_696, _x_main_module_700);
-auto _x_main_module_702 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_701, _x_main_module_123);
-auto _x_main_module_703 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_702, _x_main_module_122, _x_main_module_121, _x_main_module_120, _x_main_module_119);
-auto _x_main_module_704 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_703);
-auto _x_main_module_705 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_704, _x_main_module_118);
-auto _x_main_module_706 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_705, _x_main_module_117, _x_main_module_116, _x_main_module_115, _x_main_module_114);
-auto _x_main_module_707 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_706);
-auto _x_main_module_708 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_701, _x_main_module_113);
-auto _x_main_module_709 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_708, _x_main_module_112, _x_main_module_111, _x_main_module_110, _x_main_module_109);
-auto _x_main_module_710 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_709);
-auto _x_main_module_711 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_710, _x_main_module_108);
-auto _x_main_module_712 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_711, _x_main_module_107, _x_main_module_106, _x_main_module_105, _x_main_module_104);
-auto _x_main_module_713 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_712);
-auto _x_main_module_714 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_713, _x_main_module_103);
-auto _x_main_module_715 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_714, _x_main_module_102, _x_main_module_101, _x_main_module_100, _x_main_module_99);
-auto _x_main_module_716 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_715);
-auto _x_main_module_717 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_716, _x_main_module_98);
-auto _x_main_module_718 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_717, _x_main_module_97, _x_main_module_96, _x_main_module_95, _x_main_module_94);
-auto _x_main_module_719 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_718);
-auto _x_main_module_720 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), _x_main_module_701);
-auto _x_main_module_721 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_707, _x_main_module_719, _x_main_module_720);
-auto _x_main_module_722 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_721, _x_main_module_93);
-auto _x_main_module_723 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_722, _x_main_module_92, _x_main_module_91, _x_main_module_90, _x_main_module_89);
-auto _x_main_module_724 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_723);
-auto _x_main_module_725 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_721, _x_main_module_88);
-auto _x_main_module_726 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_725, _x_main_module_87, _x_main_module_86, _x_main_module_85, _x_main_module_84);
-auto _x_main_module_727 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_726);
-auto _x_main_module_728 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_727, _x_main_module_83);
-auto _x_main_module_729 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_728, _x_main_module_82, _x_main_module_81, _x_main_module_80, _x_main_module_79);
-auto _x_main_module_730 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_729);
-auto _x_main_module_731 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_727, _x_main_module_78);
-auto _x_main_module_732 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_731, _x_main_module_77, _x_main_module_76, _x_main_module_75, _x_main_module_74);
-auto _x_main_module_733 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_732);
-auto _x_main_module_734 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_730, _x_main_module_733);
-auto _x_main_module_735 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_721, _x_main_module_73);
-auto _x_main_module_736 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_735, _x_main_module_72, _x_main_module_71, _x_main_module_70, _x_main_module_69);
-auto _x_main_module_737 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_736);
-auto _x_main_module_738 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_737, _x_main_module_68);
-auto _x_main_module_739 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_738, _x_main_module_67, _x_main_module_66, _x_main_module_65, _x_main_module_64);
-auto _x_main_module_740 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_739);
-auto _x_main_module_741 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_740, _x_main_module_63);
-auto _x_main_module_742 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_741, _x_main_module_62, _x_main_module_61, _x_main_module_60, _x_main_module_59);
-auto _x_main_module_743 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_742);
-auto _x_main_module_744 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_740, _x_main_module_58);
-auto _x_main_module_745 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_744, _x_main_module_57, _x_main_module_56, _x_main_module_55, _x_main_module_54);
-auto _x_main_module_746 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_745);
-auto _x_main_module_747 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_743, _x_main_module_746);
-auto _x_main_module_748 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_721);
-auto _x_main_module_749 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_748, _x_main_module_53);
-auto _x_main_module_750 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_749, _x_main_module_52, _x_main_module_51, _x_main_module_50, _x_main_module_49);
-auto _x_main_module_751 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_750);
-auto _x_main_module_752 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_724, _x_main_module_734, _x_main_module_747, _x_main_module_751);
-auto _x_main_module_753 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_752, _x_main_module_48);
-auto _x_main_module_754 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_753, _x_main_module_47, _x_main_module_46, _x_main_module_45, _x_main_module_44);
-auto _x_main_module_755 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_754);
-auto _x_main_module_756 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_752, _x_main_module_43);
-auto _x_main_module_757 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_756, _x_main_module_42, _x_main_module_41, _x_main_module_40, _x_main_module_39);
-auto _x_main_module_758 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_757);
-auto _x_main_module_759 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_758, _x_main_module_38);
-auto _x_main_module_760 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_759, _x_main_module_37, _x_main_module_36, _x_main_module_35, _x_main_module_34);
-auto _x_main_module_761 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_760);
-auto _x_main_module_762 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_758, _x_main_module_33);
-auto _x_main_module_763 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_762, _x_main_module_32, _x_main_module_31, _x_main_module_30, _x_main_module_29);
-auto _x_main_module_764 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_763);
-auto _x_main_module_765 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_761, _x_main_module_764);
-auto _x_main_module_766 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_752, _x_main_module_28);
-auto _x_main_module_767 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_766, _x_main_module_27, _x_main_module_26, _x_main_module_25, _x_main_module_24);
-auto _x_main_module_768 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_767);
-auto _x_main_module_769 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_768, _x_main_module_23);
-auto _x_main_module_770 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_769, _x_main_module_22, _x_main_module_21, _x_main_module_20, _x_main_module_19);
-auto _x_main_module_771 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_770);
-auto _x_main_module_772 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_771, _x_main_module_18);
-auto _x_main_module_773 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_772, _x_main_module_17, _x_main_module_16, _x_main_module_15, _x_main_module_14);
-auto _x_main_module_774 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_773);
-auto _x_main_module_775 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_771, _x_main_module_13);
-auto _x_main_module_776 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_775, _x_main_module_12, _x_main_module_11, _x_main_module_10, _x_main_module_9);
-auto _x_main_module_777 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_776);
-auto _x_main_module_778 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_774, _x_main_module_777);
-auto _x_main_module_779 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_752);
-auto _x_main_module_780 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_779, _x_main_module_8);
-auto _x_main_module_781 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_780, _x_main_module_7, _x_main_module_6, _x_main_module_5, _x_main_module_4);
-auto _x_main_module_782 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_781);
-auto _x_main_module_783 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_755, _x_main_module_765, _x_main_module_778, _x_main_module_782);
-auto _x_main_module_784 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[8,8],\"lp_order\":2,\"mode\":0,\"padding\":[0,0,0,0],\"stride\":[8,8]}")), _x_main_module_783);
-auto _x_main_module_785 = mmain->add_instruction(migraphx::make_op("identity"), _x_main_module_784);
-auto _x_main_module_786 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_785);
-auto _x_main_module_787 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), _x_main_module_3);
-auto _x_main_module_788 = mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_786, _x_main_module_787);
-auto _x_main_module_789 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), _x_main_module_2);
-auto _x_main_module_790 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), _x_main_module_0);
-auto _x_main_module_791 = mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_789, _x_main_module_790);
-auto _x_main_module_792 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_788, _x_main_module_791);
-mmain->add_return({_x_main_module_792});
-
+    migraphx::module_ref mmain = p.get_main_module();
+    auto _x_main_module_0      = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+    auto _x_0                  = mmain->add_parameter(
+        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 299, 299}});
+    auto _x_main_module_2 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
+    auto _x_main_module_3 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
+    auto _x_main_module_4 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 3)));
+    auto _x_main_module_5 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 4));
+    auto _x_main_module_6 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 5));
+    auto _x_main_module_7  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 6)));
+    auto _x_main_module_8  = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 2048, 1, 1}}, 7));
+    auto _x_main_module_9  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 8)));
+    auto _x_main_module_10 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 9));
+    auto _x_main_module_11 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 10));
+    auto _x_main_module_12 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 11)));
+    auto _x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 12));
+    auto _x_main_module_14 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13)));
+    auto _x_main_module_15 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 14));
+    auto _x_main_module_16 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 15));
+    auto _x_main_module_17 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 16)));
+    auto _x_main_module_18 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 17));
+    auto _x_main_module_19 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 18)));
+    auto _x_main_module_20 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 19));
+    auto _x_main_module_21 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 20));
+    auto _x_main_module_22 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 21)));
+    auto _x_main_module_23 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 22));
+    auto _x_main_module_24 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 23)));
+    auto _x_main_module_25 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 24));
+    auto _x_main_module_26 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 25));
+    auto _x_main_module_27 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 26)));
+    auto _x_main_module_28 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {448, 2048, 1, 1}}, 27));
+    auto _x_main_module_29 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 28)));
+    auto _x_main_module_30 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 29)));
+    auto _x_main_module_31 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 30));
+    auto _x_main_module_32 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 31)));
+    auto _x_main_module_33 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 32));
+    auto _x_main_module_34 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 33)));
+    auto _x_main_module_35 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 34)));
+    auto _x_main_module_36 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 35));
+    auto _x_main_module_37 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 36)));
+    auto _x_main_module_38 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 37));
+    auto _x_main_module_39 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 38)));
+    auto _x_main_module_40 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 39));
+    auto _x_main_module_41 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 40));
+    auto _x_main_module_42 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 41)));
+    auto _x_main_module_43 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 2048, 1, 1}}, 42));
+    auto _x_main_module_44 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 43)));
+    auto _x_main_module_45 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 44));
+    auto _x_main_module_46 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 45));
+    auto _x_main_module_47 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 46)));
+    auto _x_main_module_48 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {320, 2048, 1, 1}}, 47));
+    auto _x_main_module_49 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 48)));
+    auto _x_main_module_50 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 49));
+    auto _x_main_module_51 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 50));
+    auto _x_main_module_52 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 51)));
+    auto _x_main_module_53 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 1280, 1, 1}}, 52));
+    auto _x_main_module_54 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 53)));
+    auto _x_main_module_55 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 54));
+    auto _x_main_module_56 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 55));
+    auto _x_main_module_57 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 56)));
+    auto _x_main_module_58 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 57));
+    auto _x_main_module_59 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 58)));
+    auto _x_main_module_60 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 59));
+    auto _x_main_module_61 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 60));
+    auto _x_main_module_62 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 61)));
+    auto _x_main_module_63 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 62));
+    auto _x_main_module_64 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 63)));
+    auto _x_main_module_65 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 64));
+    auto _x_main_module_66 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 65));
+    auto _x_main_module_67 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 66)));
+    auto _x_main_module_68 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 67));
+    auto _x_main_module_69 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 68)));
+    auto _x_main_module_70 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 69));
+    auto _x_main_module_71 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 70));
+    auto _x_main_module_72 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 71)));
+    auto _x_main_module_73 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {448, 1280, 1, 1}}, 72));
+    auto _x_main_module_74 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 73)));
+    auto _x_main_module_75 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 74));
+    auto _x_main_module_76 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 75));
+    auto _x_main_module_77 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 76)));
+    auto _x_main_module_78 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 77));
+    auto _x_main_module_79 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 78)));
+    auto _x_main_module_80 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 79));
+    auto _x_main_module_81 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 80));
+    auto _x_main_module_82 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 81)));
+    auto _x_main_module_83 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 82));
+    auto _x_main_module_84 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 83)));
+    auto _x_main_module_85 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 84));
+    auto _x_main_module_86 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 85));
+    auto _x_main_module_87 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 86)));
+    auto _x_main_module_88 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 1280, 1, 1}}, 87));
+    auto _x_main_module_89 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 88)));
+    auto _x_main_module_90 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 89));
+    auto _x_main_module_91 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 90));
+    auto _x_main_module_92 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 91)));
+    auto _x_main_module_93 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {320, 1280, 1, 1}}, 92));
+    auto _x_main_module_94 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 93)));
+    auto _x_main_module_95 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 94));
+    auto _x_main_module_96 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 95));
+    auto _x_main_module_97  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 96)));
+    auto _x_main_module_98  = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 3, 3}}, 97));
+    auto _x_main_module_99  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 98)));
+    auto _x_main_module_100 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 99));
+    auto _x_main_module_101 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 100));
+    auto _x_main_module_102 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 101)));
+    auto _x_main_module_103 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 102));
+    auto _x_main_module_104 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 103)));
+    auto _x_main_module_105 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 104));
+    auto _x_main_module_106 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 105));
+    auto _x_main_module_107 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 106)));
+    auto _x_main_module_108 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 107));
+    auto _x_main_module_109 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 108)));
+    auto _x_main_module_110 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 109));
+    auto _x_main_module_111 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 110));
+    auto _x_main_module_112 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 111)));
+    auto _x_main_module_113 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 112));
+    auto _x_main_module_114 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 113)));
+    auto _x_main_module_115 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 114));
+    auto _x_main_module_116 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 115));
+    auto _x_main_module_117 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 116)));
+    auto _x_main_module_118 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {320, 192, 3, 3}}, 117));
+    auto _x_main_module_119 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 118)));
+    auto _x_main_module_120 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 119));
+    auto _x_main_module_121 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 120));
+    auto _x_main_module_122 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 121)));
+    auto _x_main_module_123 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 122));
+    auto _x_main_module_124 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 123)));
+    auto _x_main_module_125 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 124));
+    auto _x_main_module_126 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 125));
+    auto _x_main_module_127 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 126)));
+    auto _x_main_module_128 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 127));
+    auto _x_main_module_129 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 128)));
+    auto _x_main_module_130 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 129));
+    auto _x_main_module_131 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 130));
+    auto _x_main_module_132 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 131)));
+    auto _x_main_module_133 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 132));
+    auto _x_main_module_134 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 133)));
+    auto _x_main_module_135 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 134));
+    auto _x_main_module_136 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 135));
+    auto _x_main_module_137 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 136)));
+    auto _x_main_module_138 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 137));
+    auto _x_main_module_139 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 138)));
+    auto _x_main_module_140 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 139));
+    auto _x_main_module_141 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 140));
+    auto _x_main_module_142 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 141)));
+    auto _x_main_module_143 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 142));
+    auto _x_main_module_144 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 143)));
+    auto _x_main_module_145 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 144));
+    auto _x_main_module_146 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 145));
+    auto _x_main_module_147 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 146)));
+    auto _x_main_module_148 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 147));
+    auto _x_main_module_149 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 148)));
+    auto _x_main_module_150 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 149));
+    auto _x_main_module_151 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 150));
+    auto _x_main_module_152 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 151)));
+    auto _x_main_module_153 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 152));
+    auto _x_main_module_154 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 153)));
+    auto _x_main_module_155 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 154));
+    auto _x_main_module_156 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 155));
+    auto _x_main_module_157 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 156)));
+    auto _x_main_module_158 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 157));
+    auto _x_main_module_159 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 158)));
+    auto _x_main_module_160 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 159));
+    auto _x_main_module_161 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 160));
+    auto _x_main_module_162 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 161)));
+    auto _x_main_module_163 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 162));
+    auto _x_main_module_164 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 163)));
+    auto _x_main_module_165 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 164));
+    auto _x_main_module_166 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 165));
+    auto _x_main_module_167 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 166)));
+    auto _x_main_module_168 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 167));
+    auto _x_main_module_169 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 168)));
+    auto _x_main_module_170 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 169));
+    auto _x_main_module_171 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 170));
+    auto _x_main_module_172 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 171)));
+    auto _x_main_module_173 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 172));
+    auto _x_main_module_174 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 173)));
+    auto _x_main_module_175 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 174));
+    auto _x_main_module_176 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 175));
+    auto _x_main_module_177 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 176)));
+    auto _x_main_module_178 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 177));
+    auto _x_main_module_179 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 178)));
+    auto _x_main_module_180 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 179));
+    auto _x_main_module_181 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 180));
+    auto _x_main_module_182 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 181)));
+    auto _x_main_module_183 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 182));
+    auto _x_main_module_184 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 183)));
+    auto _x_main_module_185 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 184));
+    auto _x_main_module_186 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 185));
+    auto _x_main_module_187 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 186)));
+    auto _x_main_module_188 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 187));
+    auto _x_main_module_189 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 188)));
+    auto _x_main_module_190 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 189));
+    auto _x_main_module_191 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 190));
+    auto _x_main_module_192 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 191)));
+    auto _x_main_module_193 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 192));
+    auto _x_main_module_194 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 193)));
+    auto _x_main_module_195 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 194));
+    auto _x_main_module_196 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 195));
+    auto _x_main_module_197 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 196)));
+    auto _x_main_module_198 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 197));
+    auto _x_main_module_199 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 198)));
+    auto _x_main_module_200 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 199));
+    auto _x_main_module_201 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 200));
+    auto _x_main_module_202 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 201)));
+    auto _x_main_module_203 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 202));
+    auto _x_main_module_204 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 203)));
+    auto _x_main_module_205 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 204));
+    auto _x_main_module_206 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 205));
+    auto _x_main_module_207 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 206)));
+    auto _x_main_module_208 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 207));
+    auto _x_main_module_209 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 208)));
+    auto _x_main_module_210 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 209));
+    auto _x_main_module_211 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 210));
+    auto _x_main_module_212 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 211)));
+    auto _x_main_module_213 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 212));
+    auto _x_main_module_214 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 213)));
+    auto _x_main_module_215 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 214));
+    auto _x_main_module_216 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 215));
+    auto _x_main_module_217 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 216)));
+    auto _x_main_module_218 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 217));
+    auto _x_main_module_219 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 218)));
+    auto _x_main_module_220 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 219));
+    auto _x_main_module_221 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 220));
+    auto _x_main_module_222 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 221)));
+    auto _x_main_module_223 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 222));
+    auto _x_main_module_224 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 223)));
+    auto _x_main_module_225 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 224));
+    auto _x_main_module_226 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 225));
+    auto _x_main_module_227 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 226)));
+    auto _x_main_module_228 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 227));
+    auto _x_main_module_229 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 228)));
+    auto _x_main_module_230 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 229));
+    auto _x_main_module_231 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 230));
+    auto _x_main_module_232 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 231)));
+    auto _x_main_module_233 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 232));
+    auto _x_main_module_234 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 233)));
+    auto _x_main_module_235 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 234));
+    auto _x_main_module_236 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 235));
+    auto _x_main_module_237 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 236)));
+    auto _x_main_module_238 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 237));
+    auto _x_main_module_239 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 238)));
+    auto _x_main_module_240 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 239));
+    auto _x_main_module_241 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 240));
+    auto _x_main_module_242 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 241)));
+    auto _x_main_module_243 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 242));
+    auto _x_main_module_244 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 243)));
+    auto _x_main_module_245 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 244));
+    auto _x_main_module_246 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 245));
+    auto _x_main_module_247 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 246)));
+    auto _x_main_module_248 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 247));
+    auto _x_main_module_249 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 248)));
+    auto _x_main_module_250 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 249));
+    auto _x_main_module_251 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 250));
+    auto _x_main_module_252 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 251)));
+    auto _x_main_module_253 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 252));
+    auto _x_main_module_254 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 253)));
+    auto _x_main_module_255 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 254));
+    auto _x_main_module_256 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 255));
+    auto _x_main_module_257 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 256)));
+    auto _x_main_module_258 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 257));
+    auto _x_main_module_259 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 258)));
+    auto _x_main_module_260 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 259));
+    auto _x_main_module_261 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 260));
+    auto _x_main_module_262 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 261)));
+    auto _x_main_module_263 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 262));
+    auto _x_main_module_264 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 263)));
+    auto _x_main_module_265 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 264));
+    auto _x_main_module_266 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 265));
+    auto _x_main_module_267 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 266)));
+    auto _x_main_module_268 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 267));
+    auto _x_main_module_269 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 268)));
+    auto _x_main_module_270 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 269));
+    auto _x_main_module_271 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 270));
+    auto _x_main_module_272 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 271)));
+    auto _x_main_module_273 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 272));
+    auto _x_main_module_274 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 273)));
+    auto _x_main_module_275 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 274));
+    auto _x_main_module_276 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 275));
+    auto _x_main_module_277 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 276)));
+    auto _x_main_module_278 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 277));
+    auto _x_main_module_279 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 278)));
+    auto _x_main_module_280 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 279));
+    auto _x_main_module_281 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 280));
+    auto _x_main_module_282 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 281)));
+    auto _x_main_module_283 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 128, 1, 7}}, 282));
+    auto _x_main_module_284 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 283)));
+    auto _x_main_module_285 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 284));
+    auto _x_main_module_286 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 285));
+    auto _x_main_module_287 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 286)));
+    auto _x_main_module_288 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 287));
+    auto _x_main_module_289 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 288)));
+    auto _x_main_module_290 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 289));
+    auto _x_main_module_291 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 290));
+    auto _x_main_module_292 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 291)));
+    auto _x_main_module_293 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 292));
+    auto _x_main_module_294 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 293)));
+    auto _x_main_module_295 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 294));
+    auto _x_main_module_296 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 295));
+    auto _x_main_module_297 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 296)));
+    auto _x_main_module_298 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 297));
+    auto _x_main_module_299 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 298)));
+    auto _x_main_module_300 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 299));
+    auto _x_main_module_301 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 300));
+    auto _x_main_module_302 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 301)));
+    auto _x_main_module_303 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 302));
+    auto _x_main_module_304 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 303)));
+    auto _x_main_module_305 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 304));
+    auto _x_main_module_306 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 305));
+    auto _x_main_module_307 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 306)));
+    auto _x_main_module_308 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 128, 7, 1}}, 307));
+    auto _x_main_module_309 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 308)));
+    auto _x_main_module_310 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 309));
+    auto _x_main_module_311 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 310));
+    auto _x_main_module_312 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 311)));
+    auto _x_main_module_313 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 312));
+    auto _x_main_module_314 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 313)));
+    auto _x_main_module_315 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 314));
+    auto _x_main_module_316 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 315));
+    auto _x_main_module_317 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 316)));
+    auto _x_main_module_318 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 317));
+    auto _x_main_module_319 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 318)));
+    auto _x_main_module_320 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 319));
+    auto _x_main_module_321 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 320));
+    auto _x_main_module_322 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 321)));
+    auto _x_main_module_323 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 322));
+    auto _x_main_module_324 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 323)));
+    auto _x_main_module_325 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 324));
+    auto _x_main_module_326 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 325));
+    auto _x_main_module_327 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 326)));
+    auto _x_main_module_328 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 327));
+    auto _x_main_module_329 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 328)));
+    auto _x_main_module_330 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 329));
+    auto _x_main_module_331 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 330));
+    auto _x_main_module_332 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 331)));
+    auto _x_main_module_333 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 332));
+    auto _x_main_module_334 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 333)));
+    auto _x_main_module_335 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 334));
+    auto _x_main_module_336 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 335));
+    auto _x_main_module_337 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 336)));
+    auto _x_main_module_338 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 337));
+    auto _x_main_module_339 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 338)));
+    auto _x_main_module_340 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 339));
+    auto _x_main_module_341 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 340));
+    auto _x_main_module_342 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 341)));
+    auto _x_main_module_343 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 288, 3, 3}}, 342));
+    auto _x_main_module_344 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 343)));
+    auto _x_main_module_345 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 344));
+    auto _x_main_module_346 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 345));
+    auto _x_main_module_347 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 346)));
+    auto _x_main_module_348 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 347));
+    auto _x_main_module_349 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 348)));
+    auto _x_main_module_350 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 349));
+    auto _x_main_module_351 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 350));
+    auto _x_main_module_352 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 351)));
+    auto _x_main_module_353 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 352));
+    auto _x_main_module_354 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 353)));
+    auto _x_main_module_355 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 354));
+    auto _x_main_module_356 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 355));
+    auto _x_main_module_357 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 356)));
+    auto _x_main_module_358 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 357));
+    auto _x_main_module_359 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 358)));
+    auto _x_main_module_360 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 359));
+    auto _x_main_module_361 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 360));
+    auto _x_main_module_362 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 361)));
+    auto _x_main_module_363 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 362));
+    auto _x_main_module_364 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 363)));
+    auto _x_main_module_365 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 364));
+    auto _x_main_module_366 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 365));
+    auto _x_main_module_367 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 366)));
+    auto _x_main_module_368 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 367));
+    auto _x_main_module_369 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 368)));
+    auto _x_main_module_370 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 369));
+    auto _x_main_module_371 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 370));
+    auto _x_main_module_372 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 371)));
+    auto _x_main_module_373 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {48, 288, 1, 1}}, 372));
+    auto _x_main_module_374 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 373)));
+    auto _x_main_module_375 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 374));
+    auto _x_main_module_376 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 375));
+    auto _x_main_module_377 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 376)));
+    auto _x_main_module_378 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 377));
+    auto _x_main_module_379 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 378)));
+    auto _x_main_module_380 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 379));
+    auto _x_main_module_381 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 380));
+    auto _x_main_module_382 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 381)));
+    auto _x_main_module_383 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 382));
+    auto _x_main_module_384 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 383)));
+    auto _x_main_module_385 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 384));
+    auto _x_main_module_386 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 385));
+    auto _x_main_module_387 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 386)));
+    auto _x_main_module_388 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 387));
+    auto _x_main_module_389 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 388)));
+    auto _x_main_module_390 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 389));
+    auto _x_main_module_391 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 390));
+    auto _x_main_module_392 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 391)));
+    auto _x_main_module_393 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 392));
+    auto _x_main_module_394 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 393)));
+    auto _x_main_module_395 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 394));
+    auto _x_main_module_396 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 395));
+    auto _x_main_module_397 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 396)));
+    auto _x_main_module_398 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 397));
+    auto _x_main_module_399 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 398)));
+    auto _x_main_module_400 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 399));
+    auto _x_main_module_401 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 400));
+    auto _x_main_module_402 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 401)));
+    auto _x_main_module_403 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 402));
+    auto _x_main_module_404 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 403)));
+    auto _x_main_module_405 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 404));
+    auto _x_main_module_406 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 405));
+    auto _x_main_module_407 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 406)));
+    auto _x_main_module_408 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {48, 256, 1, 1}}, 407));
+    auto _x_main_module_409 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 408)));
+    auto _x_main_module_410 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 409));
+    auto _x_main_module_411 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 410));
+    auto _x_main_module_412 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 411)));
+    auto _x_main_module_413 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 412));
+    auto _x_main_module_414 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 413)));
+    auto _x_main_module_415 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 414));
+    auto _x_main_module_416 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 415));
+    auto _x_main_module_417 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 416)));
+    auto _x_main_module_418 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {32, 192, 1, 1}}, 417));
+    auto _x_main_module_419 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 418)));
+    auto _x_main_module_420 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 419));
+    auto _x_main_module_421 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 420));
+    auto _x_main_module_422 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 421)));
+    auto _x_main_module_423 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 422));
+    auto _x_main_module_424 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 423)));
+    auto _x_main_module_425 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 424));
+    auto _x_main_module_426 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 425));
+    auto _x_main_module_427 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 426)));
+    auto _x_main_module_428 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 427));
+    auto _x_main_module_429 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 428)));
+    auto _x_main_module_430 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 429));
+    auto _x_main_module_431 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 430));
+    auto _x_main_module_432 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 431)));
+    auto _x_main_module_433 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 432));
+    auto _x_main_module_434 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 433)));
+    auto _x_main_module_435 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 434));
+    auto _x_main_module_436 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 435));
+    auto _x_main_module_437 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 436)));
+    auto _x_main_module_438 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 437));
+    auto _x_main_module_439 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 438)));
+    auto _x_main_module_440 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 439));
+    auto _x_main_module_441 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 440));
+    auto _x_main_module_442 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 441)));
+    auto _x_main_module_443 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {48, 192, 1, 1}}, 442));
+    auto _x_main_module_444 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 443)));
+    auto _x_main_module_445 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 444));
+    auto _x_main_module_446 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 445));
+    auto _x_main_module_447 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 446)));
+    auto _x_main_module_448 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 447));
+    auto _x_main_module_449 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 448)));
+    auto _x_main_module_450 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 449));
+    auto _x_main_module_451 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 450));
+    auto _x_main_module_452 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 451)));
+    auto _x_main_module_453 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 80, 3, 3}}, 452));
+    auto _x_main_module_454 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 453)));
+    auto _x_main_module_455 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 454));
+    auto _x_main_module_456 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 455));
+    auto _x_main_module_457 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 456)));
+    auto _x_main_module_458 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {80, 64, 1, 1}}, 457));
+    auto _x_main_module_459 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 458)));
+    auto _x_main_module_460 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 459));
+    auto _x_main_module_461 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 460));
+    auto _x_main_module_462 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 461)));
+    auto _x_main_module_463 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 32, 3, 3}}, 462));
+    auto _x_main_module_464 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 463)));
+    auto _x_main_module_465 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 464));
+    auto _x_main_module_466 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 465));
+    auto _x_main_module_467 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 466)));
+    auto _x_main_module_468 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {32, 32, 3, 3}}, 467));
+    auto _x_main_module_469 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 468)));
+    auto _x_main_module_470 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 469));
+    auto _x_main_module_471 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 470));
+    auto _x_main_module_472 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 471)));
+    auto _x_main_module_473 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {32, 3, 3, 3}}, 472));
+    auto _x_main_module_474 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        _x_0,
+        _x_main_module_473);
+    auto _x_main_module_475 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_474,
+        _x_main_module_472,
+        _x_main_module_471,
+        _x_main_module_470,
+        _x_main_module_469);
+    auto _x_main_module_476 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_475);
+    auto _x_main_module_477 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_476,
+        _x_main_module_468);
+    auto _x_main_module_478 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_477,
+        _x_main_module_467,
+        _x_main_module_466,
+        _x_main_module_465,
+        _x_main_module_464);
+    auto _x_main_module_479 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_478);
+    auto _x_main_module_480 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_479,
+        _x_main_module_463);
+    auto _x_main_module_481 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_480,
+        _x_main_module_462,
+        _x_main_module_461,
+        _x_main_module_460,
+        _x_main_module_459);
+    auto _x_main_module_482 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_481);
+    auto _x_main_module_483 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        _x_main_module_482);
+    auto _x_main_module_484 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_483,
+        _x_main_module_458);
+    auto _x_main_module_485 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_484,
+        _x_main_module_457,
+        _x_main_module_456,
+        _x_main_module_455,
+        _x_main_module_454);
+    auto _x_main_module_486 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_485);
+    auto _x_main_module_487 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_486,
+        _x_main_module_453);
+    auto _x_main_module_488 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_487,
+        _x_main_module_452,
+        _x_main_module_451,
+        _x_main_module_450,
+        _x_main_module_449);
+    auto _x_main_module_489 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_488);
+    auto _x_main_module_490 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        _x_main_module_489);
+    auto _x_main_module_491 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_490,
+        _x_main_module_448);
+    auto _x_main_module_492 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_491,
+        _x_main_module_447,
+        _x_main_module_446,
+        _x_main_module_445,
+        _x_main_module_444);
+    auto _x_main_module_493 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_492);
+    auto _x_main_module_494 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_490,
+        _x_main_module_443);
+    auto _x_main_module_495 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_494,
+        _x_main_module_442,
+        _x_main_module_441,
+        _x_main_module_440,
+        _x_main_module_439);
+    auto _x_main_module_496 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_495);
+    auto _x_main_module_497 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_496,
+        _x_main_module_438);
+    auto _x_main_module_498 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_497,
+        _x_main_module_437,
+        _x_main_module_436,
+        _x_main_module_435,
+        _x_main_module_434);
+    auto _x_main_module_499 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_498);
+    auto _x_main_module_500 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_490,
+        _x_main_module_433);
+    auto _x_main_module_501 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_500,
+        _x_main_module_432,
+        _x_main_module_431,
+        _x_main_module_430,
+        _x_main_module_429);
+    auto _x_main_module_502 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_501);
+    auto _x_main_module_503 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_502,
+        _x_main_module_428);
+    auto _x_main_module_504 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_503,
+        _x_main_module_427,
+        _x_main_module_426,
+        _x_main_module_425,
+        _x_main_module_424);
+    auto _x_main_module_505 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_504);
+    auto _x_main_module_506 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_505,
+        _x_main_module_423);
+    auto _x_main_module_507 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_506,
+        _x_main_module_422,
+        _x_main_module_421,
+        _x_main_module_420,
+        _x_main_module_419);
+    auto _x_main_module_508 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_507);
+    auto _x_main_module_509 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        _x_main_module_490);
+    auto _x_main_module_510 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_509,
+        _x_main_module_418);
+    auto _x_main_module_511 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_510,
+        _x_main_module_417,
+        _x_main_module_416,
+        _x_main_module_415,
+        _x_main_module_414);
+    auto _x_main_module_512 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_511);
+    auto _x_main_module_513 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_493,
+        _x_main_module_499,
+        _x_main_module_508,
+        _x_main_module_512);
+    auto _x_main_module_514 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_513,
+        _x_main_module_413);
+    auto _x_main_module_515 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_514,
+        _x_main_module_412,
+        _x_main_module_411,
+        _x_main_module_410,
+        _x_main_module_409);
+    auto _x_main_module_516 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_515);
+    auto _x_main_module_517 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_513,
+        _x_main_module_408);
+    auto _x_main_module_518 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_517,
+        _x_main_module_407,
+        _x_main_module_406,
+        _x_main_module_405,
+        _x_main_module_404);
+    auto _x_main_module_519 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_518);
+    auto _x_main_module_520 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_519,
+        _x_main_module_403);
+    auto _x_main_module_521 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_520,
+        _x_main_module_402,
+        _x_main_module_401,
+        _x_main_module_400,
+        _x_main_module_399);
+    auto _x_main_module_522 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_521);
+    auto _x_main_module_523 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_513,
+        _x_main_module_398);
+    auto _x_main_module_524 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_523,
+        _x_main_module_397,
+        _x_main_module_396,
+        _x_main_module_395,
+        _x_main_module_394);
+    auto _x_main_module_525 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_524);
+    auto _x_main_module_526 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_525,
+        _x_main_module_393);
+    auto _x_main_module_527 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_526,
+        _x_main_module_392,
+        _x_main_module_391,
+        _x_main_module_390,
+        _x_main_module_389);
+    auto _x_main_module_528 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_527);
+    auto _x_main_module_529 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_528,
+        _x_main_module_388);
+    auto _x_main_module_530 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_529,
+        _x_main_module_387,
+        _x_main_module_386,
+        _x_main_module_385,
+        _x_main_module_384);
+    auto _x_main_module_531 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_530);
+    auto _x_main_module_532 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        _x_main_module_513);
+    auto _x_main_module_533 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_532,
+        _x_main_module_383);
+    auto _x_main_module_534 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_533,
+        _x_main_module_382,
+        _x_main_module_381,
+        _x_main_module_380,
+        _x_main_module_379);
+    auto _x_main_module_535 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_534);
+    auto _x_main_module_536 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_516,
+        _x_main_module_522,
+        _x_main_module_531,
+        _x_main_module_535);
+    auto _x_main_module_537 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_536,
+        _x_main_module_378);
+    auto _x_main_module_538 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_537,
+        _x_main_module_377,
+        _x_main_module_376,
+        _x_main_module_375,
+        _x_main_module_374);
+    auto _x_main_module_539 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_538);
+    auto _x_main_module_540 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_536,
+        _x_main_module_373);
+    auto _x_main_module_541 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_540,
+        _x_main_module_372,
+        _x_main_module_371,
+        _x_main_module_370,
+        _x_main_module_369);
+    auto _x_main_module_542 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_541);
+    auto _x_main_module_543 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_542,
+        _x_main_module_368);
+    auto _x_main_module_544 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_543,
+        _x_main_module_367,
+        _x_main_module_366,
+        _x_main_module_365,
+        _x_main_module_364);
+    auto _x_main_module_545 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_544);
+    auto _x_main_module_546 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_536,
+        _x_main_module_363);
+    auto _x_main_module_547 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_546,
+        _x_main_module_362,
+        _x_main_module_361,
+        _x_main_module_360,
+        _x_main_module_359);
+    auto _x_main_module_548 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_547);
+    auto _x_main_module_549 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_548,
+        _x_main_module_358);
+    auto _x_main_module_550 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_549,
+        _x_main_module_357,
+        _x_main_module_356,
+        _x_main_module_355,
+        _x_main_module_354);
+    auto _x_main_module_551 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_550);
+    auto _x_main_module_552 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_551,
+        _x_main_module_353);
+    auto _x_main_module_553 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_552,
+        _x_main_module_352,
+        _x_main_module_351,
+        _x_main_module_350,
+        _x_main_module_349);
+    auto _x_main_module_554 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_553);
+    auto _x_main_module_555 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        _x_main_module_536);
+    auto _x_main_module_556 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_555,
+        _x_main_module_348);
+    auto _x_main_module_557 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_556,
+        _x_main_module_347,
+        _x_main_module_346,
+        _x_main_module_345,
+        _x_main_module_344);
+    auto _x_main_module_558 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_557);
+    auto _x_main_module_559 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_539,
+        _x_main_module_545,
+        _x_main_module_554,
+        _x_main_module_558);
+    auto _x_main_module_560 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_559,
+        _x_main_module_343);
+    auto _x_main_module_561 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_560,
+        _x_main_module_342,
+        _x_main_module_341,
+        _x_main_module_340,
+        _x_main_module_339);
+    auto _x_main_module_562 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_561);
+    auto _x_main_module_563 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_559,
+        _x_main_module_338);
+    auto _x_main_module_564 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_563,
+        _x_main_module_337,
+        _x_main_module_336,
+        _x_main_module_335,
+        _x_main_module_334);
+    auto _x_main_module_565 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_564);
+    auto _x_main_module_566 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_565,
+        _x_main_module_333);
+    auto _x_main_module_567 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_566,
+        _x_main_module_332,
+        _x_main_module_331,
+        _x_main_module_330,
+        _x_main_module_329);
+    auto _x_main_module_568 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_567);
+    auto _x_main_module_569 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_568,
+        _x_main_module_328);
+    auto _x_main_module_570 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_569,
+        _x_main_module_327,
+        _x_main_module_326,
+        _x_main_module_325,
+        _x_main_module_324);
+    auto _x_main_module_571 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_570);
+    auto _x_main_module_572 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        _x_main_module_559);
+    auto _x_main_module_573 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_562,
+        _x_main_module_571,
+        _x_main_module_572);
+    auto _x_main_module_574 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_573,
+        _x_main_module_323);
+    auto _x_main_module_575 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_574,
+        _x_main_module_322,
+        _x_main_module_321,
+        _x_main_module_320,
+        _x_main_module_319);
+    auto _x_main_module_576 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_575);
+    auto _x_main_module_577 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_573,
+        _x_main_module_318);
+    auto _x_main_module_578 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_577,
+        _x_main_module_317,
+        _x_main_module_316,
+        _x_main_module_315,
+        _x_main_module_314);
+    auto _x_main_module_579 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_578);
+    auto _x_main_module_580 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_579,
+        _x_main_module_313);
+    auto _x_main_module_581 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_580,
+        _x_main_module_312,
+        _x_main_module_311,
+        _x_main_module_310,
+        _x_main_module_309);
+    auto _x_main_module_582 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_581);
+    auto _x_main_module_583 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_582,
+        _x_main_module_308);
+    auto _x_main_module_584 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_583,
+        _x_main_module_307,
+        _x_main_module_306,
+        _x_main_module_305,
+        _x_main_module_304);
+    auto _x_main_module_585 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_584);
+    auto _x_main_module_586 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_573,
+        _x_main_module_303);
+    auto _x_main_module_587 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_586,
+        _x_main_module_302,
+        _x_main_module_301,
+        _x_main_module_300,
+        _x_main_module_299);
+    auto _x_main_module_588 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_587);
+    auto _x_main_module_589 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_588,
+        _x_main_module_298);
+    auto _x_main_module_590 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_589,
+        _x_main_module_297,
+        _x_main_module_296,
+        _x_main_module_295,
+        _x_main_module_294);
+    auto _x_main_module_591 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_590);
+    auto _x_main_module_592 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_591,
+        _x_main_module_293);
+    auto _x_main_module_593 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_592,
+        _x_main_module_292,
+        _x_main_module_291,
+        _x_main_module_290,
+        _x_main_module_289);
+    auto _x_main_module_594 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_593);
+    auto _x_main_module_595 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_594,
+        _x_main_module_288);
+    auto _x_main_module_596 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_595,
+        _x_main_module_287,
+        _x_main_module_286,
+        _x_main_module_285,
+        _x_main_module_284);
+    auto _x_main_module_597 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_596);
+    auto _x_main_module_598 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_597,
+        _x_main_module_283);
+    auto _x_main_module_599 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_598,
+        _x_main_module_282,
+        _x_main_module_281,
+        _x_main_module_280,
+        _x_main_module_279);
+    auto _x_main_module_600 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_599);
+    auto _x_main_module_601 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        _x_main_module_573);
+    auto _x_main_module_602 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_601,
+        _x_main_module_278);
+    auto _x_main_module_603 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_602,
+        _x_main_module_277,
+        _x_main_module_276,
+        _x_main_module_275,
+        _x_main_module_274);
+    auto _x_main_module_604 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_603);
+    auto _x_main_module_605 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_576,
+        _x_main_module_585,
+        _x_main_module_600,
+        _x_main_module_604);
+    auto _x_main_module_606 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_605,
+        _x_main_module_273);
+    auto _x_main_module_607 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_606,
+        _x_main_module_272,
+        _x_main_module_271,
+        _x_main_module_270,
+        _x_main_module_269);
+    auto _x_main_module_608 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_607);
+    auto _x_main_module_609 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_605,
+        _x_main_module_268);
+    auto _x_main_module_610 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_609,
+        _x_main_module_267,
+        _x_main_module_266,
+        _x_main_module_265,
+        _x_main_module_264);
+    auto _x_main_module_611 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_610);
+    auto _x_main_module_612 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_611,
+        _x_main_module_263);
+    auto _x_main_module_613 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_612,
+        _x_main_module_262,
+        _x_main_module_261,
+        _x_main_module_260,
+        _x_main_module_259);
+    auto _x_main_module_614 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_613);
+    auto _x_main_module_615 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_614,
+        _x_main_module_258);
+    auto _x_main_module_616 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_615,
+        _x_main_module_257,
+        _x_main_module_256,
+        _x_main_module_255,
+        _x_main_module_254);
+    auto _x_main_module_617 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_616);
+    auto _x_main_module_618 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_605,
+        _x_main_module_253);
+    auto _x_main_module_619 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_618,
+        _x_main_module_252,
+        _x_main_module_251,
+        _x_main_module_250,
+        _x_main_module_249);
+    auto _x_main_module_620 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_619);
+    auto _x_main_module_621 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_620,
+        _x_main_module_248);
+    auto _x_main_module_622 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_621,
+        _x_main_module_247,
+        _x_main_module_246,
+        _x_main_module_245,
+        _x_main_module_244);
+    auto _x_main_module_623 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_622);
+    auto _x_main_module_624 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_623,
+        _x_main_module_243);
+    auto _x_main_module_625 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_624,
+        _x_main_module_242,
+        _x_main_module_241,
+        _x_main_module_240,
+        _x_main_module_239);
+    auto _x_main_module_626 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_625);
+    auto _x_main_module_627 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_626,
+        _x_main_module_238);
+    auto _x_main_module_628 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_627,
+        _x_main_module_237,
+        _x_main_module_236,
+        _x_main_module_235,
+        _x_main_module_234);
+    auto _x_main_module_629 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_628);
+    auto _x_main_module_630 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_629,
+        _x_main_module_233);
+    auto _x_main_module_631 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_630,
+        _x_main_module_232,
+        _x_main_module_231,
+        _x_main_module_230,
+        _x_main_module_229);
+    auto _x_main_module_632 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_631);
+    auto _x_main_module_633 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        _x_main_module_605);
+    auto _x_main_module_634 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_633,
+        _x_main_module_228);
+    auto _x_main_module_635 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_634,
+        _x_main_module_227,
+        _x_main_module_226,
+        _x_main_module_225,
+        _x_main_module_224);
+    auto _x_main_module_636 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_635);
+    auto _x_main_module_637 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_608,
+        _x_main_module_617,
+        _x_main_module_632,
+        _x_main_module_636);
+    auto _x_main_module_638 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_637,
+        _x_main_module_223);
+    auto _x_main_module_639 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_638,
+        _x_main_module_222,
+        _x_main_module_221,
+        _x_main_module_220,
+        _x_main_module_219);
+    auto _x_main_module_640 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_639);
+    auto _x_main_module_641 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_637,
+        _x_main_module_218);
+    auto _x_main_module_642 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_641,
+        _x_main_module_217,
+        _x_main_module_216,
+        _x_main_module_215,
+        _x_main_module_214);
+    auto _x_main_module_643 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_642);
+    auto _x_main_module_644 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_643,
+        _x_main_module_213);
+    auto _x_main_module_645 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_644,
+        _x_main_module_212,
+        _x_main_module_211,
+        _x_main_module_210,
+        _x_main_module_209);
+    auto _x_main_module_646 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_645);
+    auto _x_main_module_647 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_646,
+        _x_main_module_208);
+    auto _x_main_module_648 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_647,
+        _x_main_module_207,
+        _x_main_module_206,
+        _x_main_module_205,
+        _x_main_module_204);
+    auto _x_main_module_649 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_648);
+    auto _x_main_module_650 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_637,
+        _x_main_module_203);
+    auto _x_main_module_651 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_650,
+        _x_main_module_202,
+        _x_main_module_201,
+        _x_main_module_200,
+        _x_main_module_199);
+    auto _x_main_module_652 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_651);
+    auto _x_main_module_653 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_652,
+        _x_main_module_198);
+    auto _x_main_module_654 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_653,
+        _x_main_module_197,
+        _x_main_module_196,
+        _x_main_module_195,
+        _x_main_module_194);
+    auto _x_main_module_655 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_654);
+    auto _x_main_module_656 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_655,
+        _x_main_module_193);
+    auto _x_main_module_657 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_656,
+        _x_main_module_192,
+        _x_main_module_191,
+        _x_main_module_190,
+        _x_main_module_189);
+    auto _x_main_module_658 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_657);
+    auto _x_main_module_659 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_658,
+        _x_main_module_188);
+    auto _x_main_module_660 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_659,
+        _x_main_module_187,
+        _x_main_module_186,
+        _x_main_module_185,
+        _x_main_module_184);
+    auto _x_main_module_661 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_660);
+    auto _x_main_module_662 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_661,
+        _x_main_module_183);
+    auto _x_main_module_663 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_662,
+        _x_main_module_182,
+        _x_main_module_181,
+        _x_main_module_180,
+        _x_main_module_179);
+    auto _x_main_module_664 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_663);
+    auto _x_main_module_665 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        _x_main_module_637);
+    auto _x_main_module_666 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_665,
+        _x_main_module_178);
+    auto _x_main_module_667 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_666,
+        _x_main_module_177,
+        _x_main_module_176,
+        _x_main_module_175,
+        _x_main_module_174);
+    auto _x_main_module_668 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_667);
+    auto _x_main_module_669 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_640,
+        _x_main_module_649,
+        _x_main_module_664,
+        _x_main_module_668);
+    auto _x_main_module_670 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_669,
+        _x_main_module_173);
+    auto _x_main_module_671 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_670,
+        _x_main_module_172,
+        _x_main_module_171,
+        _x_main_module_170,
+        _x_main_module_169);
+    auto _x_main_module_672 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_671);
+    auto _x_main_module_673 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_669,
+        _x_main_module_168);
+    auto _x_main_module_674 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_673,
+        _x_main_module_167,
+        _x_main_module_166,
+        _x_main_module_165,
+        _x_main_module_164);
+    auto _x_main_module_675 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_674);
+    auto _x_main_module_676 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_675,
+        _x_main_module_163);
+    auto _x_main_module_677 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_676,
+        _x_main_module_162,
+        _x_main_module_161,
+        _x_main_module_160,
+        _x_main_module_159);
+    auto _x_main_module_678 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_677);
+    auto _x_main_module_679 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_678,
+        _x_main_module_158);
+    auto _x_main_module_680 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_679,
+        _x_main_module_157,
+        _x_main_module_156,
+        _x_main_module_155,
+        _x_main_module_154);
+    auto _x_main_module_681 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_680);
+    auto _x_main_module_682 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_669,
+        _x_main_module_153);
+    auto _x_main_module_683 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_682,
+        _x_main_module_152,
+        _x_main_module_151,
+        _x_main_module_150,
+        _x_main_module_149);
+    auto _x_main_module_684 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_683);
+    auto _x_main_module_685 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_684,
+        _x_main_module_148);
+    auto _x_main_module_686 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_685,
+        _x_main_module_147,
+        _x_main_module_146,
+        _x_main_module_145,
+        _x_main_module_144);
+    auto _x_main_module_687 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_686);
+    auto _x_main_module_688 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_687,
+        _x_main_module_143);
+    auto _x_main_module_689 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_688,
+        _x_main_module_142,
+        _x_main_module_141,
+        _x_main_module_140,
+        _x_main_module_139);
+    auto _x_main_module_690 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_689);
+    auto _x_main_module_691 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_690,
+        _x_main_module_138);
+    auto _x_main_module_692 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_691,
+        _x_main_module_137,
+        _x_main_module_136,
+        _x_main_module_135,
+        _x_main_module_134);
+    auto _x_main_module_693 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_692);
+    auto _x_main_module_694 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_693,
+        _x_main_module_133);
+    auto _x_main_module_695 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_694,
+        _x_main_module_132,
+        _x_main_module_131,
+        _x_main_module_130,
+        _x_main_module_129);
+    auto _x_main_module_696 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_695);
+    auto _x_main_module_697 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        _x_main_module_669);
+    auto _x_main_module_698 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_697,
+        _x_main_module_128);
+    auto _x_main_module_699 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_698,
+        _x_main_module_127,
+        _x_main_module_126,
+        _x_main_module_125,
+        _x_main_module_124);
+    auto _x_main_module_700 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_699);
+    auto _x_main_module_701 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_672,
+        _x_main_module_681,
+        _x_main_module_696,
+        _x_main_module_700);
+    auto _x_main_module_702 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_701,
+        _x_main_module_123);
+    auto _x_main_module_703 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_702,
+        _x_main_module_122,
+        _x_main_module_121,
+        _x_main_module_120,
+        _x_main_module_119);
+    auto _x_main_module_704 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_703);
+    auto _x_main_module_705 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_704,
+        _x_main_module_118);
+    auto _x_main_module_706 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_705,
+        _x_main_module_117,
+        _x_main_module_116,
+        _x_main_module_115,
+        _x_main_module_114);
+    auto _x_main_module_707 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_706);
+    auto _x_main_module_708 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_701,
+        _x_main_module_113);
+    auto _x_main_module_709 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_708,
+        _x_main_module_112,
+        _x_main_module_111,
+        _x_main_module_110,
+        _x_main_module_109);
+    auto _x_main_module_710 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_709);
+    auto _x_main_module_711 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_710,
+        _x_main_module_108);
+    auto _x_main_module_712 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_711,
+        _x_main_module_107,
+        _x_main_module_106,
+        _x_main_module_105,
+        _x_main_module_104);
+    auto _x_main_module_713 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_712);
+    auto _x_main_module_714 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_713,
+        _x_main_module_103);
+    auto _x_main_module_715 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_714,
+        _x_main_module_102,
+        _x_main_module_101,
+        _x_main_module_100,
+        _x_main_module_99);
+    auto _x_main_module_716 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_715);
+    auto _x_main_module_717 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_716,
+        _x_main_module_98);
+    auto _x_main_module_718 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_717,
+        _x_main_module_97,
+        _x_main_module_96,
+        _x_main_module_95,
+        _x_main_module_94);
+    auto _x_main_module_719 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_718);
+    auto _x_main_module_720 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        _x_main_module_701);
+    auto _x_main_module_721 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_707,
+        _x_main_module_719,
+        _x_main_module_720);
+    auto _x_main_module_722 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_721,
+        _x_main_module_93);
+    auto _x_main_module_723 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_722,
+        _x_main_module_92,
+        _x_main_module_91,
+        _x_main_module_90,
+        _x_main_module_89);
+    auto _x_main_module_724 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_723);
+    auto _x_main_module_725 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_721,
+        _x_main_module_88);
+    auto _x_main_module_726 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_725,
+        _x_main_module_87,
+        _x_main_module_86,
+        _x_main_module_85,
+        _x_main_module_84);
+    auto _x_main_module_727 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_726);
+    auto _x_main_module_728 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_727,
+        _x_main_module_83);
+    auto _x_main_module_729 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_728,
+        _x_main_module_82,
+        _x_main_module_81,
+        _x_main_module_80,
+        _x_main_module_79);
+    auto _x_main_module_730 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_729);
+    auto _x_main_module_731 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_727,
+        _x_main_module_78);
+    auto _x_main_module_732 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_731,
+        _x_main_module_77,
+        _x_main_module_76,
+        _x_main_module_75,
+        _x_main_module_74);
+    auto _x_main_module_733 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_732);
+    auto _x_main_module_734 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_730,
+        _x_main_module_733);
+    auto _x_main_module_735 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_721,
+        _x_main_module_73);
+    auto _x_main_module_736 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_735,
+        _x_main_module_72,
+        _x_main_module_71,
+        _x_main_module_70,
+        _x_main_module_69);
+    auto _x_main_module_737 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_736);
+    auto _x_main_module_738 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_737,
+        _x_main_module_68);
+    auto _x_main_module_739 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_738,
+        _x_main_module_67,
+        _x_main_module_66,
+        _x_main_module_65,
+        _x_main_module_64);
+    auto _x_main_module_740 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_739);
+    auto _x_main_module_741 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_740,
+        _x_main_module_63);
+    auto _x_main_module_742 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_741,
+        _x_main_module_62,
+        _x_main_module_61,
+        _x_main_module_60,
+        _x_main_module_59);
+    auto _x_main_module_743 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_742);
+    auto _x_main_module_744 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_740,
+        _x_main_module_58);
+    auto _x_main_module_745 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_744,
+        _x_main_module_57,
+        _x_main_module_56,
+        _x_main_module_55,
+        _x_main_module_54);
+    auto _x_main_module_746 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_745);
+    auto _x_main_module_747 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_743,
+        _x_main_module_746);
+    auto _x_main_module_748 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        _x_main_module_721);
+    auto _x_main_module_749 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_748,
+        _x_main_module_53);
+    auto _x_main_module_750 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_749,
+        _x_main_module_52,
+        _x_main_module_51,
+        _x_main_module_50,
+        _x_main_module_49);
+    auto _x_main_module_751 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_750);
+    auto _x_main_module_752 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_724,
+        _x_main_module_734,
+        _x_main_module_747,
+        _x_main_module_751);
+    auto _x_main_module_753 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_752,
+        _x_main_module_48);
+    auto _x_main_module_754 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_753,
+        _x_main_module_47,
+        _x_main_module_46,
+        _x_main_module_45,
+        _x_main_module_44);
+    auto _x_main_module_755 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_754);
+    auto _x_main_module_756 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_752,
+        _x_main_module_43);
+    auto _x_main_module_757 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_756,
+        _x_main_module_42,
+        _x_main_module_41,
+        _x_main_module_40,
+        _x_main_module_39);
+    auto _x_main_module_758 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_757);
+    auto _x_main_module_759 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_758,
+        _x_main_module_38);
+    auto _x_main_module_760 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_759,
+        _x_main_module_37,
+        _x_main_module_36,
+        _x_main_module_35,
+        _x_main_module_34);
+    auto _x_main_module_761 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_760);
+    auto _x_main_module_762 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_758,
+        _x_main_module_33);
+    auto _x_main_module_763 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_762,
+        _x_main_module_32,
+        _x_main_module_31,
+        _x_main_module_30,
+        _x_main_module_29);
+    auto _x_main_module_764 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_763);
+    auto _x_main_module_765 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_761,
+        _x_main_module_764);
+    auto _x_main_module_766 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_752,
+        _x_main_module_28);
+    auto _x_main_module_767 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_766,
+        _x_main_module_27,
+        _x_main_module_26,
+        _x_main_module_25,
+        _x_main_module_24);
+    auto _x_main_module_768 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_767);
+    auto _x_main_module_769 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_768,
+        _x_main_module_23);
+    auto _x_main_module_770 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_769,
+        _x_main_module_22,
+        _x_main_module_21,
+        _x_main_module_20,
+        _x_main_module_19);
+    auto _x_main_module_771 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_770);
+    auto _x_main_module_772 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_771,
+        _x_main_module_18);
+    auto _x_main_module_773 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_772,
+        _x_main_module_17,
+        _x_main_module_16,
+        _x_main_module_15,
+        _x_main_module_14);
+    auto _x_main_module_774 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_773);
+    auto _x_main_module_775 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_771,
+        _x_main_module_13);
+    auto _x_main_module_776 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_775,
+        _x_main_module_12,
+        _x_main_module_11,
+        _x_main_module_10,
+        _x_main_module_9);
+    auto _x_main_module_777 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_776);
+    auto _x_main_module_778 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_774,
+        _x_main_module_777);
+    auto _x_main_module_779 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        _x_main_module_752);
+    auto _x_main_module_780 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_779,
+        _x_main_module_8);
+    auto _x_main_module_781 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_780,
+        _x_main_module_7,
+        _x_main_module_6,
+        _x_main_module_5,
+        _x_main_module_4);
+    auto _x_main_module_782 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_781);
+    auto _x_main_module_783 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_755,
+        _x_main_module_765,
+        _x_main_module_778,
+        _x_main_module_782);
+    auto _x_main_module_784 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[8,8],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[0,0,0,0],\"stride\":[8,8]}")),
+        _x_main_module_783);
+    auto _x_main_module_785 =
+        mmain->add_instruction(migraphx::make_op("identity"), _x_main_module_784);
+    auto _x_main_module_786 = mmain->add_instruction(
+        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_785);
+    auto _x_main_module_787 = mmain->add_instruction(
+        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
+        _x_main_module_3);
+    auto _x_main_module_788 =
+        mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_786, _x_main_module_787);
+    auto _x_main_module_789 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        _x_main_module_2);
+    auto _x_main_module_790 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        _x_main_module_0);
+    auto _x_main_module_791 =
+        mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_789, _x_main_module_790);
+    auto _x_main_module_792 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_788, _x_main_module_791);
+    mmain->add_return({_x_main_module_792});
 
     return p;
 }

--- a/src/driver/inceptionv3.cpp
+++ b/src/driver/inceptionv3.cpp
@@ -33,2832 +33,802 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program inceptionv3(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-    migraphx::module_ref mmain = p.get_main_module();
-    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-    auto x_0                   = mmain->add_parameter(
-        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 299, 299}});
-    auto x_main_module_2 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
-    auto x_main_module_3 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
-    auto x_main_module_4 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 3)));
-    auto x_main_module_5 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 4));
-    auto x_main_module_6 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 5));
-    auto x_main_module_7  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 6)));
-    auto x_main_module_8  = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 2048, 1, 1}}, 7));
-    auto x_main_module_9  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 8)));
-    auto x_main_module_10 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 9));
-    auto x_main_module_11 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 10));
-    auto x_main_module_12 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 11)));
-    auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 12));
-    auto x_main_module_14 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13)));
-    auto x_main_module_15 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 14));
-    auto x_main_module_16 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 15));
-    auto x_main_module_17 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 16)));
-    auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 17));
-    auto x_main_module_19 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 18)));
-    auto x_main_module_20 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 19));
-    auto x_main_module_21 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 20));
-    auto x_main_module_22 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 21)));
-    auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 22));
-    auto x_main_module_24 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 23)));
-    auto x_main_module_25 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 24));
-    auto x_main_module_26 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 25));
-    auto x_main_module_27 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 26)));
-    auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {448, 2048, 1, 1}}, 27));
-    auto x_main_module_29 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 28)));
-    auto x_main_module_30 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 29)));
-    auto x_main_module_31 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 30));
-    auto x_main_module_32 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 31)));
-    auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 32));
-    auto x_main_module_34 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 33)));
-    auto x_main_module_35 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 34)));
-    auto x_main_module_36 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 35));
-    auto x_main_module_37 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 36)));
-    auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 37));
-    auto x_main_module_39 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 38)));
-    auto x_main_module_40 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 39));
-    auto x_main_module_41 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 40));
-    auto x_main_module_42 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 41)));
-    auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 2048, 1, 1}}, 42));
-    auto x_main_module_44 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 43)));
-    auto x_main_module_45 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 44));
-    auto x_main_module_46 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 45));
-    auto x_main_module_47 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 46)));
-    auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {320, 2048, 1, 1}}, 47));
-    auto x_main_module_49 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 48)));
-    auto x_main_module_50 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 49));
-    auto x_main_module_51 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 50));
-    auto x_main_module_52 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 51)));
-    auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 1280, 1, 1}}, 52));
-    auto x_main_module_54 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 53)));
-    auto x_main_module_55 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 54));
-    auto x_main_module_56 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 55));
-    auto x_main_module_57 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 56)));
-    auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 57));
-    auto x_main_module_59 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 58)));
-    auto x_main_module_60 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 59));
-    auto x_main_module_61 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 60));
-    auto x_main_module_62 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 61)));
-    auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 62));
-    auto x_main_module_64 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 63)));
-    auto x_main_module_65 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 64));
-    auto x_main_module_66 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 65));
-    auto x_main_module_67 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 66)));
-    auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 67));
-    auto x_main_module_69 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 68)));
-    auto x_main_module_70 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 69));
-    auto x_main_module_71 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 70));
-    auto x_main_module_72 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 71)));
-    auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {448, 1280, 1, 1}}, 72));
-    auto x_main_module_74 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 73)));
-    auto x_main_module_75 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 74));
-    auto x_main_module_76 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 75));
-    auto x_main_module_77 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 76)));
-    auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 77));
-    auto x_main_module_79 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 78)));
-    auto x_main_module_80 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 79));
-    auto x_main_module_81 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 80));
-    auto x_main_module_82 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 81)));
-    auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 82));
-    auto x_main_module_84 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 83)));
-    auto x_main_module_85 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 84));
-    auto x_main_module_86 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 85));
-    auto x_main_module_87 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 86)));
-    auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 1280, 1, 1}}, 87));
-    auto x_main_module_89 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 88)));
-    auto x_main_module_90 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 89));
-    auto x_main_module_91 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 90));
-    auto x_main_module_92 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 91)));
-    auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {320, 1280, 1, 1}}, 92));
-    auto x_main_module_94 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 93)));
-    auto x_main_module_95 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 94));
-    auto x_main_module_96 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 95));
-    auto x_main_module_97  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 96)));
-    auto x_main_module_98  = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 3, 3}}, 97));
-    auto x_main_module_99  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 98)));
-    auto x_main_module_100 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 99));
-    auto x_main_module_101 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 100));
-    auto x_main_module_102 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 101)));
-    auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 102));
-    auto x_main_module_104 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 103)));
-    auto x_main_module_105 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 104));
-    auto x_main_module_106 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 105));
-    auto x_main_module_107 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 106)));
-    auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 107));
-    auto x_main_module_109 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 108)));
-    auto x_main_module_110 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 109));
-    auto x_main_module_111 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 110));
-    auto x_main_module_112 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 111)));
-    auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 112));
-    auto x_main_module_114 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 113)));
-    auto x_main_module_115 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 114));
-    auto x_main_module_116 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 115));
-    auto x_main_module_117 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 116)));
-    auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {320, 192, 3, 3}}, 117));
-    auto x_main_module_119 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 118)));
-    auto x_main_module_120 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 119));
-    auto x_main_module_121 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 120));
-    auto x_main_module_122 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 121)));
-    auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 122));
-    auto x_main_module_124 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 123)));
-    auto x_main_module_125 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 124));
-    auto x_main_module_126 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 125));
-    auto x_main_module_127 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 126)));
-    auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 127));
-    auto x_main_module_129 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 128)));
-    auto x_main_module_130 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 129));
-    auto x_main_module_131 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 130));
-    auto x_main_module_132 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 131)));
-    auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 132));
-    auto x_main_module_134 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 133)));
-    auto x_main_module_135 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 134));
-    auto x_main_module_136 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 135));
-    auto x_main_module_137 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 136)));
-    auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 137));
-    auto x_main_module_139 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 138)));
-    auto x_main_module_140 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 139));
-    auto x_main_module_141 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 140));
-    auto x_main_module_142 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 141)));
-    auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 142));
-    auto x_main_module_144 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 143)));
-    auto x_main_module_145 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 144));
-    auto x_main_module_146 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 145));
-    auto x_main_module_147 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 146)));
-    auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 147));
-    auto x_main_module_149 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 148)));
-    auto x_main_module_150 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 149));
-    auto x_main_module_151 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 150));
-    auto x_main_module_152 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 151)));
-    auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 152));
-    auto x_main_module_154 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 153)));
-    auto x_main_module_155 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 154));
-    auto x_main_module_156 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 155));
-    auto x_main_module_157 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 156)));
-    auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 157));
-    auto x_main_module_159 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 158)));
-    auto x_main_module_160 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 159));
-    auto x_main_module_161 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 160));
-    auto x_main_module_162 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 161)));
-    auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 162));
-    auto x_main_module_164 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 163)));
-    auto x_main_module_165 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 164));
-    auto x_main_module_166 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 165));
-    auto x_main_module_167 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 166)));
-    auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 167));
-    auto x_main_module_169 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 168)));
-    auto x_main_module_170 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 169));
-    auto x_main_module_171 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 170));
-    auto x_main_module_172 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 171)));
-    auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 172));
-    auto x_main_module_174 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 173)));
-    auto x_main_module_175 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 174));
-    auto x_main_module_176 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 175));
-    auto x_main_module_177 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 176)));
-    auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 177));
-    auto x_main_module_179 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 178)));
-    auto x_main_module_180 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 179));
-    auto x_main_module_181 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 180));
-    auto x_main_module_182 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 181)));
-    auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 182));
-    auto x_main_module_184 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 183)));
-    auto x_main_module_185 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 184));
-    auto x_main_module_186 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 185));
-    auto x_main_module_187 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 186)));
-    auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 187));
-    auto x_main_module_189 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 188)));
-    auto x_main_module_190 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 189));
-    auto x_main_module_191 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 190));
-    auto x_main_module_192 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 191)));
-    auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 192));
-    auto x_main_module_194 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 193)));
-    auto x_main_module_195 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 194));
-    auto x_main_module_196 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 195));
-    auto x_main_module_197 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 196)));
-    auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 197));
-    auto x_main_module_199 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 198)));
-    auto x_main_module_200 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 199));
-    auto x_main_module_201 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 200));
-    auto x_main_module_202 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 201)));
-    auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 202));
-    auto x_main_module_204 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 203)));
-    auto x_main_module_205 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 204));
-    auto x_main_module_206 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 205));
-    auto x_main_module_207 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 206)));
-    auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 207));
-    auto x_main_module_209 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 208)));
-    auto x_main_module_210 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 209));
-    auto x_main_module_211 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 210));
-    auto x_main_module_212 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 211)));
-    auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 212));
-    auto x_main_module_214 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 213)));
-    auto x_main_module_215 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 214));
-    auto x_main_module_216 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 215));
-    auto x_main_module_217 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 216)));
-    auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 217));
-    auto x_main_module_219 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 218)));
-    auto x_main_module_220 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 219));
-    auto x_main_module_221 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 220));
-    auto x_main_module_222 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 221)));
-    auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 222));
-    auto x_main_module_224 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 223)));
-    auto x_main_module_225 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 224));
-    auto x_main_module_226 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 225));
-    auto x_main_module_227 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 226)));
-    auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 227));
-    auto x_main_module_229 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 228)));
-    auto x_main_module_230 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 229));
-    auto x_main_module_231 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 230));
-    auto x_main_module_232 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 231)));
-    auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 232));
-    auto x_main_module_234 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 233)));
-    auto x_main_module_235 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 234));
-    auto x_main_module_236 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 235));
-    auto x_main_module_237 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 236)));
-    auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 237));
-    auto x_main_module_239 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 238)));
-    auto x_main_module_240 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 239));
-    auto x_main_module_241 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 240));
-    auto x_main_module_242 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 241)));
-    auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 242));
-    auto x_main_module_244 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 243)));
-    auto x_main_module_245 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 244));
-    auto x_main_module_246 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 245));
-    auto x_main_module_247 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 246)));
-    auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 247));
-    auto x_main_module_249 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 248)));
-    auto x_main_module_250 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 249));
-    auto x_main_module_251 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 250));
-    auto x_main_module_252 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 251)));
-    auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 252));
-    auto x_main_module_254 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 253)));
-    auto x_main_module_255 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 254));
-    auto x_main_module_256 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 255));
-    auto x_main_module_257 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 256)));
-    auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 257));
-    auto x_main_module_259 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 258)));
-    auto x_main_module_260 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 259));
-    auto x_main_module_261 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 260));
-    auto x_main_module_262 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 261)));
-    auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 262));
-    auto x_main_module_264 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 263)));
-    auto x_main_module_265 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 264));
-    auto x_main_module_266 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 265));
-    auto x_main_module_267 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 266)));
-    auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 267));
-    auto x_main_module_269 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 268)));
-    auto x_main_module_270 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 269));
-    auto x_main_module_271 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 270));
-    auto x_main_module_272 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 271)));
-    auto x_main_module_273 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 272));
-    auto x_main_module_274 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 273)));
-    auto x_main_module_275 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 274));
-    auto x_main_module_276 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 275));
-    auto x_main_module_277 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 276)));
-    auto x_main_module_278 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 277));
-    auto x_main_module_279 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 278)));
-    auto x_main_module_280 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 279));
-    auto x_main_module_281 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 280));
-    auto x_main_module_282 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 281)));
-    auto x_main_module_283 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 128, 1, 7}}, 282));
-    auto x_main_module_284 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 283)));
-    auto x_main_module_285 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 284));
-    auto x_main_module_286 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 285));
-    auto x_main_module_287 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 286)));
-    auto x_main_module_288 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 287));
-    auto x_main_module_289 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 288)));
-    auto x_main_module_290 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 289));
-    auto x_main_module_291 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 290));
-    auto x_main_module_292 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 291)));
-    auto x_main_module_293 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 292));
-    auto x_main_module_294 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 293)));
-    auto x_main_module_295 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 294));
-    auto x_main_module_296 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 295));
-    auto x_main_module_297 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 296)));
-    auto x_main_module_298 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 297));
-    auto x_main_module_299 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 298)));
-    auto x_main_module_300 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 299));
-    auto x_main_module_301 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 300));
-    auto x_main_module_302 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 301)));
-    auto x_main_module_303 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 302));
-    auto x_main_module_304 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 303)));
-    auto x_main_module_305 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 304));
-    auto x_main_module_306 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 305));
-    auto x_main_module_307 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 306)));
-    auto x_main_module_308 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 128, 7, 1}}, 307));
-    auto x_main_module_309 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 308)));
-    auto x_main_module_310 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 309));
-    auto x_main_module_311 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 310));
-    auto x_main_module_312 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 311)));
-    auto x_main_module_313 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 312));
-    auto x_main_module_314 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 313)));
-    auto x_main_module_315 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 314));
-    auto x_main_module_316 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 315));
-    auto x_main_module_317 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 316)));
-    auto x_main_module_318 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 317));
-    auto x_main_module_319 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 318)));
-    auto x_main_module_320 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 319));
-    auto x_main_module_321 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 320));
-    auto x_main_module_322 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 321)));
-    auto x_main_module_323 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 322));
-    auto x_main_module_324 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 323)));
-    auto x_main_module_325 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 324));
-    auto x_main_module_326 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 325));
-    auto x_main_module_327 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 326)));
-    auto x_main_module_328 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 327));
-    auto x_main_module_329 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 328)));
-    auto x_main_module_330 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 329));
-    auto x_main_module_331 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 330));
-    auto x_main_module_332 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 331)));
-    auto x_main_module_333 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 332));
-    auto x_main_module_334 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 333)));
-    auto x_main_module_335 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 334));
-    auto x_main_module_336 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 335));
-    auto x_main_module_337 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 336)));
-    auto x_main_module_338 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 337));
-    auto x_main_module_339 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 338)));
-    auto x_main_module_340 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 339));
-    auto x_main_module_341 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 340));
-    auto x_main_module_342 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 341)));
-    auto x_main_module_343 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 288, 3, 3}}, 342));
-    auto x_main_module_344 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 343)));
-    auto x_main_module_345 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 344));
-    auto x_main_module_346 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 345));
-    auto x_main_module_347 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 346)));
-    auto x_main_module_348 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 347));
-    auto x_main_module_349 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 348)));
-    auto x_main_module_350 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 349));
-    auto x_main_module_351 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 350));
-    auto x_main_module_352 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 351)));
-    auto x_main_module_353 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 352));
-    auto x_main_module_354 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 353)));
-    auto x_main_module_355 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 354));
-    auto x_main_module_356 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 355));
-    auto x_main_module_357 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 356)));
-    auto x_main_module_358 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 357));
-    auto x_main_module_359 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 358)));
-    auto x_main_module_360 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 359));
-    auto x_main_module_361 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 360));
-    auto x_main_module_362 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 361)));
-    auto x_main_module_363 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 362));
-    auto x_main_module_364 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 363)));
-    auto x_main_module_365 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 364));
-    auto x_main_module_366 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 365));
-    auto x_main_module_367 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 366)));
-    auto x_main_module_368 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 367));
-    auto x_main_module_369 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 368)));
-    auto x_main_module_370 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 369));
-    auto x_main_module_371 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 370));
-    auto x_main_module_372 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 371)));
-    auto x_main_module_373 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {48, 288, 1, 1}}, 372));
-    auto x_main_module_374 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 373)));
-    auto x_main_module_375 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 374));
-    auto x_main_module_376 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 375));
-    auto x_main_module_377 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 376)));
-    auto x_main_module_378 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 377));
-    auto x_main_module_379 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 378)));
-    auto x_main_module_380 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 379));
-    auto x_main_module_381 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 380));
-    auto x_main_module_382 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 381)));
-    auto x_main_module_383 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 382));
-    auto x_main_module_384 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 383)));
-    auto x_main_module_385 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 384));
-    auto x_main_module_386 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 385));
-    auto x_main_module_387 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 386)));
-    auto x_main_module_388 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 387));
-    auto x_main_module_389 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 388)));
-    auto x_main_module_390 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 389));
-    auto x_main_module_391 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 390));
-    auto x_main_module_392 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 391)));
-    auto x_main_module_393 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 392));
-    auto x_main_module_394 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 393)));
-    auto x_main_module_395 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 394));
-    auto x_main_module_396 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 395));
-    auto x_main_module_397 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 396)));
-    auto x_main_module_398 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 397));
-    auto x_main_module_399 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 398)));
-    auto x_main_module_400 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 399));
-    auto x_main_module_401 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 400));
-    auto x_main_module_402 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 401)));
-    auto x_main_module_403 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 402));
-    auto x_main_module_404 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 403)));
-    auto x_main_module_405 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 404));
-    auto x_main_module_406 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 405));
-    auto x_main_module_407 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 406)));
-    auto x_main_module_408 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {48, 256, 1, 1}}, 407));
-    auto x_main_module_409 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 408)));
-    auto x_main_module_410 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 409));
-    auto x_main_module_411 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 410));
-    auto x_main_module_412 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 411)));
-    auto x_main_module_413 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 412));
-    auto x_main_module_414 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 413)));
-    auto x_main_module_415 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 414));
-    auto x_main_module_416 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 415));
-    auto x_main_module_417 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 416)));
-    auto x_main_module_418 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {32, 192, 1, 1}}, 417));
-    auto x_main_module_419 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 418)));
-    auto x_main_module_420 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 419));
-    auto x_main_module_421 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 420));
-    auto x_main_module_422 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 421)));
-    auto x_main_module_423 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 422));
-    auto x_main_module_424 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 423)));
-    auto x_main_module_425 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 424));
-    auto x_main_module_426 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 425));
-    auto x_main_module_427 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 426)));
-    auto x_main_module_428 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 427));
-    auto x_main_module_429 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 428)));
-    auto x_main_module_430 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 429));
-    auto x_main_module_431 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 430));
-    auto x_main_module_432 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 431)));
-    auto x_main_module_433 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 432));
-    auto x_main_module_434 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 433)));
-    auto x_main_module_435 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 434));
-    auto x_main_module_436 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 435));
-    auto x_main_module_437 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 436)));
-    auto x_main_module_438 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 437));
-    auto x_main_module_439 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 438)));
-    auto x_main_module_440 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 439));
-    auto x_main_module_441 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 440));
-    auto x_main_module_442 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 441)));
-    auto x_main_module_443 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {48, 192, 1, 1}}, 442));
-    auto x_main_module_444 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 443)));
-    auto x_main_module_445 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 444));
-    auto x_main_module_446 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 445));
-    auto x_main_module_447 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 446)));
-    auto x_main_module_448 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 447));
-    auto x_main_module_449 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 448)));
-    auto x_main_module_450 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 449));
-    auto x_main_module_451 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 450));
-    auto x_main_module_452 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 451)));
-    auto x_main_module_453 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 80, 3, 3}}, 452));
-    auto x_main_module_454 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 453)));
-    auto x_main_module_455 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 454));
-    auto x_main_module_456 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 455));
-    auto x_main_module_457 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 456)));
-    auto x_main_module_458 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {80, 64, 1, 1}}, 457));
-    auto x_main_module_459 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 458)));
-    auto x_main_module_460 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 459));
-    auto x_main_module_461 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 460));
-    auto x_main_module_462 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 461)));
-    auto x_main_module_463 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 32, 3, 3}}, 462));
-    auto x_main_module_464 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 463)));
-    auto x_main_module_465 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 464));
-    auto x_main_module_466 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 465));
-    auto x_main_module_467 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 466)));
-    auto x_main_module_468 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {32, 32, 3, 3}}, 467));
-    auto x_main_module_469 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 468)));
-    auto x_main_module_470 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 469));
-    auto x_main_module_471 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 470));
-    auto x_main_module_472 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 471)));
-    auto x_main_module_473 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {32, 3, 3, 3}}, 472));
-    auto x_main_module_474 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_0,
-        x_main_module_473);
-    auto x_main_module_475 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_474,
-        x_main_module_472,
-        x_main_module_471,
-        x_main_module_470,
-        x_main_module_469);
-    auto x_main_module_476 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_475);
-    auto x_main_module_477 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_476,
-        x_main_module_468);
-    auto x_main_module_478 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_477,
-        x_main_module_467,
-        x_main_module_466,
-        x_main_module_465,
-        x_main_module_464);
-    auto x_main_module_479 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_478);
-    auto x_main_module_480 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_479,
-        x_main_module_463);
-    auto x_main_module_481 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_480,
-        x_main_module_462,
-        x_main_module_461,
-        x_main_module_460,
-        x_main_module_459);
-    auto x_main_module_482 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_481);
-    auto x_main_module_483 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        x_main_module_482);
-    auto x_main_module_484 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_483,
-        x_main_module_458);
-    auto x_main_module_485 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_484,
-        x_main_module_457,
-        x_main_module_456,
-        x_main_module_455,
-        x_main_module_454);
-    auto x_main_module_486 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_485);
-    auto x_main_module_487 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_486,
-        x_main_module_453);
-    auto x_main_module_488 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_487,
-        x_main_module_452,
-        x_main_module_451,
-        x_main_module_450,
-        x_main_module_449);
-    auto x_main_module_489 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_488);
-    auto x_main_module_490 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        x_main_module_489);
-    auto x_main_module_491 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_490,
-        x_main_module_448);
-    auto x_main_module_492 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_491,
-        x_main_module_447,
-        x_main_module_446,
-        x_main_module_445,
-        x_main_module_444);
-    auto x_main_module_493 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_492);
-    auto x_main_module_494 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_490,
-        x_main_module_443);
-    auto x_main_module_495 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_494,
-        x_main_module_442,
-        x_main_module_441,
-        x_main_module_440,
-        x_main_module_439);
-    auto x_main_module_496 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_495);
-    auto x_main_module_497 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_496,
-        x_main_module_438);
-    auto x_main_module_498 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_497,
-        x_main_module_437,
-        x_main_module_436,
-        x_main_module_435,
-        x_main_module_434);
-    auto x_main_module_499 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_498);
-    auto x_main_module_500 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_490,
-        x_main_module_433);
-    auto x_main_module_501 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_500,
-        x_main_module_432,
-        x_main_module_431,
-        x_main_module_430,
-        x_main_module_429);
-    auto x_main_module_502 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_501);
-    auto x_main_module_503 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_502,
-        x_main_module_428);
-    auto x_main_module_504 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_503,
-        x_main_module_427,
-        x_main_module_426,
-        x_main_module_425,
-        x_main_module_424);
-    auto x_main_module_505 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_504);
-    auto x_main_module_506 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_505,
-        x_main_module_423);
-    auto x_main_module_507 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_506,
-        x_main_module_422,
-        x_main_module_421,
-        x_main_module_420,
-        x_main_module_419);
-    auto x_main_module_508 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_507);
-    auto x_main_module_509 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_490);
-    auto x_main_module_510 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_509,
-        x_main_module_418);
-    auto x_main_module_511 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_510,
-        x_main_module_417,
-        x_main_module_416,
-        x_main_module_415,
-        x_main_module_414);
-    auto x_main_module_512 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_511);
-    auto x_main_module_513 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_493,
-        x_main_module_499,
-        x_main_module_508,
-        x_main_module_512);
-    auto x_main_module_514 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_513,
-        x_main_module_413);
-    auto x_main_module_515 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_514,
-        x_main_module_412,
-        x_main_module_411,
-        x_main_module_410,
-        x_main_module_409);
-    auto x_main_module_516 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_515);
-    auto x_main_module_517 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_513,
-        x_main_module_408);
-    auto x_main_module_518 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_517,
-        x_main_module_407,
-        x_main_module_406,
-        x_main_module_405,
-        x_main_module_404);
-    auto x_main_module_519 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_518);
-    auto x_main_module_520 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_519,
-        x_main_module_403);
-    auto x_main_module_521 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_520,
-        x_main_module_402,
-        x_main_module_401,
-        x_main_module_400,
-        x_main_module_399);
-    auto x_main_module_522 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_521);
-    auto x_main_module_523 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_513,
-        x_main_module_398);
-    auto x_main_module_524 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_523,
-        x_main_module_397,
-        x_main_module_396,
-        x_main_module_395,
-        x_main_module_394);
-    auto x_main_module_525 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_524);
-    auto x_main_module_526 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_525,
-        x_main_module_393);
-    auto x_main_module_527 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_526,
-        x_main_module_392,
-        x_main_module_391,
-        x_main_module_390,
-        x_main_module_389);
-    auto x_main_module_528 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_527);
-    auto x_main_module_529 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_528,
-        x_main_module_388);
-    auto x_main_module_530 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_529,
-        x_main_module_387,
-        x_main_module_386,
-        x_main_module_385,
-        x_main_module_384);
-    auto x_main_module_531 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_530);
-    auto x_main_module_532 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_513);
-    auto x_main_module_533 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_532,
-        x_main_module_383);
-    auto x_main_module_534 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_533,
-        x_main_module_382,
-        x_main_module_381,
-        x_main_module_380,
-        x_main_module_379);
-    auto x_main_module_535 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_534);
-    auto x_main_module_536 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_516,
-        x_main_module_522,
-        x_main_module_531,
-        x_main_module_535);
-    auto x_main_module_537 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_536,
-        x_main_module_378);
-    auto x_main_module_538 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_537,
-        x_main_module_377,
-        x_main_module_376,
-        x_main_module_375,
-        x_main_module_374);
-    auto x_main_module_539 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_538);
-    auto x_main_module_540 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_536,
-        x_main_module_373);
-    auto x_main_module_541 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_540,
-        x_main_module_372,
-        x_main_module_371,
-        x_main_module_370,
-        x_main_module_369);
-    auto x_main_module_542 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_541);
-    auto x_main_module_543 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_542,
-        x_main_module_368);
-    auto x_main_module_544 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_543,
-        x_main_module_367,
-        x_main_module_366,
-        x_main_module_365,
-        x_main_module_364);
-    auto x_main_module_545 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_544);
-    auto x_main_module_546 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_536,
-        x_main_module_363);
-    auto x_main_module_547 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_546,
-        x_main_module_362,
-        x_main_module_361,
-        x_main_module_360,
-        x_main_module_359);
-    auto x_main_module_548 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_547);
-    auto x_main_module_549 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_548,
-        x_main_module_358);
-    auto x_main_module_550 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_549,
-        x_main_module_357,
-        x_main_module_356,
-        x_main_module_355,
-        x_main_module_354);
-    auto x_main_module_551 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_550);
-    auto x_main_module_552 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_551,
-        x_main_module_353);
-    auto x_main_module_553 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_552,
-        x_main_module_352,
-        x_main_module_351,
-        x_main_module_350,
-        x_main_module_349);
-    auto x_main_module_554 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_553);
-    auto x_main_module_555 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_536);
-    auto x_main_module_556 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_555,
-        x_main_module_348);
-    auto x_main_module_557 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_556,
-        x_main_module_347,
-        x_main_module_346,
-        x_main_module_345,
-        x_main_module_344);
-    auto x_main_module_558 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_557);
-    auto x_main_module_559 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_539,
-        x_main_module_545,
-        x_main_module_554,
-        x_main_module_558);
-    auto x_main_module_560 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_559,
-        x_main_module_343);
-    auto x_main_module_561 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_560,
-        x_main_module_342,
-        x_main_module_341,
-        x_main_module_340,
-        x_main_module_339);
-    auto x_main_module_562 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_561);
-    auto x_main_module_563 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_559,
-        x_main_module_338);
-    auto x_main_module_564 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_563,
-        x_main_module_337,
-        x_main_module_336,
-        x_main_module_335,
-        x_main_module_334);
-    auto x_main_module_565 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_564);
-    auto x_main_module_566 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_565,
-        x_main_module_333);
-    auto x_main_module_567 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_566,
-        x_main_module_332,
-        x_main_module_331,
-        x_main_module_330,
-        x_main_module_329);
-    auto x_main_module_568 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_567);
-    auto x_main_module_569 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_568,
-        x_main_module_328);
-    auto x_main_module_570 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_569,
-        x_main_module_327,
-        x_main_module_326,
-        x_main_module_325,
-        x_main_module_324);
-    auto x_main_module_571 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_570);
-    auto x_main_module_572 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        x_main_module_559);
-    auto x_main_module_573 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_562,
-        x_main_module_571,
-        x_main_module_572);
-    auto x_main_module_574 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_573,
-        x_main_module_323);
-    auto x_main_module_575 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_574,
-        x_main_module_322,
-        x_main_module_321,
-        x_main_module_320,
-        x_main_module_319);
-    auto x_main_module_576 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_575);
-    auto x_main_module_577 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_573,
-        x_main_module_318);
-    auto x_main_module_578 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_577,
-        x_main_module_317,
-        x_main_module_316,
-        x_main_module_315,
-        x_main_module_314);
-    auto x_main_module_579 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_578);
-    auto x_main_module_580 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_579,
-        x_main_module_313);
-    auto x_main_module_581 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_580,
-        x_main_module_312,
-        x_main_module_311,
-        x_main_module_310,
-        x_main_module_309);
-    auto x_main_module_582 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_581);
-    auto x_main_module_583 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_582,
-        x_main_module_308);
-    auto x_main_module_584 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_583,
-        x_main_module_307,
-        x_main_module_306,
-        x_main_module_305,
-        x_main_module_304);
-    auto x_main_module_585 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_584);
-    auto x_main_module_586 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_573,
-        x_main_module_303);
-    auto x_main_module_587 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_586,
-        x_main_module_302,
-        x_main_module_301,
-        x_main_module_300,
-        x_main_module_299);
-    auto x_main_module_588 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_587);
-    auto x_main_module_589 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_588,
-        x_main_module_298);
-    auto x_main_module_590 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_589,
-        x_main_module_297,
-        x_main_module_296,
-        x_main_module_295,
-        x_main_module_294);
-    auto x_main_module_591 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_590);
-    auto x_main_module_592 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_591,
-        x_main_module_293);
-    auto x_main_module_593 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_592,
-        x_main_module_292,
-        x_main_module_291,
-        x_main_module_290,
-        x_main_module_289);
-    auto x_main_module_594 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_593);
-    auto x_main_module_595 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_594,
-        x_main_module_288);
-    auto x_main_module_596 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_595,
-        x_main_module_287,
-        x_main_module_286,
-        x_main_module_285,
-        x_main_module_284);
-    auto x_main_module_597 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_596);
-    auto x_main_module_598 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_597,
-        x_main_module_283);
-    auto x_main_module_599 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_598,
-        x_main_module_282,
-        x_main_module_281,
-        x_main_module_280,
-        x_main_module_279);
-    auto x_main_module_600 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_599);
-    auto x_main_module_601 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_573);
-    auto x_main_module_602 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_601,
-        x_main_module_278);
-    auto x_main_module_603 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_602,
-        x_main_module_277,
-        x_main_module_276,
-        x_main_module_275,
-        x_main_module_274);
-    auto x_main_module_604 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_603);
-    auto x_main_module_605 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_576,
-        x_main_module_585,
-        x_main_module_600,
-        x_main_module_604);
-    auto x_main_module_606 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_605,
-        x_main_module_273);
-    auto x_main_module_607 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_606,
-        x_main_module_272,
-        x_main_module_271,
-        x_main_module_270,
-        x_main_module_269);
-    auto x_main_module_608 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_607);
-    auto x_main_module_609 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_605,
-        x_main_module_268);
-    auto x_main_module_610 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_609,
-        x_main_module_267,
-        x_main_module_266,
-        x_main_module_265,
-        x_main_module_264);
-    auto x_main_module_611 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_610);
-    auto x_main_module_612 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_611,
-        x_main_module_263);
-    auto x_main_module_613 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_612,
-        x_main_module_262,
-        x_main_module_261,
-        x_main_module_260,
-        x_main_module_259);
-    auto x_main_module_614 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_613);
-    auto x_main_module_615 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_614,
-        x_main_module_258);
-    auto x_main_module_616 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_615,
-        x_main_module_257,
-        x_main_module_256,
-        x_main_module_255,
-        x_main_module_254);
-    auto x_main_module_617 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_616);
-    auto x_main_module_618 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_605,
-        x_main_module_253);
-    auto x_main_module_619 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_618,
-        x_main_module_252,
-        x_main_module_251,
-        x_main_module_250,
-        x_main_module_249);
-    auto x_main_module_620 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_619);
-    auto x_main_module_621 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_620,
-        x_main_module_248);
-    auto x_main_module_622 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_621,
-        x_main_module_247,
-        x_main_module_246,
-        x_main_module_245,
-        x_main_module_244);
-    auto x_main_module_623 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_622);
-    auto x_main_module_624 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_623,
-        x_main_module_243);
-    auto x_main_module_625 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_624,
-        x_main_module_242,
-        x_main_module_241,
-        x_main_module_240,
-        x_main_module_239);
-    auto x_main_module_626 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_625);
-    auto x_main_module_627 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_626,
-        x_main_module_238);
-    auto x_main_module_628 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_627,
-        x_main_module_237,
-        x_main_module_236,
-        x_main_module_235,
-        x_main_module_234);
-    auto x_main_module_629 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_628);
-    auto x_main_module_630 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_629,
-        x_main_module_233);
-    auto x_main_module_631 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_630,
-        x_main_module_232,
-        x_main_module_231,
-        x_main_module_230,
-        x_main_module_229);
-    auto x_main_module_632 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_631);
-    auto x_main_module_633 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_605);
-    auto x_main_module_634 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_633,
-        x_main_module_228);
-    auto x_main_module_635 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_634,
-        x_main_module_227,
-        x_main_module_226,
-        x_main_module_225,
-        x_main_module_224);
-    auto x_main_module_636 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_635);
-    auto x_main_module_637 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_608,
-        x_main_module_617,
-        x_main_module_632,
-        x_main_module_636);
-    auto x_main_module_638 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_637,
-        x_main_module_223);
-    auto x_main_module_639 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_638,
-        x_main_module_222,
-        x_main_module_221,
-        x_main_module_220,
-        x_main_module_219);
-    auto x_main_module_640 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_639);
-    auto x_main_module_641 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_637,
-        x_main_module_218);
-    auto x_main_module_642 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_641,
-        x_main_module_217,
-        x_main_module_216,
-        x_main_module_215,
-        x_main_module_214);
-    auto x_main_module_643 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_642);
-    auto x_main_module_644 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_643,
-        x_main_module_213);
-    auto x_main_module_645 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_644,
-        x_main_module_212,
-        x_main_module_211,
-        x_main_module_210,
-        x_main_module_209);
-    auto x_main_module_646 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_645);
-    auto x_main_module_647 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_646,
-        x_main_module_208);
-    auto x_main_module_648 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_647,
-        x_main_module_207,
-        x_main_module_206,
-        x_main_module_205,
-        x_main_module_204);
-    auto x_main_module_649 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_648);
-    auto x_main_module_650 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_637,
-        x_main_module_203);
-    auto x_main_module_651 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_650,
-        x_main_module_202,
-        x_main_module_201,
-        x_main_module_200,
-        x_main_module_199);
-    auto x_main_module_652 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_651);
-    auto x_main_module_653 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_652,
-        x_main_module_198);
-    auto x_main_module_654 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_653,
-        x_main_module_197,
-        x_main_module_196,
-        x_main_module_195,
-        x_main_module_194);
-    auto x_main_module_655 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_654);
-    auto x_main_module_656 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_655,
-        x_main_module_193);
-    auto x_main_module_657 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_656,
-        x_main_module_192,
-        x_main_module_191,
-        x_main_module_190,
-        x_main_module_189);
-    auto x_main_module_658 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_657);
-    auto x_main_module_659 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_658,
-        x_main_module_188);
-    auto x_main_module_660 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_659,
-        x_main_module_187,
-        x_main_module_186,
-        x_main_module_185,
-        x_main_module_184);
-    auto x_main_module_661 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_660);
-    auto x_main_module_662 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_661,
-        x_main_module_183);
-    auto x_main_module_663 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_662,
-        x_main_module_182,
-        x_main_module_181,
-        x_main_module_180,
-        x_main_module_179);
-    auto x_main_module_664 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_663);
-    auto x_main_module_665 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_637);
-    auto x_main_module_666 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_665,
-        x_main_module_178);
-    auto x_main_module_667 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_666,
-        x_main_module_177,
-        x_main_module_176,
-        x_main_module_175,
-        x_main_module_174);
-    auto x_main_module_668 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_667);
-    auto x_main_module_669 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_640,
-        x_main_module_649,
-        x_main_module_664,
-        x_main_module_668);
-    auto x_main_module_670 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_669,
-        x_main_module_173);
-    auto x_main_module_671 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_670,
-        x_main_module_172,
-        x_main_module_171,
-        x_main_module_170,
-        x_main_module_169);
-    auto x_main_module_672 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_671);
-    auto x_main_module_673 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_669,
-        x_main_module_168);
-    auto x_main_module_674 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_673,
-        x_main_module_167,
-        x_main_module_166,
-        x_main_module_165,
-        x_main_module_164);
-    auto x_main_module_675 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_674);
-    auto x_main_module_676 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_675,
-        x_main_module_163);
-    auto x_main_module_677 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_676,
-        x_main_module_162,
-        x_main_module_161,
-        x_main_module_160,
-        x_main_module_159);
-    auto x_main_module_678 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_677);
-    auto x_main_module_679 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_678,
-        x_main_module_158);
-    auto x_main_module_680 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_679,
-        x_main_module_157,
-        x_main_module_156,
-        x_main_module_155,
-        x_main_module_154);
-    auto x_main_module_681 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_680);
-    auto x_main_module_682 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_669,
-        x_main_module_153);
-    auto x_main_module_683 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_682,
-        x_main_module_152,
-        x_main_module_151,
-        x_main_module_150,
-        x_main_module_149);
-    auto x_main_module_684 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_683);
-    auto x_main_module_685 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_684,
-        x_main_module_148);
-    auto x_main_module_686 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_685,
-        x_main_module_147,
-        x_main_module_146,
-        x_main_module_145,
-        x_main_module_144);
-    auto x_main_module_687 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_686);
-    auto x_main_module_688 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_687,
-        x_main_module_143);
-    auto x_main_module_689 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_688,
-        x_main_module_142,
-        x_main_module_141,
-        x_main_module_140,
-        x_main_module_139);
-    auto x_main_module_690 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_689);
-    auto x_main_module_691 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_690,
-        x_main_module_138);
-    auto x_main_module_692 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_691,
-        x_main_module_137,
-        x_main_module_136,
-        x_main_module_135,
-        x_main_module_134);
-    auto x_main_module_693 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_692);
-    auto x_main_module_694 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_693,
-        x_main_module_133);
-    auto x_main_module_695 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_694,
-        x_main_module_132,
-        x_main_module_131,
-        x_main_module_130,
-        x_main_module_129);
-    auto x_main_module_696 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_695);
-    auto x_main_module_697 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_669);
-    auto x_main_module_698 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_697,
-        x_main_module_128);
-    auto x_main_module_699 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_698,
-        x_main_module_127,
-        x_main_module_126,
-        x_main_module_125,
-        x_main_module_124);
-    auto x_main_module_700 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_699);
-    auto x_main_module_701 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_672,
-        x_main_module_681,
-        x_main_module_696,
-        x_main_module_700);
-    auto x_main_module_702 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_701,
-        x_main_module_123);
-    auto x_main_module_703 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_702,
-        x_main_module_122,
-        x_main_module_121,
-        x_main_module_120,
-        x_main_module_119);
-    auto x_main_module_704 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_703);
-    auto x_main_module_705 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_704,
-        x_main_module_118);
-    auto x_main_module_706 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_705,
-        x_main_module_117,
-        x_main_module_116,
-        x_main_module_115,
-        x_main_module_114);
-    auto x_main_module_707 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_706);
-    auto x_main_module_708 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_701,
-        x_main_module_113);
-    auto x_main_module_709 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_708,
-        x_main_module_112,
-        x_main_module_111,
-        x_main_module_110,
-        x_main_module_109);
-    auto x_main_module_710 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_709);
-    auto x_main_module_711 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_710,
-        x_main_module_108);
-    auto x_main_module_712 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_711,
-        x_main_module_107,
-        x_main_module_106,
-        x_main_module_105,
-        x_main_module_104);
-    auto x_main_module_713 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_712);
-    auto x_main_module_714 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_713,
-        x_main_module_103);
-    auto x_main_module_715 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_714,
-        x_main_module_102,
-        x_main_module_101,
-        x_main_module_100,
-        x_main_module_99);
-    auto x_main_module_716 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_715);
-    auto x_main_module_717 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_716,
-        x_main_module_98);
-    auto x_main_module_718 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_717,
-        x_main_module_97,
-        x_main_module_96,
-        x_main_module_95,
-        x_main_module_94);
-    auto x_main_module_719 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_718);
-    auto x_main_module_720 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        x_main_module_701);
-    auto x_main_module_721 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_707,
-        x_main_module_719,
-        x_main_module_720);
-    auto x_main_module_722 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_721,
-        x_main_module_93);
-    auto x_main_module_723 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_722,
-        x_main_module_92,
-        x_main_module_91,
-        x_main_module_90,
-        x_main_module_89);
-    auto x_main_module_724 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_723);
-    auto x_main_module_725 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_721,
-        x_main_module_88);
-    auto x_main_module_726 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_725,
-        x_main_module_87,
-        x_main_module_86,
-        x_main_module_85,
-        x_main_module_84);
-    auto x_main_module_727 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_726);
-    auto x_main_module_728 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_727,
-        x_main_module_83);
-    auto x_main_module_729 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_728,
-        x_main_module_82,
-        x_main_module_81,
-        x_main_module_80,
-        x_main_module_79);
-    auto x_main_module_730 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_729);
-    auto x_main_module_731 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_727,
-        x_main_module_78);
-    auto x_main_module_732 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_731,
-        x_main_module_77,
-        x_main_module_76,
-        x_main_module_75,
-        x_main_module_74);
-    auto x_main_module_733 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_732);
-    auto x_main_module_734 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_730,
-        x_main_module_733);
-    auto x_main_module_735 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_721,
-        x_main_module_73);
-    auto x_main_module_736 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_735,
-        x_main_module_72,
-        x_main_module_71,
-        x_main_module_70,
-        x_main_module_69);
-    auto x_main_module_737 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_736);
-    auto x_main_module_738 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_737,
-        x_main_module_68);
-    auto x_main_module_739 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_738,
-        x_main_module_67,
-        x_main_module_66,
-        x_main_module_65,
-        x_main_module_64);
-    auto x_main_module_740 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_739);
-    auto x_main_module_741 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_740,
-        x_main_module_63);
-    auto x_main_module_742 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_741,
-        x_main_module_62,
-        x_main_module_61,
-        x_main_module_60,
-        x_main_module_59);
-    auto x_main_module_743 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_742);
-    auto x_main_module_744 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_740,
-        x_main_module_58);
-    auto x_main_module_745 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_744,
-        x_main_module_57,
-        x_main_module_56,
-        x_main_module_55,
-        x_main_module_54);
-    auto x_main_module_746 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_745);
-    auto x_main_module_747 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_743,
-        x_main_module_746);
-    auto x_main_module_748 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_721);
-    auto x_main_module_749 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_748,
-        x_main_module_53);
-    auto x_main_module_750 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_749,
-        x_main_module_52,
-        x_main_module_51,
-        x_main_module_50,
-        x_main_module_49);
-    auto x_main_module_751 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_750);
-    auto x_main_module_752 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_724,
-        x_main_module_734,
-        x_main_module_747,
-        x_main_module_751);
-    auto x_main_module_753 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_752,
-        x_main_module_48);
-    auto x_main_module_754 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_753,
-        x_main_module_47,
-        x_main_module_46,
-        x_main_module_45,
-        x_main_module_44);
-    auto x_main_module_755 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_754);
-    auto x_main_module_756 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_752,
-        x_main_module_43);
-    auto x_main_module_757 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_756,
-        x_main_module_42,
-        x_main_module_41,
-        x_main_module_40,
-        x_main_module_39);
-    auto x_main_module_758 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_757);
-    auto x_main_module_759 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_758,
-        x_main_module_38);
-    auto x_main_module_760 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_759,
-        x_main_module_37,
-        x_main_module_36,
-        x_main_module_35,
-        x_main_module_34);
-    auto x_main_module_761 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_760);
-    auto x_main_module_762 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_758,
-        x_main_module_33);
-    auto x_main_module_763 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_762,
-        x_main_module_32,
-        x_main_module_31,
-        x_main_module_30,
-        x_main_module_29);
-    auto x_main_module_764 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_763);
-    auto x_main_module_765 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_761,
-        x_main_module_764);
-    auto x_main_module_766 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_752,
-        x_main_module_28);
-    auto x_main_module_767 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_766,
-        x_main_module_27,
-        x_main_module_26,
-        x_main_module_25,
-        x_main_module_24);
-    auto x_main_module_768 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_767);
-    auto x_main_module_769 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_768,
-        x_main_module_23);
-    auto x_main_module_770 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_769,
-        x_main_module_22,
-        x_main_module_21,
-        x_main_module_20,
-        x_main_module_19);
-    auto x_main_module_771 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_770);
-    auto x_main_module_772 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_771,
-        x_main_module_18);
-    auto x_main_module_773 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_772,
-        x_main_module_17,
-        x_main_module_16,
-        x_main_module_15,
-        x_main_module_14);
-    auto x_main_module_774 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_773);
-    auto x_main_module_775 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_771,
-        x_main_module_13);
-    auto x_main_module_776 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_775,
-        x_main_module_12,
-        x_main_module_11,
-        x_main_module_10,
-        x_main_module_9);
-    auto x_main_module_777 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_776);
-    auto x_main_module_778 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_774,
-        x_main_module_777);
-    auto x_main_module_779 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        x_main_module_752);
-    auto x_main_module_780 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_779,
-        x_main_module_8);
-    auto x_main_module_781 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_780,
-        x_main_module_7,
-        x_main_module_6,
-        x_main_module_5,
-        x_main_module_4);
-    auto x_main_module_782 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_781);
-    auto x_main_module_783 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_755,
-        x_main_module_765,
-        x_main_module_778,
-        x_main_module_782);
-    auto x_main_module_784 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[8,8],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[0,0,0,0],\"stride\":[8,8]}")),
-        x_main_module_783);
-    auto x_main_module_785 =
-        mmain->add_instruction(migraphx::make_op("identity"), x_main_module_784);
-    auto x_main_module_786 = mmain->add_instruction(
-        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_785);
-    auto x_main_module_787 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
-        x_main_module_3);
-    auto x_main_module_788 =
-        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_786, x_main_module_787);
-    auto x_main_module_789 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        x_main_module_2);
-    auto x_main_module_790 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        x_main_module_0);
-    auto x_main_module_791 =
-        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_789, x_main_module_790);
-    auto x_main_module_792 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_788, x_main_module_791);
-    mmain->add_return({x_main_module_792});
+migraphx::module_ref mmain = p.get_main_module();
+auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 299, 299}});
+auto x_main_module_2 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
+auto x_main_module_3 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
+auto x_main_module_4 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 3)));
+auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 4));
+auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 5));
+auto x_main_module_7 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 6)));
+auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 2048, 1, 1}}, 7));
+auto x_main_module_9 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 8)));
+auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 9));
+auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 10));
+auto x_main_module_12 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 11)));
+auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 12));
+auto x_main_module_14 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13)));
+auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 14));
+auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 15));
+auto x_main_module_17 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 16)));
+auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 17));
+auto x_main_module_19 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 18)));
+auto x_main_module_20 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 19));
+auto x_main_module_21 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 20));
+auto x_main_module_22 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 21)));
+auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 22));
+auto x_main_module_24 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 23)));
+auto x_main_module_25 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 24));
+auto x_main_module_26 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 25));
+auto x_main_module_27 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 26)));
+auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448, 2048, 1, 1}}, 27));
+auto x_main_module_29 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 28)));
+auto x_main_module_30 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 29)));
+auto x_main_module_31 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 30));
+auto x_main_module_32 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 31)));
+auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 32));
+auto x_main_module_34 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 33)));
+auto x_main_module_35 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 34)));
+auto x_main_module_36 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 35));
+auto x_main_module_37 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 36)));
+auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 37));
+auto x_main_module_39 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 38)));
+auto x_main_module_40 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 39));
+auto x_main_module_41 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 40));
+auto x_main_module_42 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 41)));
+auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 2048, 1, 1}}, 42));
+auto x_main_module_44 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 43)));
+auto x_main_module_45 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 44));
+auto x_main_module_46 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 45));
+auto x_main_module_47 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 46)));
+auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 2048, 1, 1}}, 47));
+auto x_main_module_49 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 48)));
+auto x_main_module_50 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 49));
+auto x_main_module_51 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 50));
+auto x_main_module_52 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 51)));
+auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 1280, 1, 1}}, 52));
+auto x_main_module_54 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 53)));
+auto x_main_module_55 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 54));
+auto x_main_module_56 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 55));
+auto x_main_module_57 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 56)));
+auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 57));
+auto x_main_module_59 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 58)));
+auto x_main_module_60 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 59));
+auto x_main_module_61 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 60));
+auto x_main_module_62 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 61)));
+auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 62));
+auto x_main_module_64 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 63)));
+auto x_main_module_65 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 64));
+auto x_main_module_66 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 65));
+auto x_main_module_67 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 66)));
+auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 67));
+auto x_main_module_69 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 68)));
+auto x_main_module_70 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 69));
+auto x_main_module_71 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 70));
+auto x_main_module_72 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 71)));
+auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448, 1280, 1, 1}}, 72));
+auto x_main_module_74 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 73)));
+auto x_main_module_75 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 74));
+auto x_main_module_76 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 75));
+auto x_main_module_77 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 76)));
+auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 77));
+auto x_main_module_79 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 78)));
+auto x_main_module_80 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 79));
+auto x_main_module_81 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 80));
+auto x_main_module_82 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 81)));
+auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 82));
+auto x_main_module_84 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 83)));
+auto x_main_module_85 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 84));
+auto x_main_module_86 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 85));
+auto x_main_module_87 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 86)));
+auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 1280, 1, 1}}, 87));
+auto x_main_module_89 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 88)));
+auto x_main_module_90 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 89));
+auto x_main_module_91 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 90));
+auto x_main_module_92 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 91)));
+auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 1280, 1, 1}}, 92));
+auto x_main_module_94 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 93)));
+auto x_main_module_95 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 94));
+auto x_main_module_96 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 95));
+auto x_main_module_97 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 96)));
+auto x_main_module_98 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 3, 3}}, 97));
+auto x_main_module_99 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 98)));
+auto x_main_module_100 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 99));
+auto x_main_module_101 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 100));
+auto x_main_module_102 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 101)));
+auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 102));
+auto x_main_module_104 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 103)));
+auto x_main_module_105 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 104));
+auto x_main_module_106 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 105));
+auto x_main_module_107 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 106)));
+auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 107));
+auto x_main_module_109 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 108)));
+auto x_main_module_110 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 109));
+auto x_main_module_111 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 110));
+auto x_main_module_112 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 111)));
+auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 112));
+auto x_main_module_114 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 113)));
+auto x_main_module_115 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 114));
+auto x_main_module_116 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 115));
+auto x_main_module_117 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 116)));
+auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 192, 3, 3}}, 117));
+auto x_main_module_119 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 118)));
+auto x_main_module_120 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 119));
+auto x_main_module_121 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 120));
+auto x_main_module_122 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 121)));
+auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 122));
+auto x_main_module_124 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 123)));
+auto x_main_module_125 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 124));
+auto x_main_module_126 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 125));
+auto x_main_module_127 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 126)));
+auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 127));
+auto x_main_module_129 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 128)));
+auto x_main_module_130 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 129));
+auto x_main_module_131 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 130));
+auto x_main_module_132 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 131)));
+auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 132));
+auto x_main_module_134 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 133)));
+auto x_main_module_135 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 134));
+auto x_main_module_136 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 135));
+auto x_main_module_137 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 136)));
+auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 137));
+auto x_main_module_139 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 138)));
+auto x_main_module_140 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 139));
+auto x_main_module_141 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 140));
+auto x_main_module_142 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 141)));
+auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 142));
+auto x_main_module_144 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 143)));
+auto x_main_module_145 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 144));
+auto x_main_module_146 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 145));
+auto x_main_module_147 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 146)));
+auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 147));
+auto x_main_module_149 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 148)));
+auto x_main_module_150 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 149));
+auto x_main_module_151 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 150));
+auto x_main_module_152 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 151)));
+auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 152));
+auto x_main_module_154 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 153)));
+auto x_main_module_155 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 154));
+auto x_main_module_156 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 155));
+auto x_main_module_157 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 156)));
+auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 157));
+auto x_main_module_159 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 158)));
+auto x_main_module_160 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 159));
+auto x_main_module_161 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 160));
+auto x_main_module_162 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 161)));
+auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 162));
+auto x_main_module_164 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 163)));
+auto x_main_module_165 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 164));
+auto x_main_module_166 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 165));
+auto x_main_module_167 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 166)));
+auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 167));
+auto x_main_module_169 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 168)));
+auto x_main_module_170 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 169));
+auto x_main_module_171 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 170));
+auto x_main_module_172 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 171)));
+auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 172));
+auto x_main_module_174 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 173)));
+auto x_main_module_175 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 174));
+auto x_main_module_176 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 175));
+auto x_main_module_177 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 176)));
+auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 177));
+auto x_main_module_179 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 178)));
+auto x_main_module_180 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 179));
+auto x_main_module_181 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 180));
+auto x_main_module_182 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 181)));
+auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 182));
+auto x_main_module_184 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 183)));
+auto x_main_module_185 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 184));
+auto x_main_module_186 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 185));
+auto x_main_module_187 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 186)));
+auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 187));
+auto x_main_module_189 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 188)));
+auto x_main_module_190 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 189));
+auto x_main_module_191 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 190));
+auto x_main_module_192 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 191)));
+auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 192));
+auto x_main_module_194 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 193)));
+auto x_main_module_195 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 194));
+auto x_main_module_196 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 195));
+auto x_main_module_197 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 196)));
+auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 197));
+auto x_main_module_199 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 198)));
+auto x_main_module_200 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 199));
+auto x_main_module_201 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 200));
+auto x_main_module_202 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 201)));
+auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 202));
+auto x_main_module_204 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 203)));
+auto x_main_module_205 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 204));
+auto x_main_module_206 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 205));
+auto x_main_module_207 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 206)));
+auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 207));
+auto x_main_module_209 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 208)));
+auto x_main_module_210 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 209));
+auto x_main_module_211 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 210));
+auto x_main_module_212 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 211)));
+auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 212));
+auto x_main_module_214 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 213)));
+auto x_main_module_215 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 214));
+auto x_main_module_216 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 215));
+auto x_main_module_217 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 216)));
+auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 217));
+auto x_main_module_219 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 218)));
+auto x_main_module_220 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 219));
+auto x_main_module_221 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 220));
+auto x_main_module_222 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 221)));
+auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 222));
+auto x_main_module_224 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 223)));
+auto x_main_module_225 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 224));
+auto x_main_module_226 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 225));
+auto x_main_module_227 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 226)));
+auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 227));
+auto x_main_module_229 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 228)));
+auto x_main_module_230 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 229));
+auto x_main_module_231 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 230));
+auto x_main_module_232 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 231)));
+auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 232));
+auto x_main_module_234 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 233)));
+auto x_main_module_235 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 234));
+auto x_main_module_236 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 235));
+auto x_main_module_237 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 236)));
+auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 237));
+auto x_main_module_239 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 238)));
+auto x_main_module_240 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 239));
+auto x_main_module_241 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 240));
+auto x_main_module_242 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 241)));
+auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 242));
+auto x_main_module_244 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 243)));
+auto x_main_module_245 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 244));
+auto x_main_module_246 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 245));
+auto x_main_module_247 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 246)));
+auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 247));
+auto x_main_module_249 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 248)));
+auto x_main_module_250 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 249));
+auto x_main_module_251 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 250));
+auto x_main_module_252 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 251)));
+auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 252));
+auto x_main_module_254 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 253)));
+auto x_main_module_255 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 254));
+auto x_main_module_256 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 255));
+auto x_main_module_257 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 256)));
+auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 257));
+auto x_main_module_259 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 258)));
+auto x_main_module_260 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 259));
+auto x_main_module_261 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 260));
+auto x_main_module_262 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 261)));
+auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 262));
+auto x_main_module_264 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 263)));
+auto x_main_module_265 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 264));
+auto x_main_module_266 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 265));
+auto x_main_module_267 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 266)));
+auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 267));
+auto x_main_module_269 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 268)));
+auto x_main_module_270 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 269));
+auto x_main_module_271 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 270));
+auto x_main_module_272 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 271)));
+auto x_main_module_273 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 272));
+auto x_main_module_274 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 273)));
+auto x_main_module_275 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 274));
+auto x_main_module_276 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 275));
+auto x_main_module_277 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 276)));
+auto x_main_module_278 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 277));
+auto x_main_module_279 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 278)));
+auto x_main_module_280 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 279));
+auto x_main_module_281 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 280));
+auto x_main_module_282 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 281)));
+auto x_main_module_283 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 128, 1, 7}}, 282));
+auto x_main_module_284 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 283)));
+auto x_main_module_285 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 284));
+auto x_main_module_286 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 285));
+auto x_main_module_287 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 286)));
+auto x_main_module_288 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 287));
+auto x_main_module_289 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 288)));
+auto x_main_module_290 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 289));
+auto x_main_module_291 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 290));
+auto x_main_module_292 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 291)));
+auto x_main_module_293 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 292));
+auto x_main_module_294 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 293)));
+auto x_main_module_295 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 294));
+auto x_main_module_296 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 295));
+auto x_main_module_297 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 296)));
+auto x_main_module_298 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 297));
+auto x_main_module_299 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 298)));
+auto x_main_module_300 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 299));
+auto x_main_module_301 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 300));
+auto x_main_module_302 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 301)));
+auto x_main_module_303 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 302));
+auto x_main_module_304 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 303)));
+auto x_main_module_305 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 304));
+auto x_main_module_306 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 305));
+auto x_main_module_307 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 306)));
+auto x_main_module_308 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 128, 7, 1}}, 307));
+auto x_main_module_309 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 308)));
+auto x_main_module_310 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 309));
+auto x_main_module_311 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 310));
+auto x_main_module_312 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 311)));
+auto x_main_module_313 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 312));
+auto x_main_module_314 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 313)));
+auto x_main_module_315 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 314));
+auto x_main_module_316 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 315));
+auto x_main_module_317 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 316)));
+auto x_main_module_318 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 317));
+auto x_main_module_319 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 318)));
+auto x_main_module_320 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 319));
+auto x_main_module_321 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 320));
+auto x_main_module_322 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 321)));
+auto x_main_module_323 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 322));
+auto x_main_module_324 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 323)));
+auto x_main_module_325 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 324));
+auto x_main_module_326 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 325));
+auto x_main_module_327 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 326)));
+auto x_main_module_328 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 327));
+auto x_main_module_329 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 328)));
+auto x_main_module_330 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 329));
+auto x_main_module_331 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 330));
+auto x_main_module_332 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 331)));
+auto x_main_module_333 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 332));
+auto x_main_module_334 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 333)));
+auto x_main_module_335 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 334));
+auto x_main_module_336 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 335));
+auto x_main_module_337 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 336)));
+auto x_main_module_338 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 337));
+auto x_main_module_339 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 338)));
+auto x_main_module_340 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 339));
+auto x_main_module_341 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 340));
+auto x_main_module_342 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 341)));
+auto x_main_module_343 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 288, 3, 3}}, 342));
+auto x_main_module_344 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 343)));
+auto x_main_module_345 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 344));
+auto x_main_module_346 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 345));
+auto x_main_module_347 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 346)));
+auto x_main_module_348 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 347));
+auto x_main_module_349 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 348)));
+auto x_main_module_350 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 349));
+auto x_main_module_351 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 350));
+auto x_main_module_352 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 351)));
+auto x_main_module_353 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 352));
+auto x_main_module_354 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 353)));
+auto x_main_module_355 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 354));
+auto x_main_module_356 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 355));
+auto x_main_module_357 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 356)));
+auto x_main_module_358 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 357));
+auto x_main_module_359 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 358)));
+auto x_main_module_360 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 359));
+auto x_main_module_361 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 360));
+auto x_main_module_362 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 361)));
+auto x_main_module_363 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 362));
+auto x_main_module_364 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 363)));
+auto x_main_module_365 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 364));
+auto x_main_module_366 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 365));
+auto x_main_module_367 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 366)));
+auto x_main_module_368 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 367));
+auto x_main_module_369 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 368)));
+auto x_main_module_370 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 369));
+auto x_main_module_371 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 370));
+auto x_main_module_372 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 371)));
+auto x_main_module_373 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 288, 1, 1}}, 372));
+auto x_main_module_374 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 373)));
+auto x_main_module_375 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 374));
+auto x_main_module_376 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 375));
+auto x_main_module_377 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 376)));
+auto x_main_module_378 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 377));
+auto x_main_module_379 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 378)));
+auto x_main_module_380 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 379));
+auto x_main_module_381 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 380));
+auto x_main_module_382 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 381)));
+auto x_main_module_383 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 382));
+auto x_main_module_384 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 383)));
+auto x_main_module_385 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 384));
+auto x_main_module_386 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 385));
+auto x_main_module_387 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 386)));
+auto x_main_module_388 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 387));
+auto x_main_module_389 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 388)));
+auto x_main_module_390 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 389));
+auto x_main_module_391 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 390));
+auto x_main_module_392 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 391)));
+auto x_main_module_393 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 392));
+auto x_main_module_394 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 393)));
+auto x_main_module_395 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 394));
+auto x_main_module_396 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 395));
+auto x_main_module_397 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 396)));
+auto x_main_module_398 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 397));
+auto x_main_module_399 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 398)));
+auto x_main_module_400 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 399));
+auto x_main_module_401 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 400));
+auto x_main_module_402 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 401)));
+auto x_main_module_403 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 402));
+auto x_main_module_404 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 403)));
+auto x_main_module_405 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 404));
+auto x_main_module_406 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 405));
+auto x_main_module_407 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 406)));
+auto x_main_module_408 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 256, 1, 1}}, 407));
+auto x_main_module_409 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 408)));
+auto x_main_module_410 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 409));
+auto x_main_module_411 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 410));
+auto x_main_module_412 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 411)));
+auto x_main_module_413 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 412));
+auto x_main_module_414 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 413)));
+auto x_main_module_415 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 414));
+auto x_main_module_416 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 415));
+auto x_main_module_417 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 416)));
+auto x_main_module_418 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 192, 1, 1}}, 417));
+auto x_main_module_419 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 418)));
+auto x_main_module_420 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 419));
+auto x_main_module_421 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 420));
+auto x_main_module_422 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 421)));
+auto x_main_module_423 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 422));
+auto x_main_module_424 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 423)));
+auto x_main_module_425 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 424));
+auto x_main_module_426 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 425));
+auto x_main_module_427 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 426)));
+auto x_main_module_428 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 427));
+auto x_main_module_429 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 428)));
+auto x_main_module_430 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 429));
+auto x_main_module_431 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 430));
+auto x_main_module_432 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 431)));
+auto x_main_module_433 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 432));
+auto x_main_module_434 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 433)));
+auto x_main_module_435 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 434));
+auto x_main_module_436 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 435));
+auto x_main_module_437 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 436)));
+auto x_main_module_438 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 437));
+auto x_main_module_439 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 438)));
+auto x_main_module_440 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 439));
+auto x_main_module_441 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 440));
+auto x_main_module_442 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 441)));
+auto x_main_module_443 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 192, 1, 1}}, 442));
+auto x_main_module_444 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 443)));
+auto x_main_module_445 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 444));
+auto x_main_module_446 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 445));
+auto x_main_module_447 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 446)));
+auto x_main_module_448 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 447));
+auto x_main_module_449 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 448)));
+auto x_main_module_450 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 449));
+auto x_main_module_451 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 450));
+auto x_main_module_452 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 451)));
+auto x_main_module_453 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 80, 3, 3}}, 452));
+auto x_main_module_454 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 453)));
+auto x_main_module_455 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 454));
+auto x_main_module_456 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 455));
+auto x_main_module_457 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 456)));
+auto x_main_module_458 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80, 64, 1, 1}}, 457));
+auto x_main_module_459 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 458)));
+auto x_main_module_460 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 459));
+auto x_main_module_461 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 460));
+auto x_main_module_462 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 461)));
+auto x_main_module_463 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 32, 3, 3}}, 462));
+auto x_main_module_464 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 463)));
+auto x_main_module_465 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 464));
+auto x_main_module_466 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 465));
+auto x_main_module_467 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 466)));
+auto x_main_module_468 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 32, 3, 3}}, 467));
+auto x_main_module_469 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 468)));
+auto x_main_module_470 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 469));
+auto x_main_module_471 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 470));
+auto x_main_module_472 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 471)));
+auto x_main_module_473 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 3, 3, 3}}, 472));
+auto x_main_module_474 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_0, x_main_module_473); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_475 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_474, x_main_module_472, x_main_module_471, x_main_module_470, x_main_module_469); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_476 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_475);
+auto x_main_module_477 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_476, x_main_module_468); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_478 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_477, x_main_module_467, x_main_module_466, x_main_module_465, x_main_module_464); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_479 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_478);
+auto x_main_module_480 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_479, x_main_module_463); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_481 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_480, x_main_module_462, x_main_module_461, x_main_module_460, x_main_module_459); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_482 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_481);
+auto x_main_module_483 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_482); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_484 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_483, x_main_module_458); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_485 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_484, x_main_module_457, x_main_module_456, x_main_module_455, x_main_module_454); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_486 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_485);
+auto x_main_module_487 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_486, x_main_module_453); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_488 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_487, x_main_module_452, x_main_module_451, x_main_module_450, x_main_module_449); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_489 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_488);
+auto x_main_module_490 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_489); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_491 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_490, x_main_module_448); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_492 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_491, x_main_module_447, x_main_module_446, x_main_module_445, x_main_module_444); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_493 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_492);
+auto x_main_module_494 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_490, x_main_module_443); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_495 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_494, x_main_module_442, x_main_module_441, x_main_module_440, x_main_module_439); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_496 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_495);
+auto x_main_module_497 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_496, x_main_module_438); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_498 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_497, x_main_module_437, x_main_module_436, x_main_module_435, x_main_module_434); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_499 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_498);
+auto x_main_module_500 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_490, x_main_module_433); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_501 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_500, x_main_module_432, x_main_module_431, x_main_module_430, x_main_module_429); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_502 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_501);
+auto x_main_module_503 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_502, x_main_module_428); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_504 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_503, x_main_module_427, x_main_module_426, x_main_module_425, x_main_module_424); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_505 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_504);
+auto x_main_module_506 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_505, x_main_module_423); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_507 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_506, x_main_module_422, x_main_module_421, x_main_module_420, x_main_module_419); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_508 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_507);
+auto x_main_module_509 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_490); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_510 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_509, x_main_module_418); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_511 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_510, x_main_module_417, x_main_module_416, x_main_module_415, x_main_module_414); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_512 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_511);
+auto x_main_module_513 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_493, x_main_module_499, x_main_module_508, x_main_module_512); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_514 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_513, x_main_module_413); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_515 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_514, x_main_module_412, x_main_module_411, x_main_module_410, x_main_module_409); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_516 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_515);
+auto x_main_module_517 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_513, x_main_module_408); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_518 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_517, x_main_module_407, x_main_module_406, x_main_module_405, x_main_module_404); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_519 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_518);
+auto x_main_module_520 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_519, x_main_module_403); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_521 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_520, x_main_module_402, x_main_module_401, x_main_module_400, x_main_module_399); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_522 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_521);
+auto x_main_module_523 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_513, x_main_module_398); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_524 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_523, x_main_module_397, x_main_module_396, x_main_module_395, x_main_module_394); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_525 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_524);
+auto x_main_module_526 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_525, x_main_module_393); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_527 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_526, x_main_module_392, x_main_module_391, x_main_module_390, x_main_module_389); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_528 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_527);
+auto x_main_module_529 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_528, x_main_module_388); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_530 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_529, x_main_module_387, x_main_module_386, x_main_module_385, x_main_module_384); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_531 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_530);
+auto x_main_module_532 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_513); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_533 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_532, x_main_module_383); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_534 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_533, x_main_module_382, x_main_module_381, x_main_module_380, x_main_module_379); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_535 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_534);
+auto x_main_module_536 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_516, x_main_module_522, x_main_module_531, x_main_module_535); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_537 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_536, x_main_module_378); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_538 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_537, x_main_module_377, x_main_module_376, x_main_module_375, x_main_module_374); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_539 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_538);
+auto x_main_module_540 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_536, x_main_module_373); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_541 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_540, x_main_module_372, x_main_module_371, x_main_module_370, x_main_module_369); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_542 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_541);
+auto x_main_module_543 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_542, x_main_module_368); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_544 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_543, x_main_module_367, x_main_module_366, x_main_module_365, x_main_module_364); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_545 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_544);
+auto x_main_module_546 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_536, x_main_module_363); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_547 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_546, x_main_module_362, x_main_module_361, x_main_module_360, x_main_module_359); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_548 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_547);
+auto x_main_module_549 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_548, x_main_module_358); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_550 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_549, x_main_module_357, x_main_module_356, x_main_module_355, x_main_module_354); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_551 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_550);
+auto x_main_module_552 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_551, x_main_module_353); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_553 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_552, x_main_module_352, x_main_module_351, x_main_module_350, x_main_module_349); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_554 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_553);
+auto x_main_module_555 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_536); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_556 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_555, x_main_module_348); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_557 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_556, x_main_module_347, x_main_module_346, x_main_module_345, x_main_module_344); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_558 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_557);
+auto x_main_module_559 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_539, x_main_module_545, x_main_module_554, x_main_module_558); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_560 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_559, x_main_module_343); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_561 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_560, x_main_module_342, x_main_module_341, x_main_module_340, x_main_module_339); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_562 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_561);
+auto x_main_module_563 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_559, x_main_module_338); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_564 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_563, x_main_module_337, x_main_module_336, x_main_module_335, x_main_module_334); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_565 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_564);
+auto x_main_module_566 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_565, x_main_module_333); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_567 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_566, x_main_module_332, x_main_module_331, x_main_module_330, x_main_module_329); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_568 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_567);
+auto x_main_module_569 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_568, x_main_module_328); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_570 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_569, x_main_module_327, x_main_module_326, x_main_module_325, x_main_module_324); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_571 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_570);
+auto x_main_module_572 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_559); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_573 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_562, x_main_module_571, x_main_module_572); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_574 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_573, x_main_module_323); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_575 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_574, x_main_module_322, x_main_module_321, x_main_module_320, x_main_module_319); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_576 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_575);
+auto x_main_module_577 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_573, x_main_module_318); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_578 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_577, x_main_module_317, x_main_module_316, x_main_module_315, x_main_module_314); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_579 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_578);
+auto x_main_module_580 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_579, x_main_module_313); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_581 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_580, x_main_module_312, x_main_module_311, x_main_module_310, x_main_module_309); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_582 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_581);
+auto x_main_module_583 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_582, x_main_module_308); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_584 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_583, x_main_module_307, x_main_module_306, x_main_module_305, x_main_module_304); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_585 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_584);
+auto x_main_module_586 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_573, x_main_module_303); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_587 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_586, x_main_module_302, x_main_module_301, x_main_module_300, x_main_module_299); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_588 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_587);
+auto x_main_module_589 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_588, x_main_module_298); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_590 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_589, x_main_module_297, x_main_module_296, x_main_module_295, x_main_module_294); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_591 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_590);
+auto x_main_module_592 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_591, x_main_module_293); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_593 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_592, x_main_module_292, x_main_module_291, x_main_module_290, x_main_module_289); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_594 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_593);
+auto x_main_module_595 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_594, x_main_module_288); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_596 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_595, x_main_module_287, x_main_module_286, x_main_module_285, x_main_module_284); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_597 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_596);
+auto x_main_module_598 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_597, x_main_module_283); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_599 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_598, x_main_module_282, x_main_module_281, x_main_module_280, x_main_module_279); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_600 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_599);
+auto x_main_module_601 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_573); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_602 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_601, x_main_module_278); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_603 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_602, x_main_module_277, x_main_module_276, x_main_module_275, x_main_module_274); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_604 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_603);
+auto x_main_module_605 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_576, x_main_module_585, x_main_module_600, x_main_module_604); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_606 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_605, x_main_module_273); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_607 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_606, x_main_module_272, x_main_module_271, x_main_module_270, x_main_module_269); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_608 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_607);
+auto x_main_module_609 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_605, x_main_module_268); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_610 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_609, x_main_module_267, x_main_module_266, x_main_module_265, x_main_module_264); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_611 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_610);
+auto x_main_module_612 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_611, x_main_module_263); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_613 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_612, x_main_module_262, x_main_module_261, x_main_module_260, x_main_module_259); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_614 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_613);
+auto x_main_module_615 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_614, x_main_module_258); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_616 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_615, x_main_module_257, x_main_module_256, x_main_module_255, x_main_module_254); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_617 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_616);
+auto x_main_module_618 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_605, x_main_module_253); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_619 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_618, x_main_module_252, x_main_module_251, x_main_module_250, x_main_module_249); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_620 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_619);
+auto x_main_module_621 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_620, x_main_module_248); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_622 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_621, x_main_module_247, x_main_module_246, x_main_module_245, x_main_module_244); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_623 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_622);
+auto x_main_module_624 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_623, x_main_module_243); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_625 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_624, x_main_module_242, x_main_module_241, x_main_module_240, x_main_module_239); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_626 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_625);
+auto x_main_module_627 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_626, x_main_module_238); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_628 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_627, x_main_module_237, x_main_module_236, x_main_module_235, x_main_module_234); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_629 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_628);
+auto x_main_module_630 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_629, x_main_module_233); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_631 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_630, x_main_module_232, x_main_module_231, x_main_module_230, x_main_module_229); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_632 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_631);
+auto x_main_module_633 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_605); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_634 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_633, x_main_module_228); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_635 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_634, x_main_module_227, x_main_module_226, x_main_module_225, x_main_module_224); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_636 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_635);
+auto x_main_module_637 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_608, x_main_module_617, x_main_module_632, x_main_module_636); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_638 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_637, x_main_module_223); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_639 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_638, x_main_module_222, x_main_module_221, x_main_module_220, x_main_module_219); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_640 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_639);
+auto x_main_module_641 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_637, x_main_module_218); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_642 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_641, x_main_module_217, x_main_module_216, x_main_module_215, x_main_module_214); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_643 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_642);
+auto x_main_module_644 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_643, x_main_module_213); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_645 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_644, x_main_module_212, x_main_module_211, x_main_module_210, x_main_module_209); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_646 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_645);
+auto x_main_module_647 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_646, x_main_module_208); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_648 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_647, x_main_module_207, x_main_module_206, x_main_module_205, x_main_module_204); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_649 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_648);
+auto x_main_module_650 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_637, x_main_module_203); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_651 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_650, x_main_module_202, x_main_module_201, x_main_module_200, x_main_module_199); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_652 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_651);
+auto x_main_module_653 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_652, x_main_module_198); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_654 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_653, x_main_module_197, x_main_module_196, x_main_module_195, x_main_module_194); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_655 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_654);
+auto x_main_module_656 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_655, x_main_module_193); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_657 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_656, x_main_module_192, x_main_module_191, x_main_module_190, x_main_module_189); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_658 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_657);
+auto x_main_module_659 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_658, x_main_module_188); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_660 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_659, x_main_module_187, x_main_module_186, x_main_module_185, x_main_module_184); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_661 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_660);
+auto x_main_module_662 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_661, x_main_module_183); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_663 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_662, x_main_module_182, x_main_module_181, x_main_module_180, x_main_module_179); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_664 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_663);
+auto x_main_module_665 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_637); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_666 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_665, x_main_module_178); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_667 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_666, x_main_module_177, x_main_module_176, x_main_module_175, x_main_module_174); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_668 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_667);
+auto x_main_module_669 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_640, x_main_module_649, x_main_module_664, x_main_module_668); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_670 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_669, x_main_module_173); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_671 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_670, x_main_module_172, x_main_module_171, x_main_module_170, x_main_module_169); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_672 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_671);
+auto x_main_module_673 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_669, x_main_module_168); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_674 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_673, x_main_module_167, x_main_module_166, x_main_module_165, x_main_module_164); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_675 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_674);
+auto x_main_module_676 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_675, x_main_module_163); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_677 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_676, x_main_module_162, x_main_module_161, x_main_module_160, x_main_module_159); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_678 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_677);
+auto x_main_module_679 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_678, x_main_module_158); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_680 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_679, x_main_module_157, x_main_module_156, x_main_module_155, x_main_module_154); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_681 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_680);
+auto x_main_module_682 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_669, x_main_module_153); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_683 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_682, x_main_module_152, x_main_module_151, x_main_module_150, x_main_module_149); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_684 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_683);
+auto x_main_module_685 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_684, x_main_module_148); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_686 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_685, x_main_module_147, x_main_module_146, x_main_module_145, x_main_module_144); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_687 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_686);
+auto x_main_module_688 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_687, x_main_module_143); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_689 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_688, x_main_module_142, x_main_module_141, x_main_module_140, x_main_module_139); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_690 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_689);
+auto x_main_module_691 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_690, x_main_module_138); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_692 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_691, x_main_module_137, x_main_module_136, x_main_module_135, x_main_module_134); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_693 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_692);
+auto x_main_module_694 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_693, x_main_module_133); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_695 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_694, x_main_module_132, x_main_module_131, x_main_module_130, x_main_module_129); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_696 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_695);
+auto x_main_module_697 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_669); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_698 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_697, x_main_module_128); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_699 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_698, x_main_module_127, x_main_module_126, x_main_module_125, x_main_module_124); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_700 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_699);
+auto x_main_module_701 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_672, x_main_module_681, x_main_module_696, x_main_module_700); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_702 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_701, x_main_module_123); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_703 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_702, x_main_module_122, x_main_module_121, x_main_module_120, x_main_module_119); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_704 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_703);
+auto x_main_module_705 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_704, x_main_module_118); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_706 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_705, x_main_module_117, x_main_module_116, x_main_module_115, x_main_module_114); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_707 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_706);
+auto x_main_module_708 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_701, x_main_module_113); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_709 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_708, x_main_module_112, x_main_module_111, x_main_module_110, x_main_module_109); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_710 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_709);
+auto x_main_module_711 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_710, x_main_module_108); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_712 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_711, x_main_module_107, x_main_module_106, x_main_module_105, x_main_module_104); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_713 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_712);
+auto x_main_module_714 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_713, x_main_module_103); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_715 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_714, x_main_module_102, x_main_module_101, x_main_module_100, x_main_module_99); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_716 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_715);
+auto x_main_module_717 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_716, x_main_module_98); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_718 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_717, x_main_module_97, x_main_module_96, x_main_module_95, x_main_module_94); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_719 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_718);
+auto x_main_module_720 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_701); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_721 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_707, x_main_module_719, x_main_module_720); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_722 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_721, x_main_module_93); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_723 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_722, x_main_module_92, x_main_module_91, x_main_module_90, x_main_module_89); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_724 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_723);
+auto x_main_module_725 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_721, x_main_module_88); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_726 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_725, x_main_module_87, x_main_module_86, x_main_module_85, x_main_module_84); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_727 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_726);
+auto x_main_module_728 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_727, x_main_module_83); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_729 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_728, x_main_module_82, x_main_module_81, x_main_module_80, x_main_module_79); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_730 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_729);
+auto x_main_module_731 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_727, x_main_module_78); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_732 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_731, x_main_module_77, x_main_module_76, x_main_module_75, x_main_module_74); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_733 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_732);
+auto x_main_module_734 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_730, x_main_module_733); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_735 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_721, x_main_module_73); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_736 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_735, x_main_module_72, x_main_module_71, x_main_module_70, x_main_module_69); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_737 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_736);
+auto x_main_module_738 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_737, x_main_module_68); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_739 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_738, x_main_module_67, x_main_module_66, x_main_module_65, x_main_module_64); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_740 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_739);
+auto x_main_module_741 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_740, x_main_module_63); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_742 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_741, x_main_module_62, x_main_module_61, x_main_module_60, x_main_module_59); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_743 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_742);
+auto x_main_module_744 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_740, x_main_module_58); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_745 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_744, x_main_module_57, x_main_module_56, x_main_module_55, x_main_module_54); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_746 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_745);
+auto x_main_module_747 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_743, x_main_module_746); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_748 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_721); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_749 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_748, x_main_module_53); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_750 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_749, x_main_module_52, x_main_module_51, x_main_module_50, x_main_module_49); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_751 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_750);
+auto x_main_module_752 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_724, x_main_module_734, x_main_module_747, x_main_module_751); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_753 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_752, x_main_module_48); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_754 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_753, x_main_module_47, x_main_module_46, x_main_module_45, x_main_module_44); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_755 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_754);
+auto x_main_module_756 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_752, x_main_module_43); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_757 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_756, x_main_module_42, x_main_module_41, x_main_module_40, x_main_module_39); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_758 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_757);
+auto x_main_module_759 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_758, x_main_module_38); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_760 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_759, x_main_module_37, x_main_module_36, x_main_module_35, x_main_module_34); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_761 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_760);
+auto x_main_module_762 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_758, x_main_module_33); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_763 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_762, x_main_module_32, x_main_module_31, x_main_module_30, x_main_module_29); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_764 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_763);
+auto x_main_module_765 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_761, x_main_module_764); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_766 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_752, x_main_module_28); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_767 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_766, x_main_module_27, x_main_module_26, x_main_module_25, x_main_module_24); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_768 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_767);
+auto x_main_module_769 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_768, x_main_module_23); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_770 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_769, x_main_module_22, x_main_module_21, x_main_module_20, x_main_module_19); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_771 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_770);
+auto x_main_module_772 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_771, x_main_module_18); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_773 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_772, x_main_module_17, x_main_module_16, x_main_module_15, x_main_module_14); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_774 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_773);
+auto x_main_module_775 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_771, x_main_module_13); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_776 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_775, x_main_module_12, x_main_module_11, x_main_module_10, x_main_module_9); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_777 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_776);
+auto x_main_module_778 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_774, x_main_module_777); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_779 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_752); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_780 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_779, x_main_module_8); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_781 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_780, x_main_module_7, x_main_module_6, x_main_module_5, x_main_module_4); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_782 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_781);
+auto x_main_module_783 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_755, x_main_module_765, x_main_module_778, x_main_module_782); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_784 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[8,8],\"lp_order\":2,\"mode\":0,\"padding\":[0,0,0,0],\"stride\":[8,8]}")), x_main_module_783); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_785 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_784);
+auto x_main_module_786 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), x_main_module_785); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_787 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_3); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_788 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_786, x_main_module_787);
+auto x_main_module_789 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_2); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_790 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_0); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_791 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_789, x_main_module_790);
+auto x_main_module_792 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_788, x_main_module_791);
+mmain->add_return({x_main_module_792});
+
 
     return p;
 }

--- a/src/driver/inceptionv3.cpp
+++ b/src/driver/inceptionv3.cpp
@@ -33,802 +33,2832 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program inceptionv3(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-migraphx::module_ref mmain = p.get_main_module();
-auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 299, 299}});
-auto x_main_module_2 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
-auto x_main_module_3 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
-auto x_main_module_4 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 3)));
-auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 4));
-auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 5));
-auto x_main_module_7 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 6)));
-auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 2048, 1, 1}}, 7));
-auto x_main_module_9 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 8)));
-auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 9));
-auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 10));
-auto x_main_module_12 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 11)));
-auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 12));
-auto x_main_module_14 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13)));
-auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 14));
-auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 15));
-auto x_main_module_17 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 16)));
-auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 17));
-auto x_main_module_19 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 18)));
-auto x_main_module_20 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 19));
-auto x_main_module_21 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 20));
-auto x_main_module_22 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 21)));
-auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 22));
-auto x_main_module_24 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 23)));
-auto x_main_module_25 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 24));
-auto x_main_module_26 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 25));
-auto x_main_module_27 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 26)));
-auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448, 2048, 1, 1}}, 27));
-auto x_main_module_29 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 28)));
-auto x_main_module_30 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 29)));
-auto x_main_module_31 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 30));
-auto x_main_module_32 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 31)));
-auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 32));
-auto x_main_module_34 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 33)));
-auto x_main_module_35 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 34)));
-auto x_main_module_36 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 35));
-auto x_main_module_37 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 36)));
-auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 37));
-auto x_main_module_39 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 38)));
-auto x_main_module_40 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 39));
-auto x_main_module_41 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 40));
-auto x_main_module_42 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 41)));
-auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 2048, 1, 1}}, 42));
-auto x_main_module_44 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 43)));
-auto x_main_module_45 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 44));
-auto x_main_module_46 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 45));
-auto x_main_module_47 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 46)));
-auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 2048, 1, 1}}, 47));
-auto x_main_module_49 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 48)));
-auto x_main_module_50 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 49));
-auto x_main_module_51 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 50));
-auto x_main_module_52 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 51)));
-auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 1280, 1, 1}}, 52));
-auto x_main_module_54 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 53)));
-auto x_main_module_55 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 54));
-auto x_main_module_56 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 55));
-auto x_main_module_57 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 56)));
-auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 57));
-auto x_main_module_59 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 58)));
-auto x_main_module_60 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 59));
-auto x_main_module_61 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 60));
-auto x_main_module_62 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 61)));
-auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 62));
-auto x_main_module_64 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 63)));
-auto x_main_module_65 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 64));
-auto x_main_module_66 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 65));
-auto x_main_module_67 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 66)));
-auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 67));
-auto x_main_module_69 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 68)));
-auto x_main_module_70 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 69));
-auto x_main_module_71 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 70));
-auto x_main_module_72 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 71)));
-auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448, 1280, 1, 1}}, 72));
-auto x_main_module_74 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 73)));
-auto x_main_module_75 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 74));
-auto x_main_module_76 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 75));
-auto x_main_module_77 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 76)));
-auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 77));
-auto x_main_module_79 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 78)));
-auto x_main_module_80 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 79));
-auto x_main_module_81 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 80));
-auto x_main_module_82 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 81)));
-auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 82));
-auto x_main_module_84 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 83)));
-auto x_main_module_85 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 84));
-auto x_main_module_86 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 85));
-auto x_main_module_87 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 86)));
-auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 1280, 1, 1}}, 87));
-auto x_main_module_89 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 88)));
-auto x_main_module_90 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 89));
-auto x_main_module_91 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 90));
-auto x_main_module_92 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 91)));
-auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 1280, 1, 1}}, 92));
-auto x_main_module_94 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 93)));
-auto x_main_module_95 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 94));
-auto x_main_module_96 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 95));
-auto x_main_module_97 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 96)));
-auto x_main_module_98 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 3, 3}}, 97));
-auto x_main_module_99 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 98)));
-auto x_main_module_100 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 99));
-auto x_main_module_101 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 100));
-auto x_main_module_102 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 101)));
-auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 102));
-auto x_main_module_104 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 103)));
-auto x_main_module_105 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 104));
-auto x_main_module_106 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 105));
-auto x_main_module_107 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 106)));
-auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 107));
-auto x_main_module_109 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 108)));
-auto x_main_module_110 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 109));
-auto x_main_module_111 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 110));
-auto x_main_module_112 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 111)));
-auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 112));
-auto x_main_module_114 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 113)));
-auto x_main_module_115 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 114));
-auto x_main_module_116 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 115));
-auto x_main_module_117 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 116)));
-auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 192, 3, 3}}, 117));
-auto x_main_module_119 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 118)));
-auto x_main_module_120 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 119));
-auto x_main_module_121 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 120));
-auto x_main_module_122 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 121)));
-auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 122));
-auto x_main_module_124 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 123)));
-auto x_main_module_125 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 124));
-auto x_main_module_126 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 125));
-auto x_main_module_127 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 126)));
-auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 127));
-auto x_main_module_129 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 128)));
-auto x_main_module_130 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 129));
-auto x_main_module_131 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 130));
-auto x_main_module_132 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 131)));
-auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 132));
-auto x_main_module_134 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 133)));
-auto x_main_module_135 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 134));
-auto x_main_module_136 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 135));
-auto x_main_module_137 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 136)));
-auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 137));
-auto x_main_module_139 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 138)));
-auto x_main_module_140 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 139));
-auto x_main_module_141 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 140));
-auto x_main_module_142 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 141)));
-auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 142));
-auto x_main_module_144 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 143)));
-auto x_main_module_145 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 144));
-auto x_main_module_146 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 145));
-auto x_main_module_147 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 146)));
-auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 147));
-auto x_main_module_149 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 148)));
-auto x_main_module_150 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 149));
-auto x_main_module_151 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 150));
-auto x_main_module_152 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 151)));
-auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 152));
-auto x_main_module_154 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 153)));
-auto x_main_module_155 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 154));
-auto x_main_module_156 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 155));
-auto x_main_module_157 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 156)));
-auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 157));
-auto x_main_module_159 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 158)));
-auto x_main_module_160 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 159));
-auto x_main_module_161 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 160));
-auto x_main_module_162 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 161)));
-auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 162));
-auto x_main_module_164 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 163)));
-auto x_main_module_165 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 164));
-auto x_main_module_166 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 165));
-auto x_main_module_167 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 166)));
-auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 167));
-auto x_main_module_169 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 168)));
-auto x_main_module_170 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 169));
-auto x_main_module_171 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 170));
-auto x_main_module_172 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 171)));
-auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 172));
-auto x_main_module_174 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 173)));
-auto x_main_module_175 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 174));
-auto x_main_module_176 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 175));
-auto x_main_module_177 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 176)));
-auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 177));
-auto x_main_module_179 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 178)));
-auto x_main_module_180 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 179));
-auto x_main_module_181 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 180));
-auto x_main_module_182 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 181)));
-auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 182));
-auto x_main_module_184 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 183)));
-auto x_main_module_185 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 184));
-auto x_main_module_186 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 185));
-auto x_main_module_187 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 186)));
-auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 187));
-auto x_main_module_189 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 188)));
-auto x_main_module_190 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 189));
-auto x_main_module_191 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 190));
-auto x_main_module_192 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 191)));
-auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 192));
-auto x_main_module_194 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 193)));
-auto x_main_module_195 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 194));
-auto x_main_module_196 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 195));
-auto x_main_module_197 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 196)));
-auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 197));
-auto x_main_module_199 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 198)));
-auto x_main_module_200 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 199));
-auto x_main_module_201 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 200));
-auto x_main_module_202 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 201)));
-auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 202));
-auto x_main_module_204 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 203)));
-auto x_main_module_205 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 204));
-auto x_main_module_206 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 205));
-auto x_main_module_207 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 206)));
-auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 207));
-auto x_main_module_209 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 208)));
-auto x_main_module_210 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 209));
-auto x_main_module_211 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 210));
-auto x_main_module_212 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 211)));
-auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 212));
-auto x_main_module_214 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 213)));
-auto x_main_module_215 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 214));
-auto x_main_module_216 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 215));
-auto x_main_module_217 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 216)));
-auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 217));
-auto x_main_module_219 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 218)));
-auto x_main_module_220 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 219));
-auto x_main_module_221 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 220));
-auto x_main_module_222 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 221)));
-auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 222));
-auto x_main_module_224 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 223)));
-auto x_main_module_225 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 224));
-auto x_main_module_226 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 225));
-auto x_main_module_227 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 226)));
-auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 227));
-auto x_main_module_229 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 228)));
-auto x_main_module_230 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 229));
-auto x_main_module_231 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 230));
-auto x_main_module_232 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 231)));
-auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 232));
-auto x_main_module_234 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 233)));
-auto x_main_module_235 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 234));
-auto x_main_module_236 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 235));
-auto x_main_module_237 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 236)));
-auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 237));
-auto x_main_module_239 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 238)));
-auto x_main_module_240 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 239));
-auto x_main_module_241 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 240));
-auto x_main_module_242 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 241)));
-auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 242));
-auto x_main_module_244 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 243)));
-auto x_main_module_245 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 244));
-auto x_main_module_246 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 245));
-auto x_main_module_247 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 246)));
-auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 247));
-auto x_main_module_249 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 248)));
-auto x_main_module_250 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 249));
-auto x_main_module_251 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 250));
-auto x_main_module_252 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 251)));
-auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 252));
-auto x_main_module_254 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 253)));
-auto x_main_module_255 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 254));
-auto x_main_module_256 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 255));
-auto x_main_module_257 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 256)));
-auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 257));
-auto x_main_module_259 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 258)));
-auto x_main_module_260 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 259));
-auto x_main_module_261 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 260));
-auto x_main_module_262 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 261)));
-auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 262));
-auto x_main_module_264 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 263)));
-auto x_main_module_265 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 264));
-auto x_main_module_266 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 265));
-auto x_main_module_267 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 266)));
-auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 267));
-auto x_main_module_269 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 268)));
-auto x_main_module_270 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 269));
-auto x_main_module_271 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 270));
-auto x_main_module_272 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 271)));
-auto x_main_module_273 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 272));
-auto x_main_module_274 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 273)));
-auto x_main_module_275 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 274));
-auto x_main_module_276 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 275));
-auto x_main_module_277 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 276)));
-auto x_main_module_278 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 277));
-auto x_main_module_279 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 278)));
-auto x_main_module_280 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 279));
-auto x_main_module_281 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 280));
-auto x_main_module_282 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 281)));
-auto x_main_module_283 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 128, 1, 7}}, 282));
-auto x_main_module_284 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 283)));
-auto x_main_module_285 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 284));
-auto x_main_module_286 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 285));
-auto x_main_module_287 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 286)));
-auto x_main_module_288 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 287));
-auto x_main_module_289 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 288)));
-auto x_main_module_290 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 289));
-auto x_main_module_291 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 290));
-auto x_main_module_292 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 291)));
-auto x_main_module_293 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 292));
-auto x_main_module_294 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 293)));
-auto x_main_module_295 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 294));
-auto x_main_module_296 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 295));
-auto x_main_module_297 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 296)));
-auto x_main_module_298 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 297));
-auto x_main_module_299 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 298)));
-auto x_main_module_300 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 299));
-auto x_main_module_301 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 300));
-auto x_main_module_302 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 301)));
-auto x_main_module_303 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 302));
-auto x_main_module_304 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 303)));
-auto x_main_module_305 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 304));
-auto x_main_module_306 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 305));
-auto x_main_module_307 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 306)));
-auto x_main_module_308 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 128, 7, 1}}, 307));
-auto x_main_module_309 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 308)));
-auto x_main_module_310 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 309));
-auto x_main_module_311 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 310));
-auto x_main_module_312 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 311)));
-auto x_main_module_313 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 312));
-auto x_main_module_314 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 313)));
-auto x_main_module_315 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 314));
-auto x_main_module_316 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 315));
-auto x_main_module_317 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 316)));
-auto x_main_module_318 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 317));
-auto x_main_module_319 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 318)));
-auto x_main_module_320 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 319));
-auto x_main_module_321 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 320));
-auto x_main_module_322 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 321)));
-auto x_main_module_323 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 322));
-auto x_main_module_324 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 323)));
-auto x_main_module_325 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 324));
-auto x_main_module_326 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 325));
-auto x_main_module_327 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 326)));
-auto x_main_module_328 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 327));
-auto x_main_module_329 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 328)));
-auto x_main_module_330 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 329));
-auto x_main_module_331 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 330));
-auto x_main_module_332 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 331)));
-auto x_main_module_333 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 332));
-auto x_main_module_334 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 333)));
-auto x_main_module_335 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 334));
-auto x_main_module_336 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 335));
-auto x_main_module_337 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 336)));
-auto x_main_module_338 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 337));
-auto x_main_module_339 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 338)));
-auto x_main_module_340 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 339));
-auto x_main_module_341 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 340));
-auto x_main_module_342 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 341)));
-auto x_main_module_343 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 288, 3, 3}}, 342));
-auto x_main_module_344 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 343)));
-auto x_main_module_345 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 344));
-auto x_main_module_346 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 345));
-auto x_main_module_347 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 346)));
-auto x_main_module_348 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 347));
-auto x_main_module_349 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 348)));
-auto x_main_module_350 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 349));
-auto x_main_module_351 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 350));
-auto x_main_module_352 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 351)));
-auto x_main_module_353 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 352));
-auto x_main_module_354 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 353)));
-auto x_main_module_355 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 354));
-auto x_main_module_356 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 355));
-auto x_main_module_357 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 356)));
-auto x_main_module_358 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 357));
-auto x_main_module_359 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 358)));
-auto x_main_module_360 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 359));
-auto x_main_module_361 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 360));
-auto x_main_module_362 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 361)));
-auto x_main_module_363 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 362));
-auto x_main_module_364 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 363)));
-auto x_main_module_365 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 364));
-auto x_main_module_366 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 365));
-auto x_main_module_367 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 366)));
-auto x_main_module_368 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 367));
-auto x_main_module_369 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 368)));
-auto x_main_module_370 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 369));
-auto x_main_module_371 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 370));
-auto x_main_module_372 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 371)));
-auto x_main_module_373 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 288, 1, 1}}, 372));
-auto x_main_module_374 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 373)));
-auto x_main_module_375 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 374));
-auto x_main_module_376 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 375));
-auto x_main_module_377 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 376)));
-auto x_main_module_378 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 377));
-auto x_main_module_379 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 378)));
-auto x_main_module_380 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 379));
-auto x_main_module_381 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 380));
-auto x_main_module_382 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 381)));
-auto x_main_module_383 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 382));
-auto x_main_module_384 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 383)));
-auto x_main_module_385 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 384));
-auto x_main_module_386 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 385));
-auto x_main_module_387 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 386)));
-auto x_main_module_388 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 387));
-auto x_main_module_389 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 388)));
-auto x_main_module_390 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 389));
-auto x_main_module_391 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 390));
-auto x_main_module_392 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 391)));
-auto x_main_module_393 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 392));
-auto x_main_module_394 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 393)));
-auto x_main_module_395 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 394));
-auto x_main_module_396 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 395));
-auto x_main_module_397 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 396)));
-auto x_main_module_398 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 397));
-auto x_main_module_399 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 398)));
-auto x_main_module_400 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 399));
-auto x_main_module_401 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 400));
-auto x_main_module_402 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 401)));
-auto x_main_module_403 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 402));
-auto x_main_module_404 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 403)));
-auto x_main_module_405 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 404));
-auto x_main_module_406 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 405));
-auto x_main_module_407 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 406)));
-auto x_main_module_408 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 256, 1, 1}}, 407));
-auto x_main_module_409 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 408)));
-auto x_main_module_410 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 409));
-auto x_main_module_411 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 410));
-auto x_main_module_412 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 411)));
-auto x_main_module_413 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 412));
-auto x_main_module_414 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 413)));
-auto x_main_module_415 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 414));
-auto x_main_module_416 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 415));
-auto x_main_module_417 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 416)));
-auto x_main_module_418 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 192, 1, 1}}, 417));
-auto x_main_module_419 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 418)));
-auto x_main_module_420 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 419));
-auto x_main_module_421 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 420));
-auto x_main_module_422 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 421)));
-auto x_main_module_423 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 422));
-auto x_main_module_424 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 423)));
-auto x_main_module_425 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 424));
-auto x_main_module_426 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 425));
-auto x_main_module_427 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 426)));
-auto x_main_module_428 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 427));
-auto x_main_module_429 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 428)));
-auto x_main_module_430 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 429));
-auto x_main_module_431 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 430));
-auto x_main_module_432 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 431)));
-auto x_main_module_433 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 432));
-auto x_main_module_434 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 433)));
-auto x_main_module_435 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 434));
-auto x_main_module_436 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 435));
-auto x_main_module_437 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 436)));
-auto x_main_module_438 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 437));
-auto x_main_module_439 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 438)));
-auto x_main_module_440 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 439));
-auto x_main_module_441 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 440));
-auto x_main_module_442 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 441)));
-auto x_main_module_443 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 192, 1, 1}}, 442));
-auto x_main_module_444 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 443)));
-auto x_main_module_445 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 444));
-auto x_main_module_446 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 445));
-auto x_main_module_447 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 446)));
-auto x_main_module_448 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 447));
-auto x_main_module_449 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 448)));
-auto x_main_module_450 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 449));
-auto x_main_module_451 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 450));
-auto x_main_module_452 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 451)));
-auto x_main_module_453 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 80, 3, 3}}, 452));
-auto x_main_module_454 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 453)));
-auto x_main_module_455 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 454));
-auto x_main_module_456 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 455));
-auto x_main_module_457 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 456)));
-auto x_main_module_458 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80, 64, 1, 1}}, 457));
-auto x_main_module_459 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 458)));
-auto x_main_module_460 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 459));
-auto x_main_module_461 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 460));
-auto x_main_module_462 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 461)));
-auto x_main_module_463 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 32, 3, 3}}, 462));
-auto x_main_module_464 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 463)));
-auto x_main_module_465 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 464));
-auto x_main_module_466 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 465));
-auto x_main_module_467 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 466)));
-auto x_main_module_468 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 32, 3, 3}}, 467));
-auto x_main_module_469 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 468)));
-auto x_main_module_470 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 469));
-auto x_main_module_471 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 470));
-auto x_main_module_472 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 471)));
-auto x_main_module_473 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 3, 3, 3}}, 472));
-auto x_main_module_474 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_0, x_main_module_473);
-auto x_main_module_475 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_474, x_main_module_472, x_main_module_471, x_main_module_470, x_main_module_469);
-auto x_main_module_476 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_475);
-auto x_main_module_477 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_476, x_main_module_468);
-auto x_main_module_478 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_477, x_main_module_467, x_main_module_466, x_main_module_465, x_main_module_464);
-auto x_main_module_479 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_478);
-auto x_main_module_480 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_479, x_main_module_463);
-auto x_main_module_481 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_480, x_main_module_462, x_main_module_461, x_main_module_460, x_main_module_459);
-auto x_main_module_482 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_481);
-auto x_main_module_483 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_482);
-auto x_main_module_484 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_483, x_main_module_458);
-auto x_main_module_485 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_484, x_main_module_457, x_main_module_456, x_main_module_455, x_main_module_454);
-auto x_main_module_486 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_485);
-auto x_main_module_487 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_486, x_main_module_453);
-auto x_main_module_488 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_487, x_main_module_452, x_main_module_451, x_main_module_450, x_main_module_449);
-auto x_main_module_489 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_488);
-auto x_main_module_490 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_489);
-auto x_main_module_491 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_490, x_main_module_448);
-auto x_main_module_492 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_491, x_main_module_447, x_main_module_446, x_main_module_445, x_main_module_444);
-auto x_main_module_493 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_492);
-auto x_main_module_494 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_490, x_main_module_443);
-auto x_main_module_495 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_494, x_main_module_442, x_main_module_441, x_main_module_440, x_main_module_439);
-auto x_main_module_496 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_495);
-auto x_main_module_497 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_496, x_main_module_438);
-auto x_main_module_498 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_497, x_main_module_437, x_main_module_436, x_main_module_435, x_main_module_434);
-auto x_main_module_499 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_498);
-auto x_main_module_500 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_490, x_main_module_433);
-auto x_main_module_501 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_500, x_main_module_432, x_main_module_431, x_main_module_430, x_main_module_429);
-auto x_main_module_502 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_501);
-auto x_main_module_503 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_502, x_main_module_428);
-auto x_main_module_504 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_503, x_main_module_427, x_main_module_426, x_main_module_425, x_main_module_424);
-auto x_main_module_505 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_504);
-auto x_main_module_506 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_505, x_main_module_423);
-auto x_main_module_507 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_506, x_main_module_422, x_main_module_421, x_main_module_420, x_main_module_419);
-auto x_main_module_508 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_507);
-auto x_main_module_509 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_490);
-auto x_main_module_510 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_509, x_main_module_418);
-auto x_main_module_511 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_510, x_main_module_417, x_main_module_416, x_main_module_415, x_main_module_414);
-auto x_main_module_512 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_511);
-auto x_main_module_513 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_493, x_main_module_499, x_main_module_508, x_main_module_512);
-auto x_main_module_514 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_513, x_main_module_413);
-auto x_main_module_515 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_514, x_main_module_412, x_main_module_411, x_main_module_410, x_main_module_409);
-auto x_main_module_516 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_515);
-auto x_main_module_517 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_513, x_main_module_408);
-auto x_main_module_518 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_517, x_main_module_407, x_main_module_406, x_main_module_405, x_main_module_404);
-auto x_main_module_519 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_518);
-auto x_main_module_520 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_519, x_main_module_403);
-auto x_main_module_521 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_520, x_main_module_402, x_main_module_401, x_main_module_400, x_main_module_399);
-auto x_main_module_522 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_521);
-auto x_main_module_523 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_513, x_main_module_398);
-auto x_main_module_524 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_523, x_main_module_397, x_main_module_396, x_main_module_395, x_main_module_394);
-auto x_main_module_525 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_524);
-auto x_main_module_526 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_525, x_main_module_393);
-auto x_main_module_527 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_526, x_main_module_392, x_main_module_391, x_main_module_390, x_main_module_389);
-auto x_main_module_528 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_527);
-auto x_main_module_529 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_528, x_main_module_388);
-auto x_main_module_530 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_529, x_main_module_387, x_main_module_386, x_main_module_385, x_main_module_384);
-auto x_main_module_531 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_530);
-auto x_main_module_532 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_513);
-auto x_main_module_533 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_532, x_main_module_383);
-auto x_main_module_534 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_533, x_main_module_382, x_main_module_381, x_main_module_380, x_main_module_379);
-auto x_main_module_535 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_534);
-auto x_main_module_536 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_516, x_main_module_522, x_main_module_531, x_main_module_535);
-auto x_main_module_537 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_536, x_main_module_378);
-auto x_main_module_538 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_537, x_main_module_377, x_main_module_376, x_main_module_375, x_main_module_374);
-auto x_main_module_539 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_538);
-auto x_main_module_540 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_536, x_main_module_373);
-auto x_main_module_541 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_540, x_main_module_372, x_main_module_371, x_main_module_370, x_main_module_369);
-auto x_main_module_542 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_541);
-auto x_main_module_543 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_542, x_main_module_368);
-auto x_main_module_544 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_543, x_main_module_367, x_main_module_366, x_main_module_365, x_main_module_364);
-auto x_main_module_545 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_544);
-auto x_main_module_546 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_536, x_main_module_363);
-auto x_main_module_547 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_546, x_main_module_362, x_main_module_361, x_main_module_360, x_main_module_359);
-auto x_main_module_548 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_547);
-auto x_main_module_549 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_548, x_main_module_358);
-auto x_main_module_550 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_549, x_main_module_357, x_main_module_356, x_main_module_355, x_main_module_354);
-auto x_main_module_551 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_550);
-auto x_main_module_552 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_551, x_main_module_353);
-auto x_main_module_553 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_552, x_main_module_352, x_main_module_351, x_main_module_350, x_main_module_349);
-auto x_main_module_554 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_553);
-auto x_main_module_555 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_536);
-auto x_main_module_556 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_555, x_main_module_348);
-auto x_main_module_557 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_556, x_main_module_347, x_main_module_346, x_main_module_345, x_main_module_344);
-auto x_main_module_558 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_557);
-auto x_main_module_559 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_539, x_main_module_545, x_main_module_554, x_main_module_558);
-auto x_main_module_560 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_559, x_main_module_343);
-auto x_main_module_561 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_560, x_main_module_342, x_main_module_341, x_main_module_340, x_main_module_339);
-auto x_main_module_562 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_561);
-auto x_main_module_563 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_559, x_main_module_338);
-auto x_main_module_564 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_563, x_main_module_337, x_main_module_336, x_main_module_335, x_main_module_334);
-auto x_main_module_565 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_564);
-auto x_main_module_566 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_565, x_main_module_333);
-auto x_main_module_567 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_566, x_main_module_332, x_main_module_331, x_main_module_330, x_main_module_329);
-auto x_main_module_568 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_567);
-auto x_main_module_569 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_568, x_main_module_328);
-auto x_main_module_570 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_569, x_main_module_327, x_main_module_326, x_main_module_325, x_main_module_324);
-auto x_main_module_571 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_570);
-auto x_main_module_572 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_559);
-auto x_main_module_573 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_562, x_main_module_571, x_main_module_572);
-auto x_main_module_574 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_573, x_main_module_323);
-auto x_main_module_575 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_574, x_main_module_322, x_main_module_321, x_main_module_320, x_main_module_319);
-auto x_main_module_576 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_575);
-auto x_main_module_577 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_573, x_main_module_318);
-auto x_main_module_578 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_577, x_main_module_317, x_main_module_316, x_main_module_315, x_main_module_314);
-auto x_main_module_579 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_578);
-auto x_main_module_580 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_579, x_main_module_313);
-auto x_main_module_581 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_580, x_main_module_312, x_main_module_311, x_main_module_310, x_main_module_309);
-auto x_main_module_582 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_581);
-auto x_main_module_583 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_582, x_main_module_308);
-auto x_main_module_584 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_583, x_main_module_307, x_main_module_306, x_main_module_305, x_main_module_304);
-auto x_main_module_585 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_584);
-auto x_main_module_586 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_573, x_main_module_303);
-auto x_main_module_587 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_586, x_main_module_302, x_main_module_301, x_main_module_300, x_main_module_299);
-auto x_main_module_588 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_587);
-auto x_main_module_589 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_588, x_main_module_298);
-auto x_main_module_590 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_589, x_main_module_297, x_main_module_296, x_main_module_295, x_main_module_294);
-auto x_main_module_591 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_590);
-auto x_main_module_592 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_591, x_main_module_293);
-auto x_main_module_593 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_592, x_main_module_292, x_main_module_291, x_main_module_290, x_main_module_289);
-auto x_main_module_594 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_593);
-auto x_main_module_595 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_594, x_main_module_288);
-auto x_main_module_596 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_595, x_main_module_287, x_main_module_286, x_main_module_285, x_main_module_284);
-auto x_main_module_597 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_596);
-auto x_main_module_598 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_597, x_main_module_283);
-auto x_main_module_599 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_598, x_main_module_282, x_main_module_281, x_main_module_280, x_main_module_279);
-auto x_main_module_600 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_599);
-auto x_main_module_601 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_573);
-auto x_main_module_602 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_601, x_main_module_278);
-auto x_main_module_603 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_602, x_main_module_277, x_main_module_276, x_main_module_275, x_main_module_274);
-auto x_main_module_604 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_603);
-auto x_main_module_605 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_576, x_main_module_585, x_main_module_600, x_main_module_604);
-auto x_main_module_606 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_605, x_main_module_273);
-auto x_main_module_607 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_606, x_main_module_272, x_main_module_271, x_main_module_270, x_main_module_269);
-auto x_main_module_608 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_607);
-auto x_main_module_609 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_605, x_main_module_268);
-auto x_main_module_610 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_609, x_main_module_267, x_main_module_266, x_main_module_265, x_main_module_264);
-auto x_main_module_611 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_610);
-auto x_main_module_612 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_611, x_main_module_263);
-auto x_main_module_613 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_612, x_main_module_262, x_main_module_261, x_main_module_260, x_main_module_259);
-auto x_main_module_614 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_613);
-auto x_main_module_615 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_614, x_main_module_258);
-auto x_main_module_616 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_615, x_main_module_257, x_main_module_256, x_main_module_255, x_main_module_254);
-auto x_main_module_617 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_616);
-auto x_main_module_618 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_605, x_main_module_253);
-auto x_main_module_619 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_618, x_main_module_252, x_main_module_251, x_main_module_250, x_main_module_249);
-auto x_main_module_620 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_619);
-auto x_main_module_621 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_620, x_main_module_248);
-auto x_main_module_622 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_621, x_main_module_247, x_main_module_246, x_main_module_245, x_main_module_244);
-auto x_main_module_623 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_622);
-auto x_main_module_624 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_623, x_main_module_243);
-auto x_main_module_625 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_624, x_main_module_242, x_main_module_241, x_main_module_240, x_main_module_239);
-auto x_main_module_626 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_625);
-auto x_main_module_627 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_626, x_main_module_238);
-auto x_main_module_628 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_627, x_main_module_237, x_main_module_236, x_main_module_235, x_main_module_234);
-auto x_main_module_629 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_628);
-auto x_main_module_630 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_629, x_main_module_233);
-auto x_main_module_631 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_630, x_main_module_232, x_main_module_231, x_main_module_230, x_main_module_229);
-auto x_main_module_632 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_631);
-auto x_main_module_633 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_605);
-auto x_main_module_634 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_633, x_main_module_228);
-auto x_main_module_635 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_634, x_main_module_227, x_main_module_226, x_main_module_225, x_main_module_224);
-auto x_main_module_636 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_635);
-auto x_main_module_637 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_608, x_main_module_617, x_main_module_632, x_main_module_636);
-auto x_main_module_638 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_637, x_main_module_223);
-auto x_main_module_639 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_638, x_main_module_222, x_main_module_221, x_main_module_220, x_main_module_219);
-auto x_main_module_640 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_639);
-auto x_main_module_641 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_637, x_main_module_218);
-auto x_main_module_642 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_641, x_main_module_217, x_main_module_216, x_main_module_215, x_main_module_214);
-auto x_main_module_643 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_642);
-auto x_main_module_644 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_643, x_main_module_213);
-auto x_main_module_645 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_644, x_main_module_212, x_main_module_211, x_main_module_210, x_main_module_209);
-auto x_main_module_646 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_645);
-auto x_main_module_647 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_646, x_main_module_208);
-auto x_main_module_648 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_647, x_main_module_207, x_main_module_206, x_main_module_205, x_main_module_204);
-auto x_main_module_649 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_648);
-auto x_main_module_650 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_637, x_main_module_203);
-auto x_main_module_651 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_650, x_main_module_202, x_main_module_201, x_main_module_200, x_main_module_199);
-auto x_main_module_652 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_651);
-auto x_main_module_653 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_652, x_main_module_198);
-auto x_main_module_654 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_653, x_main_module_197, x_main_module_196, x_main_module_195, x_main_module_194);
-auto x_main_module_655 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_654);
-auto x_main_module_656 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_655, x_main_module_193);
-auto x_main_module_657 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_656, x_main_module_192, x_main_module_191, x_main_module_190, x_main_module_189);
-auto x_main_module_658 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_657);
-auto x_main_module_659 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_658, x_main_module_188);
-auto x_main_module_660 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_659, x_main_module_187, x_main_module_186, x_main_module_185, x_main_module_184);
-auto x_main_module_661 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_660);
-auto x_main_module_662 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_661, x_main_module_183);
-auto x_main_module_663 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_662, x_main_module_182, x_main_module_181, x_main_module_180, x_main_module_179);
-auto x_main_module_664 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_663);
-auto x_main_module_665 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_637);
-auto x_main_module_666 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_665, x_main_module_178);
-auto x_main_module_667 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_666, x_main_module_177, x_main_module_176, x_main_module_175, x_main_module_174);
-auto x_main_module_668 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_667);
-auto x_main_module_669 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_640, x_main_module_649, x_main_module_664, x_main_module_668);
-auto x_main_module_670 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_669, x_main_module_173);
-auto x_main_module_671 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_670, x_main_module_172, x_main_module_171, x_main_module_170, x_main_module_169);
-auto x_main_module_672 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_671);
-auto x_main_module_673 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_669, x_main_module_168);
-auto x_main_module_674 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_673, x_main_module_167, x_main_module_166, x_main_module_165, x_main_module_164);
-auto x_main_module_675 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_674);
-auto x_main_module_676 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_675, x_main_module_163);
-auto x_main_module_677 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_676, x_main_module_162, x_main_module_161, x_main_module_160, x_main_module_159);
-auto x_main_module_678 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_677);
-auto x_main_module_679 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_678, x_main_module_158);
-auto x_main_module_680 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_679, x_main_module_157, x_main_module_156, x_main_module_155, x_main_module_154);
-auto x_main_module_681 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_680);
-auto x_main_module_682 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_669, x_main_module_153);
-auto x_main_module_683 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_682, x_main_module_152, x_main_module_151, x_main_module_150, x_main_module_149);
-auto x_main_module_684 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_683);
-auto x_main_module_685 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_684, x_main_module_148);
-auto x_main_module_686 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_685, x_main_module_147, x_main_module_146, x_main_module_145, x_main_module_144);
-auto x_main_module_687 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_686);
-auto x_main_module_688 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_687, x_main_module_143);
-auto x_main_module_689 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_688, x_main_module_142, x_main_module_141, x_main_module_140, x_main_module_139);
-auto x_main_module_690 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_689);
-auto x_main_module_691 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_690, x_main_module_138);
-auto x_main_module_692 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_691, x_main_module_137, x_main_module_136, x_main_module_135, x_main_module_134);
-auto x_main_module_693 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_692);
-auto x_main_module_694 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_693, x_main_module_133);
-auto x_main_module_695 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_694, x_main_module_132, x_main_module_131, x_main_module_130, x_main_module_129);
-auto x_main_module_696 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_695);
-auto x_main_module_697 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_669);
-auto x_main_module_698 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_697, x_main_module_128);
-auto x_main_module_699 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_698, x_main_module_127, x_main_module_126, x_main_module_125, x_main_module_124);
-auto x_main_module_700 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_699);
-auto x_main_module_701 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_672, x_main_module_681, x_main_module_696, x_main_module_700);
-auto x_main_module_702 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_701, x_main_module_123);
-auto x_main_module_703 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_702, x_main_module_122, x_main_module_121, x_main_module_120, x_main_module_119);
-auto x_main_module_704 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_703);
-auto x_main_module_705 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_704, x_main_module_118);
-auto x_main_module_706 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_705, x_main_module_117, x_main_module_116, x_main_module_115, x_main_module_114);
-auto x_main_module_707 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_706);
-auto x_main_module_708 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_701, x_main_module_113);
-auto x_main_module_709 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_708, x_main_module_112, x_main_module_111, x_main_module_110, x_main_module_109);
-auto x_main_module_710 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_709);
-auto x_main_module_711 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_710, x_main_module_108);
-auto x_main_module_712 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_711, x_main_module_107, x_main_module_106, x_main_module_105, x_main_module_104);
-auto x_main_module_713 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_712);
-auto x_main_module_714 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_713, x_main_module_103);
-auto x_main_module_715 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_714, x_main_module_102, x_main_module_101, x_main_module_100, x_main_module_99);
-auto x_main_module_716 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_715);
-auto x_main_module_717 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_716, x_main_module_98);
-auto x_main_module_718 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_717, x_main_module_97, x_main_module_96, x_main_module_95, x_main_module_94);
-auto x_main_module_719 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_718);
-auto x_main_module_720 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_701);
-auto x_main_module_721 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_707, x_main_module_719, x_main_module_720);
-auto x_main_module_722 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_721, x_main_module_93);
-auto x_main_module_723 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_722, x_main_module_92, x_main_module_91, x_main_module_90, x_main_module_89);
-auto x_main_module_724 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_723);
-auto x_main_module_725 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_721, x_main_module_88);
-auto x_main_module_726 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_725, x_main_module_87, x_main_module_86, x_main_module_85, x_main_module_84);
-auto x_main_module_727 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_726);
-auto x_main_module_728 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_727, x_main_module_83);
-auto x_main_module_729 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_728, x_main_module_82, x_main_module_81, x_main_module_80, x_main_module_79);
-auto x_main_module_730 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_729);
-auto x_main_module_731 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_727, x_main_module_78);
-auto x_main_module_732 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_731, x_main_module_77, x_main_module_76, x_main_module_75, x_main_module_74);
-auto x_main_module_733 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_732);
-auto x_main_module_734 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_730, x_main_module_733);
-auto x_main_module_735 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_721, x_main_module_73);
-auto x_main_module_736 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_735, x_main_module_72, x_main_module_71, x_main_module_70, x_main_module_69);
-auto x_main_module_737 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_736);
-auto x_main_module_738 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_737, x_main_module_68);
-auto x_main_module_739 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_738, x_main_module_67, x_main_module_66, x_main_module_65, x_main_module_64);
-auto x_main_module_740 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_739);
-auto x_main_module_741 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_740, x_main_module_63);
-auto x_main_module_742 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_741, x_main_module_62, x_main_module_61, x_main_module_60, x_main_module_59);
-auto x_main_module_743 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_742);
-auto x_main_module_744 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_740, x_main_module_58);
-auto x_main_module_745 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_744, x_main_module_57, x_main_module_56, x_main_module_55, x_main_module_54);
-auto x_main_module_746 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_745);
-auto x_main_module_747 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_743, x_main_module_746);
-auto x_main_module_748 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_721);
-auto x_main_module_749 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_748, x_main_module_53);
-auto x_main_module_750 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_749, x_main_module_52, x_main_module_51, x_main_module_50, x_main_module_49);
-auto x_main_module_751 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_750);
-auto x_main_module_752 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_724, x_main_module_734, x_main_module_747, x_main_module_751);
-auto x_main_module_753 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_752, x_main_module_48);
-auto x_main_module_754 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_753, x_main_module_47, x_main_module_46, x_main_module_45, x_main_module_44);
-auto x_main_module_755 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_754);
-auto x_main_module_756 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_752, x_main_module_43);
-auto x_main_module_757 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_756, x_main_module_42, x_main_module_41, x_main_module_40, x_main_module_39);
-auto x_main_module_758 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_757);
-auto x_main_module_759 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_758, x_main_module_38);
-auto x_main_module_760 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_759, x_main_module_37, x_main_module_36, x_main_module_35, x_main_module_34);
-auto x_main_module_761 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_760);
-auto x_main_module_762 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_758, x_main_module_33);
-auto x_main_module_763 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_762, x_main_module_32, x_main_module_31, x_main_module_30, x_main_module_29);
-auto x_main_module_764 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_763);
-auto x_main_module_765 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_761, x_main_module_764);
-auto x_main_module_766 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_752, x_main_module_28);
-auto x_main_module_767 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_766, x_main_module_27, x_main_module_26, x_main_module_25, x_main_module_24);
-auto x_main_module_768 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_767);
-auto x_main_module_769 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_768, x_main_module_23);
-auto x_main_module_770 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_769, x_main_module_22, x_main_module_21, x_main_module_20, x_main_module_19);
-auto x_main_module_771 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_770);
-auto x_main_module_772 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_771, x_main_module_18);
-auto x_main_module_773 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_772, x_main_module_17, x_main_module_16, x_main_module_15, x_main_module_14);
-auto x_main_module_774 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_773);
-auto x_main_module_775 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_771, x_main_module_13);
-auto x_main_module_776 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_775, x_main_module_12, x_main_module_11, x_main_module_10, x_main_module_9);
-auto x_main_module_777 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_776);
-auto x_main_module_778 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_774, x_main_module_777);
-auto x_main_module_779 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_752);
-auto x_main_module_780 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_779, x_main_module_8);
-auto x_main_module_781 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_780, x_main_module_7, x_main_module_6, x_main_module_5, x_main_module_4);
-auto x_main_module_782 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_781);
-auto x_main_module_783 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_755, x_main_module_765, x_main_module_778, x_main_module_782);
-auto x_main_module_784 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[8,8],\"lp_order\":2,\"mode\":0,\"padding\":[0,0,0,0],\"stride\":[8,8]}")), x_main_module_783);
-auto x_main_module_785 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_784);
-auto x_main_module_786 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), x_main_module_785);
-auto x_main_module_787 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_3);
-auto x_main_module_788 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_786, x_main_module_787);
-auto x_main_module_789 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_2);
-auto x_main_module_790 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_0);
-auto x_main_module_791 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_789, x_main_module_790);
-auto x_main_module_792 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_788, x_main_module_791);
-mmain->add_return({x_main_module_792});
-
+    migraphx::module_ref mmain = p.get_main_module();
+    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+    auto x_0                   = mmain->add_parameter(
+        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 299, 299}});
+    auto x_main_module_2 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
+    auto x_main_module_3 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
+    auto x_main_module_4 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 3)));
+    auto x_main_module_5 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 4));
+    auto x_main_module_6 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 5));
+    auto x_main_module_7  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 6)));
+    auto x_main_module_8  = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 2048, 1, 1}}, 7));
+    auto x_main_module_9  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 8)));
+    auto x_main_module_10 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 9));
+    auto x_main_module_11 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 10));
+    auto x_main_module_12 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 11)));
+    auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 12));
+    auto x_main_module_14 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13)));
+    auto x_main_module_15 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 14));
+    auto x_main_module_16 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 15));
+    auto x_main_module_17 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 16)));
+    auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 17));
+    auto x_main_module_19 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 18)));
+    auto x_main_module_20 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 19));
+    auto x_main_module_21 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 20));
+    auto x_main_module_22 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 21)));
+    auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 22));
+    auto x_main_module_24 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 23)));
+    auto x_main_module_25 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 24));
+    auto x_main_module_26 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 25));
+    auto x_main_module_27 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 26)));
+    auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {448, 2048, 1, 1}}, 27));
+    auto x_main_module_29 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 28)));
+    auto x_main_module_30 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 29)));
+    auto x_main_module_31 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 30));
+    auto x_main_module_32 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 31)));
+    auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 32));
+    auto x_main_module_34 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 33)));
+    auto x_main_module_35 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 34)));
+    auto x_main_module_36 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 35));
+    auto x_main_module_37 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 36)));
+    auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 37));
+    auto x_main_module_39 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 38)));
+    auto x_main_module_40 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 39));
+    auto x_main_module_41 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 40));
+    auto x_main_module_42 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 41)));
+    auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 2048, 1, 1}}, 42));
+    auto x_main_module_44 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 43)));
+    auto x_main_module_45 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 44));
+    auto x_main_module_46 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 45));
+    auto x_main_module_47 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 46)));
+    auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {320, 2048, 1, 1}}, 47));
+    auto x_main_module_49 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 48)));
+    auto x_main_module_50 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 49));
+    auto x_main_module_51 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 50));
+    auto x_main_module_52 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 51)));
+    auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 1280, 1, 1}}, 52));
+    auto x_main_module_54 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 53)));
+    auto x_main_module_55 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 54));
+    auto x_main_module_56 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 55));
+    auto x_main_module_57 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 56)));
+    auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 57));
+    auto x_main_module_59 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 58)));
+    auto x_main_module_60 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 59));
+    auto x_main_module_61 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 60));
+    auto x_main_module_62 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 61)));
+    auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 62));
+    auto x_main_module_64 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 63)));
+    auto x_main_module_65 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 64));
+    auto x_main_module_66 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 65));
+    auto x_main_module_67 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 66)));
+    auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 67));
+    auto x_main_module_69 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 68)));
+    auto x_main_module_70 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 69));
+    auto x_main_module_71 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 70));
+    auto x_main_module_72 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 71)));
+    auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {448, 1280, 1, 1}}, 72));
+    auto x_main_module_74 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 73)));
+    auto x_main_module_75 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 74));
+    auto x_main_module_76 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 75));
+    auto x_main_module_77 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 76)));
+    auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 77));
+    auto x_main_module_79 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 78)));
+    auto x_main_module_80 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 79));
+    auto x_main_module_81 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 80));
+    auto x_main_module_82 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 81)));
+    auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 82));
+    auto x_main_module_84 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 83)));
+    auto x_main_module_85 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 84));
+    auto x_main_module_86 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 85));
+    auto x_main_module_87 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 86)));
+    auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 1280, 1, 1}}, 87));
+    auto x_main_module_89 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 88)));
+    auto x_main_module_90 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 89));
+    auto x_main_module_91 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 90));
+    auto x_main_module_92 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 91)));
+    auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {320, 1280, 1, 1}}, 92));
+    auto x_main_module_94 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 93)));
+    auto x_main_module_95 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 94));
+    auto x_main_module_96 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 95));
+    auto x_main_module_97  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 96)));
+    auto x_main_module_98  = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 3, 3}}, 97));
+    auto x_main_module_99  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 98)));
+    auto x_main_module_100 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 99));
+    auto x_main_module_101 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 100));
+    auto x_main_module_102 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 101)));
+    auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 102));
+    auto x_main_module_104 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 103)));
+    auto x_main_module_105 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 104));
+    auto x_main_module_106 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 105));
+    auto x_main_module_107 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 106)));
+    auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 107));
+    auto x_main_module_109 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 108)));
+    auto x_main_module_110 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 109));
+    auto x_main_module_111 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 110));
+    auto x_main_module_112 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 111)));
+    auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 112));
+    auto x_main_module_114 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 113)));
+    auto x_main_module_115 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 114));
+    auto x_main_module_116 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 115));
+    auto x_main_module_117 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 116)));
+    auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {320, 192, 3, 3}}, 117));
+    auto x_main_module_119 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 118)));
+    auto x_main_module_120 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 119));
+    auto x_main_module_121 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 120));
+    auto x_main_module_122 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 121)));
+    auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 122));
+    auto x_main_module_124 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 123)));
+    auto x_main_module_125 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 124));
+    auto x_main_module_126 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 125));
+    auto x_main_module_127 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 126)));
+    auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 127));
+    auto x_main_module_129 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 128)));
+    auto x_main_module_130 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 129));
+    auto x_main_module_131 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 130));
+    auto x_main_module_132 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 131)));
+    auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 132));
+    auto x_main_module_134 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 133)));
+    auto x_main_module_135 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 134));
+    auto x_main_module_136 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 135));
+    auto x_main_module_137 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 136)));
+    auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 137));
+    auto x_main_module_139 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 138)));
+    auto x_main_module_140 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 139));
+    auto x_main_module_141 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 140));
+    auto x_main_module_142 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 141)));
+    auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 142));
+    auto x_main_module_144 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 143)));
+    auto x_main_module_145 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 144));
+    auto x_main_module_146 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 145));
+    auto x_main_module_147 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 146)));
+    auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 147));
+    auto x_main_module_149 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 148)));
+    auto x_main_module_150 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 149));
+    auto x_main_module_151 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 150));
+    auto x_main_module_152 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 151)));
+    auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 152));
+    auto x_main_module_154 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 153)));
+    auto x_main_module_155 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 154));
+    auto x_main_module_156 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 155));
+    auto x_main_module_157 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 156)));
+    auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 157));
+    auto x_main_module_159 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 158)));
+    auto x_main_module_160 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 159));
+    auto x_main_module_161 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 160));
+    auto x_main_module_162 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 161)));
+    auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 162));
+    auto x_main_module_164 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 163)));
+    auto x_main_module_165 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 164));
+    auto x_main_module_166 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 165));
+    auto x_main_module_167 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 166)));
+    auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 167));
+    auto x_main_module_169 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 168)));
+    auto x_main_module_170 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 169));
+    auto x_main_module_171 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 170));
+    auto x_main_module_172 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 171)));
+    auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 172));
+    auto x_main_module_174 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 173)));
+    auto x_main_module_175 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 174));
+    auto x_main_module_176 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 175));
+    auto x_main_module_177 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 176)));
+    auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 177));
+    auto x_main_module_179 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 178)));
+    auto x_main_module_180 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 179));
+    auto x_main_module_181 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 180));
+    auto x_main_module_182 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 181)));
+    auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 182));
+    auto x_main_module_184 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 183)));
+    auto x_main_module_185 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 184));
+    auto x_main_module_186 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 185));
+    auto x_main_module_187 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 186)));
+    auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 187));
+    auto x_main_module_189 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 188)));
+    auto x_main_module_190 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 189));
+    auto x_main_module_191 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 190));
+    auto x_main_module_192 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 191)));
+    auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 192));
+    auto x_main_module_194 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 193)));
+    auto x_main_module_195 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 194));
+    auto x_main_module_196 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 195));
+    auto x_main_module_197 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 196)));
+    auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 197));
+    auto x_main_module_199 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 198)));
+    auto x_main_module_200 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 199));
+    auto x_main_module_201 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 200));
+    auto x_main_module_202 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 201)));
+    auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 202));
+    auto x_main_module_204 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 203)));
+    auto x_main_module_205 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 204));
+    auto x_main_module_206 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 205));
+    auto x_main_module_207 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 206)));
+    auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 207));
+    auto x_main_module_209 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 208)));
+    auto x_main_module_210 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 209));
+    auto x_main_module_211 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 210));
+    auto x_main_module_212 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 211)));
+    auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 212));
+    auto x_main_module_214 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 213)));
+    auto x_main_module_215 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 214));
+    auto x_main_module_216 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 215));
+    auto x_main_module_217 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 216)));
+    auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 217));
+    auto x_main_module_219 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 218)));
+    auto x_main_module_220 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 219));
+    auto x_main_module_221 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 220));
+    auto x_main_module_222 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 221)));
+    auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 222));
+    auto x_main_module_224 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 223)));
+    auto x_main_module_225 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 224));
+    auto x_main_module_226 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 225));
+    auto x_main_module_227 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 226)));
+    auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 227));
+    auto x_main_module_229 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 228)));
+    auto x_main_module_230 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 229));
+    auto x_main_module_231 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 230));
+    auto x_main_module_232 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 231)));
+    auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 232));
+    auto x_main_module_234 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 233)));
+    auto x_main_module_235 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 234));
+    auto x_main_module_236 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 235));
+    auto x_main_module_237 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 236)));
+    auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 237));
+    auto x_main_module_239 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 238)));
+    auto x_main_module_240 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 239));
+    auto x_main_module_241 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 240));
+    auto x_main_module_242 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 241)));
+    auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 242));
+    auto x_main_module_244 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 243)));
+    auto x_main_module_245 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 244));
+    auto x_main_module_246 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 245));
+    auto x_main_module_247 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 246)));
+    auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 247));
+    auto x_main_module_249 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 248)));
+    auto x_main_module_250 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 249));
+    auto x_main_module_251 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 250));
+    auto x_main_module_252 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 251)));
+    auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 252));
+    auto x_main_module_254 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 253)));
+    auto x_main_module_255 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 254));
+    auto x_main_module_256 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 255));
+    auto x_main_module_257 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 256)));
+    auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 257));
+    auto x_main_module_259 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 258)));
+    auto x_main_module_260 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 259));
+    auto x_main_module_261 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 260));
+    auto x_main_module_262 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 261)));
+    auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 262));
+    auto x_main_module_264 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 263)));
+    auto x_main_module_265 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 264));
+    auto x_main_module_266 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 265));
+    auto x_main_module_267 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 266)));
+    auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 267));
+    auto x_main_module_269 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 268)));
+    auto x_main_module_270 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 269));
+    auto x_main_module_271 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 270));
+    auto x_main_module_272 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 271)));
+    auto x_main_module_273 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 272));
+    auto x_main_module_274 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 273)));
+    auto x_main_module_275 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 274));
+    auto x_main_module_276 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 275));
+    auto x_main_module_277 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 276)));
+    auto x_main_module_278 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 277));
+    auto x_main_module_279 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 278)));
+    auto x_main_module_280 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 279));
+    auto x_main_module_281 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 280));
+    auto x_main_module_282 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 281)));
+    auto x_main_module_283 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 128, 1, 7}}, 282));
+    auto x_main_module_284 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 283)));
+    auto x_main_module_285 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 284));
+    auto x_main_module_286 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 285));
+    auto x_main_module_287 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 286)));
+    auto x_main_module_288 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 287));
+    auto x_main_module_289 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 288)));
+    auto x_main_module_290 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 289));
+    auto x_main_module_291 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 290));
+    auto x_main_module_292 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 291)));
+    auto x_main_module_293 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 292));
+    auto x_main_module_294 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 293)));
+    auto x_main_module_295 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 294));
+    auto x_main_module_296 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 295));
+    auto x_main_module_297 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 296)));
+    auto x_main_module_298 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 297));
+    auto x_main_module_299 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 298)));
+    auto x_main_module_300 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 299));
+    auto x_main_module_301 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 300));
+    auto x_main_module_302 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 301)));
+    auto x_main_module_303 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 302));
+    auto x_main_module_304 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 303)));
+    auto x_main_module_305 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 304));
+    auto x_main_module_306 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 305));
+    auto x_main_module_307 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 306)));
+    auto x_main_module_308 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 128, 7, 1}}, 307));
+    auto x_main_module_309 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 308)));
+    auto x_main_module_310 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 309));
+    auto x_main_module_311 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 310));
+    auto x_main_module_312 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 311)));
+    auto x_main_module_313 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 312));
+    auto x_main_module_314 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 313)));
+    auto x_main_module_315 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 314));
+    auto x_main_module_316 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 315));
+    auto x_main_module_317 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 316)));
+    auto x_main_module_318 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 317));
+    auto x_main_module_319 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 318)));
+    auto x_main_module_320 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 319));
+    auto x_main_module_321 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 320));
+    auto x_main_module_322 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 321)));
+    auto x_main_module_323 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 322));
+    auto x_main_module_324 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 323)));
+    auto x_main_module_325 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 324));
+    auto x_main_module_326 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 325));
+    auto x_main_module_327 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 326)));
+    auto x_main_module_328 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 327));
+    auto x_main_module_329 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 328)));
+    auto x_main_module_330 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 329));
+    auto x_main_module_331 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 330));
+    auto x_main_module_332 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 331)));
+    auto x_main_module_333 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 332));
+    auto x_main_module_334 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 333)));
+    auto x_main_module_335 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 334));
+    auto x_main_module_336 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 335));
+    auto x_main_module_337 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 336)));
+    auto x_main_module_338 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 337));
+    auto x_main_module_339 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 338)));
+    auto x_main_module_340 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 339));
+    auto x_main_module_341 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 340));
+    auto x_main_module_342 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 341)));
+    auto x_main_module_343 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 288, 3, 3}}, 342));
+    auto x_main_module_344 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 343)));
+    auto x_main_module_345 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 344));
+    auto x_main_module_346 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 345));
+    auto x_main_module_347 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 346)));
+    auto x_main_module_348 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 347));
+    auto x_main_module_349 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 348)));
+    auto x_main_module_350 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 349));
+    auto x_main_module_351 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 350));
+    auto x_main_module_352 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 351)));
+    auto x_main_module_353 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 352));
+    auto x_main_module_354 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 353)));
+    auto x_main_module_355 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 354));
+    auto x_main_module_356 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 355));
+    auto x_main_module_357 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 356)));
+    auto x_main_module_358 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 357));
+    auto x_main_module_359 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 358)));
+    auto x_main_module_360 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 359));
+    auto x_main_module_361 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 360));
+    auto x_main_module_362 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 361)));
+    auto x_main_module_363 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 362));
+    auto x_main_module_364 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 363)));
+    auto x_main_module_365 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 364));
+    auto x_main_module_366 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 365));
+    auto x_main_module_367 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 366)));
+    auto x_main_module_368 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 367));
+    auto x_main_module_369 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 368)));
+    auto x_main_module_370 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 369));
+    auto x_main_module_371 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 370));
+    auto x_main_module_372 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 371)));
+    auto x_main_module_373 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {48, 288, 1, 1}}, 372));
+    auto x_main_module_374 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 373)));
+    auto x_main_module_375 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 374));
+    auto x_main_module_376 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 375));
+    auto x_main_module_377 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 376)));
+    auto x_main_module_378 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 377));
+    auto x_main_module_379 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 378)));
+    auto x_main_module_380 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 379));
+    auto x_main_module_381 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 380));
+    auto x_main_module_382 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 381)));
+    auto x_main_module_383 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 382));
+    auto x_main_module_384 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 383)));
+    auto x_main_module_385 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 384));
+    auto x_main_module_386 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 385));
+    auto x_main_module_387 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 386)));
+    auto x_main_module_388 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 387));
+    auto x_main_module_389 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 388)));
+    auto x_main_module_390 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 389));
+    auto x_main_module_391 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 390));
+    auto x_main_module_392 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 391)));
+    auto x_main_module_393 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 392));
+    auto x_main_module_394 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 393)));
+    auto x_main_module_395 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 394));
+    auto x_main_module_396 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 395));
+    auto x_main_module_397 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 396)));
+    auto x_main_module_398 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 397));
+    auto x_main_module_399 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 398)));
+    auto x_main_module_400 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 399));
+    auto x_main_module_401 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 400));
+    auto x_main_module_402 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 401)));
+    auto x_main_module_403 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 402));
+    auto x_main_module_404 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 403)));
+    auto x_main_module_405 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 404));
+    auto x_main_module_406 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 405));
+    auto x_main_module_407 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 406)));
+    auto x_main_module_408 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {48, 256, 1, 1}}, 407));
+    auto x_main_module_409 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 408)));
+    auto x_main_module_410 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 409));
+    auto x_main_module_411 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 410));
+    auto x_main_module_412 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 411)));
+    auto x_main_module_413 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 412));
+    auto x_main_module_414 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 413)));
+    auto x_main_module_415 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 414));
+    auto x_main_module_416 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 415));
+    auto x_main_module_417 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 416)));
+    auto x_main_module_418 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {32, 192, 1, 1}}, 417));
+    auto x_main_module_419 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 418)));
+    auto x_main_module_420 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 419));
+    auto x_main_module_421 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 420));
+    auto x_main_module_422 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 421)));
+    auto x_main_module_423 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 422));
+    auto x_main_module_424 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 423)));
+    auto x_main_module_425 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 424));
+    auto x_main_module_426 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 425));
+    auto x_main_module_427 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 426)));
+    auto x_main_module_428 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 427));
+    auto x_main_module_429 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 428)));
+    auto x_main_module_430 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 429));
+    auto x_main_module_431 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 430));
+    auto x_main_module_432 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 431)));
+    auto x_main_module_433 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 432));
+    auto x_main_module_434 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 433)));
+    auto x_main_module_435 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 434));
+    auto x_main_module_436 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 435));
+    auto x_main_module_437 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 436)));
+    auto x_main_module_438 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 437));
+    auto x_main_module_439 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 438)));
+    auto x_main_module_440 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 439));
+    auto x_main_module_441 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 440));
+    auto x_main_module_442 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 441)));
+    auto x_main_module_443 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {48, 192, 1, 1}}, 442));
+    auto x_main_module_444 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 443)));
+    auto x_main_module_445 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 444));
+    auto x_main_module_446 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 445));
+    auto x_main_module_447 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 446)));
+    auto x_main_module_448 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 447));
+    auto x_main_module_449 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 448)));
+    auto x_main_module_450 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 449));
+    auto x_main_module_451 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 450));
+    auto x_main_module_452 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 451)));
+    auto x_main_module_453 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 80, 3, 3}}, 452));
+    auto x_main_module_454 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 453)));
+    auto x_main_module_455 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 454));
+    auto x_main_module_456 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 455));
+    auto x_main_module_457 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 456)));
+    auto x_main_module_458 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {80, 64, 1, 1}}, 457));
+    auto x_main_module_459 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 458)));
+    auto x_main_module_460 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 459));
+    auto x_main_module_461 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 460));
+    auto x_main_module_462 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 461)));
+    auto x_main_module_463 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 32, 3, 3}}, 462));
+    auto x_main_module_464 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 463)));
+    auto x_main_module_465 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 464));
+    auto x_main_module_466 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 465));
+    auto x_main_module_467 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 466)));
+    auto x_main_module_468 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {32, 32, 3, 3}}, 467));
+    auto x_main_module_469 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 468)));
+    auto x_main_module_470 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 469));
+    auto x_main_module_471 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 470));
+    auto x_main_module_472 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 471)));
+    auto x_main_module_473 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {32, 3, 3, 3}}, 472));
+    auto x_main_module_474 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_0,
+        x_main_module_473);
+    auto x_main_module_475 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_474,
+        x_main_module_472,
+        x_main_module_471,
+        x_main_module_470,
+        x_main_module_469);
+    auto x_main_module_476 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_475);
+    auto x_main_module_477 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_476,
+        x_main_module_468);
+    auto x_main_module_478 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_477,
+        x_main_module_467,
+        x_main_module_466,
+        x_main_module_465,
+        x_main_module_464);
+    auto x_main_module_479 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_478);
+    auto x_main_module_480 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_479,
+        x_main_module_463);
+    auto x_main_module_481 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_480,
+        x_main_module_462,
+        x_main_module_461,
+        x_main_module_460,
+        x_main_module_459);
+    auto x_main_module_482 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_481);
+    auto x_main_module_483 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        x_main_module_482);
+    auto x_main_module_484 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_483,
+        x_main_module_458);
+    auto x_main_module_485 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_484,
+        x_main_module_457,
+        x_main_module_456,
+        x_main_module_455,
+        x_main_module_454);
+    auto x_main_module_486 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_485);
+    auto x_main_module_487 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_486,
+        x_main_module_453);
+    auto x_main_module_488 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_487,
+        x_main_module_452,
+        x_main_module_451,
+        x_main_module_450,
+        x_main_module_449);
+    auto x_main_module_489 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_488);
+    auto x_main_module_490 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        x_main_module_489);
+    auto x_main_module_491 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_490,
+        x_main_module_448);
+    auto x_main_module_492 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_491,
+        x_main_module_447,
+        x_main_module_446,
+        x_main_module_445,
+        x_main_module_444);
+    auto x_main_module_493 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_492);
+    auto x_main_module_494 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_490,
+        x_main_module_443);
+    auto x_main_module_495 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_494,
+        x_main_module_442,
+        x_main_module_441,
+        x_main_module_440,
+        x_main_module_439);
+    auto x_main_module_496 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_495);
+    auto x_main_module_497 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_496,
+        x_main_module_438);
+    auto x_main_module_498 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_497,
+        x_main_module_437,
+        x_main_module_436,
+        x_main_module_435,
+        x_main_module_434);
+    auto x_main_module_499 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_498);
+    auto x_main_module_500 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_490,
+        x_main_module_433);
+    auto x_main_module_501 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_500,
+        x_main_module_432,
+        x_main_module_431,
+        x_main_module_430,
+        x_main_module_429);
+    auto x_main_module_502 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_501);
+    auto x_main_module_503 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_502,
+        x_main_module_428);
+    auto x_main_module_504 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_503,
+        x_main_module_427,
+        x_main_module_426,
+        x_main_module_425,
+        x_main_module_424);
+    auto x_main_module_505 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_504);
+    auto x_main_module_506 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_505,
+        x_main_module_423);
+    auto x_main_module_507 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_506,
+        x_main_module_422,
+        x_main_module_421,
+        x_main_module_420,
+        x_main_module_419);
+    auto x_main_module_508 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_507);
+    auto x_main_module_509 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_490);
+    auto x_main_module_510 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_509,
+        x_main_module_418);
+    auto x_main_module_511 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_510,
+        x_main_module_417,
+        x_main_module_416,
+        x_main_module_415,
+        x_main_module_414);
+    auto x_main_module_512 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_511);
+    auto x_main_module_513 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_493,
+        x_main_module_499,
+        x_main_module_508,
+        x_main_module_512);
+    auto x_main_module_514 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_513,
+        x_main_module_413);
+    auto x_main_module_515 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_514,
+        x_main_module_412,
+        x_main_module_411,
+        x_main_module_410,
+        x_main_module_409);
+    auto x_main_module_516 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_515);
+    auto x_main_module_517 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_513,
+        x_main_module_408);
+    auto x_main_module_518 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_517,
+        x_main_module_407,
+        x_main_module_406,
+        x_main_module_405,
+        x_main_module_404);
+    auto x_main_module_519 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_518);
+    auto x_main_module_520 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_519,
+        x_main_module_403);
+    auto x_main_module_521 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_520,
+        x_main_module_402,
+        x_main_module_401,
+        x_main_module_400,
+        x_main_module_399);
+    auto x_main_module_522 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_521);
+    auto x_main_module_523 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_513,
+        x_main_module_398);
+    auto x_main_module_524 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_523,
+        x_main_module_397,
+        x_main_module_396,
+        x_main_module_395,
+        x_main_module_394);
+    auto x_main_module_525 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_524);
+    auto x_main_module_526 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_525,
+        x_main_module_393);
+    auto x_main_module_527 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_526,
+        x_main_module_392,
+        x_main_module_391,
+        x_main_module_390,
+        x_main_module_389);
+    auto x_main_module_528 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_527);
+    auto x_main_module_529 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_528,
+        x_main_module_388);
+    auto x_main_module_530 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_529,
+        x_main_module_387,
+        x_main_module_386,
+        x_main_module_385,
+        x_main_module_384);
+    auto x_main_module_531 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_530);
+    auto x_main_module_532 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_513);
+    auto x_main_module_533 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_532,
+        x_main_module_383);
+    auto x_main_module_534 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_533,
+        x_main_module_382,
+        x_main_module_381,
+        x_main_module_380,
+        x_main_module_379);
+    auto x_main_module_535 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_534);
+    auto x_main_module_536 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_516,
+        x_main_module_522,
+        x_main_module_531,
+        x_main_module_535);
+    auto x_main_module_537 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_536,
+        x_main_module_378);
+    auto x_main_module_538 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_537,
+        x_main_module_377,
+        x_main_module_376,
+        x_main_module_375,
+        x_main_module_374);
+    auto x_main_module_539 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_538);
+    auto x_main_module_540 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_536,
+        x_main_module_373);
+    auto x_main_module_541 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_540,
+        x_main_module_372,
+        x_main_module_371,
+        x_main_module_370,
+        x_main_module_369);
+    auto x_main_module_542 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_541);
+    auto x_main_module_543 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_542,
+        x_main_module_368);
+    auto x_main_module_544 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_543,
+        x_main_module_367,
+        x_main_module_366,
+        x_main_module_365,
+        x_main_module_364);
+    auto x_main_module_545 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_544);
+    auto x_main_module_546 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_536,
+        x_main_module_363);
+    auto x_main_module_547 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_546,
+        x_main_module_362,
+        x_main_module_361,
+        x_main_module_360,
+        x_main_module_359);
+    auto x_main_module_548 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_547);
+    auto x_main_module_549 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_548,
+        x_main_module_358);
+    auto x_main_module_550 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_549,
+        x_main_module_357,
+        x_main_module_356,
+        x_main_module_355,
+        x_main_module_354);
+    auto x_main_module_551 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_550);
+    auto x_main_module_552 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_551,
+        x_main_module_353);
+    auto x_main_module_553 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_552,
+        x_main_module_352,
+        x_main_module_351,
+        x_main_module_350,
+        x_main_module_349);
+    auto x_main_module_554 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_553);
+    auto x_main_module_555 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_536);
+    auto x_main_module_556 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_555,
+        x_main_module_348);
+    auto x_main_module_557 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_556,
+        x_main_module_347,
+        x_main_module_346,
+        x_main_module_345,
+        x_main_module_344);
+    auto x_main_module_558 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_557);
+    auto x_main_module_559 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_539,
+        x_main_module_545,
+        x_main_module_554,
+        x_main_module_558);
+    auto x_main_module_560 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_559,
+        x_main_module_343);
+    auto x_main_module_561 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_560,
+        x_main_module_342,
+        x_main_module_341,
+        x_main_module_340,
+        x_main_module_339);
+    auto x_main_module_562 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_561);
+    auto x_main_module_563 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_559,
+        x_main_module_338);
+    auto x_main_module_564 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_563,
+        x_main_module_337,
+        x_main_module_336,
+        x_main_module_335,
+        x_main_module_334);
+    auto x_main_module_565 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_564);
+    auto x_main_module_566 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_565,
+        x_main_module_333);
+    auto x_main_module_567 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_566,
+        x_main_module_332,
+        x_main_module_331,
+        x_main_module_330,
+        x_main_module_329);
+    auto x_main_module_568 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_567);
+    auto x_main_module_569 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_568,
+        x_main_module_328);
+    auto x_main_module_570 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_569,
+        x_main_module_327,
+        x_main_module_326,
+        x_main_module_325,
+        x_main_module_324);
+    auto x_main_module_571 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_570);
+    auto x_main_module_572 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        x_main_module_559);
+    auto x_main_module_573 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_562,
+        x_main_module_571,
+        x_main_module_572);
+    auto x_main_module_574 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_573,
+        x_main_module_323);
+    auto x_main_module_575 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_574,
+        x_main_module_322,
+        x_main_module_321,
+        x_main_module_320,
+        x_main_module_319);
+    auto x_main_module_576 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_575);
+    auto x_main_module_577 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_573,
+        x_main_module_318);
+    auto x_main_module_578 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_577,
+        x_main_module_317,
+        x_main_module_316,
+        x_main_module_315,
+        x_main_module_314);
+    auto x_main_module_579 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_578);
+    auto x_main_module_580 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_579,
+        x_main_module_313);
+    auto x_main_module_581 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_580,
+        x_main_module_312,
+        x_main_module_311,
+        x_main_module_310,
+        x_main_module_309);
+    auto x_main_module_582 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_581);
+    auto x_main_module_583 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_582,
+        x_main_module_308);
+    auto x_main_module_584 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_583,
+        x_main_module_307,
+        x_main_module_306,
+        x_main_module_305,
+        x_main_module_304);
+    auto x_main_module_585 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_584);
+    auto x_main_module_586 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_573,
+        x_main_module_303);
+    auto x_main_module_587 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_586,
+        x_main_module_302,
+        x_main_module_301,
+        x_main_module_300,
+        x_main_module_299);
+    auto x_main_module_588 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_587);
+    auto x_main_module_589 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_588,
+        x_main_module_298);
+    auto x_main_module_590 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_589,
+        x_main_module_297,
+        x_main_module_296,
+        x_main_module_295,
+        x_main_module_294);
+    auto x_main_module_591 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_590);
+    auto x_main_module_592 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_591,
+        x_main_module_293);
+    auto x_main_module_593 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_592,
+        x_main_module_292,
+        x_main_module_291,
+        x_main_module_290,
+        x_main_module_289);
+    auto x_main_module_594 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_593);
+    auto x_main_module_595 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_594,
+        x_main_module_288);
+    auto x_main_module_596 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_595,
+        x_main_module_287,
+        x_main_module_286,
+        x_main_module_285,
+        x_main_module_284);
+    auto x_main_module_597 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_596);
+    auto x_main_module_598 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_597,
+        x_main_module_283);
+    auto x_main_module_599 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_598,
+        x_main_module_282,
+        x_main_module_281,
+        x_main_module_280,
+        x_main_module_279);
+    auto x_main_module_600 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_599);
+    auto x_main_module_601 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_573);
+    auto x_main_module_602 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_601,
+        x_main_module_278);
+    auto x_main_module_603 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_602,
+        x_main_module_277,
+        x_main_module_276,
+        x_main_module_275,
+        x_main_module_274);
+    auto x_main_module_604 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_603);
+    auto x_main_module_605 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_576,
+        x_main_module_585,
+        x_main_module_600,
+        x_main_module_604);
+    auto x_main_module_606 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_605,
+        x_main_module_273);
+    auto x_main_module_607 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_606,
+        x_main_module_272,
+        x_main_module_271,
+        x_main_module_270,
+        x_main_module_269);
+    auto x_main_module_608 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_607);
+    auto x_main_module_609 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_605,
+        x_main_module_268);
+    auto x_main_module_610 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_609,
+        x_main_module_267,
+        x_main_module_266,
+        x_main_module_265,
+        x_main_module_264);
+    auto x_main_module_611 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_610);
+    auto x_main_module_612 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_611,
+        x_main_module_263);
+    auto x_main_module_613 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_612,
+        x_main_module_262,
+        x_main_module_261,
+        x_main_module_260,
+        x_main_module_259);
+    auto x_main_module_614 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_613);
+    auto x_main_module_615 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_614,
+        x_main_module_258);
+    auto x_main_module_616 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_615,
+        x_main_module_257,
+        x_main_module_256,
+        x_main_module_255,
+        x_main_module_254);
+    auto x_main_module_617 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_616);
+    auto x_main_module_618 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_605,
+        x_main_module_253);
+    auto x_main_module_619 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_618,
+        x_main_module_252,
+        x_main_module_251,
+        x_main_module_250,
+        x_main_module_249);
+    auto x_main_module_620 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_619);
+    auto x_main_module_621 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_620,
+        x_main_module_248);
+    auto x_main_module_622 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_621,
+        x_main_module_247,
+        x_main_module_246,
+        x_main_module_245,
+        x_main_module_244);
+    auto x_main_module_623 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_622);
+    auto x_main_module_624 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_623,
+        x_main_module_243);
+    auto x_main_module_625 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_624,
+        x_main_module_242,
+        x_main_module_241,
+        x_main_module_240,
+        x_main_module_239);
+    auto x_main_module_626 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_625);
+    auto x_main_module_627 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_626,
+        x_main_module_238);
+    auto x_main_module_628 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_627,
+        x_main_module_237,
+        x_main_module_236,
+        x_main_module_235,
+        x_main_module_234);
+    auto x_main_module_629 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_628);
+    auto x_main_module_630 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_629,
+        x_main_module_233);
+    auto x_main_module_631 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_630,
+        x_main_module_232,
+        x_main_module_231,
+        x_main_module_230,
+        x_main_module_229);
+    auto x_main_module_632 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_631);
+    auto x_main_module_633 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_605);
+    auto x_main_module_634 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_633,
+        x_main_module_228);
+    auto x_main_module_635 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_634,
+        x_main_module_227,
+        x_main_module_226,
+        x_main_module_225,
+        x_main_module_224);
+    auto x_main_module_636 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_635);
+    auto x_main_module_637 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_608,
+        x_main_module_617,
+        x_main_module_632,
+        x_main_module_636);
+    auto x_main_module_638 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_637,
+        x_main_module_223);
+    auto x_main_module_639 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_638,
+        x_main_module_222,
+        x_main_module_221,
+        x_main_module_220,
+        x_main_module_219);
+    auto x_main_module_640 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_639);
+    auto x_main_module_641 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_637,
+        x_main_module_218);
+    auto x_main_module_642 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_641,
+        x_main_module_217,
+        x_main_module_216,
+        x_main_module_215,
+        x_main_module_214);
+    auto x_main_module_643 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_642);
+    auto x_main_module_644 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_643,
+        x_main_module_213);
+    auto x_main_module_645 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_644,
+        x_main_module_212,
+        x_main_module_211,
+        x_main_module_210,
+        x_main_module_209);
+    auto x_main_module_646 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_645);
+    auto x_main_module_647 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_646,
+        x_main_module_208);
+    auto x_main_module_648 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_647,
+        x_main_module_207,
+        x_main_module_206,
+        x_main_module_205,
+        x_main_module_204);
+    auto x_main_module_649 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_648);
+    auto x_main_module_650 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_637,
+        x_main_module_203);
+    auto x_main_module_651 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_650,
+        x_main_module_202,
+        x_main_module_201,
+        x_main_module_200,
+        x_main_module_199);
+    auto x_main_module_652 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_651);
+    auto x_main_module_653 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_652,
+        x_main_module_198);
+    auto x_main_module_654 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_653,
+        x_main_module_197,
+        x_main_module_196,
+        x_main_module_195,
+        x_main_module_194);
+    auto x_main_module_655 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_654);
+    auto x_main_module_656 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_655,
+        x_main_module_193);
+    auto x_main_module_657 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_656,
+        x_main_module_192,
+        x_main_module_191,
+        x_main_module_190,
+        x_main_module_189);
+    auto x_main_module_658 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_657);
+    auto x_main_module_659 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_658,
+        x_main_module_188);
+    auto x_main_module_660 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_659,
+        x_main_module_187,
+        x_main_module_186,
+        x_main_module_185,
+        x_main_module_184);
+    auto x_main_module_661 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_660);
+    auto x_main_module_662 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_661,
+        x_main_module_183);
+    auto x_main_module_663 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_662,
+        x_main_module_182,
+        x_main_module_181,
+        x_main_module_180,
+        x_main_module_179);
+    auto x_main_module_664 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_663);
+    auto x_main_module_665 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_637);
+    auto x_main_module_666 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_665,
+        x_main_module_178);
+    auto x_main_module_667 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_666,
+        x_main_module_177,
+        x_main_module_176,
+        x_main_module_175,
+        x_main_module_174);
+    auto x_main_module_668 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_667);
+    auto x_main_module_669 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_640,
+        x_main_module_649,
+        x_main_module_664,
+        x_main_module_668);
+    auto x_main_module_670 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_669,
+        x_main_module_173);
+    auto x_main_module_671 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_670,
+        x_main_module_172,
+        x_main_module_171,
+        x_main_module_170,
+        x_main_module_169);
+    auto x_main_module_672 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_671);
+    auto x_main_module_673 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_669,
+        x_main_module_168);
+    auto x_main_module_674 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_673,
+        x_main_module_167,
+        x_main_module_166,
+        x_main_module_165,
+        x_main_module_164);
+    auto x_main_module_675 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_674);
+    auto x_main_module_676 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_675,
+        x_main_module_163);
+    auto x_main_module_677 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_676,
+        x_main_module_162,
+        x_main_module_161,
+        x_main_module_160,
+        x_main_module_159);
+    auto x_main_module_678 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_677);
+    auto x_main_module_679 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_678,
+        x_main_module_158);
+    auto x_main_module_680 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_679,
+        x_main_module_157,
+        x_main_module_156,
+        x_main_module_155,
+        x_main_module_154);
+    auto x_main_module_681 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_680);
+    auto x_main_module_682 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_669,
+        x_main_module_153);
+    auto x_main_module_683 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_682,
+        x_main_module_152,
+        x_main_module_151,
+        x_main_module_150,
+        x_main_module_149);
+    auto x_main_module_684 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_683);
+    auto x_main_module_685 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_684,
+        x_main_module_148);
+    auto x_main_module_686 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_685,
+        x_main_module_147,
+        x_main_module_146,
+        x_main_module_145,
+        x_main_module_144);
+    auto x_main_module_687 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_686);
+    auto x_main_module_688 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_687,
+        x_main_module_143);
+    auto x_main_module_689 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_688,
+        x_main_module_142,
+        x_main_module_141,
+        x_main_module_140,
+        x_main_module_139);
+    auto x_main_module_690 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_689);
+    auto x_main_module_691 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_690,
+        x_main_module_138);
+    auto x_main_module_692 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_691,
+        x_main_module_137,
+        x_main_module_136,
+        x_main_module_135,
+        x_main_module_134);
+    auto x_main_module_693 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_692);
+    auto x_main_module_694 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_693,
+        x_main_module_133);
+    auto x_main_module_695 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_694,
+        x_main_module_132,
+        x_main_module_131,
+        x_main_module_130,
+        x_main_module_129);
+    auto x_main_module_696 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_695);
+    auto x_main_module_697 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_669);
+    auto x_main_module_698 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_697,
+        x_main_module_128);
+    auto x_main_module_699 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_698,
+        x_main_module_127,
+        x_main_module_126,
+        x_main_module_125,
+        x_main_module_124);
+    auto x_main_module_700 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_699);
+    auto x_main_module_701 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_672,
+        x_main_module_681,
+        x_main_module_696,
+        x_main_module_700);
+    auto x_main_module_702 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_701,
+        x_main_module_123);
+    auto x_main_module_703 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_702,
+        x_main_module_122,
+        x_main_module_121,
+        x_main_module_120,
+        x_main_module_119);
+    auto x_main_module_704 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_703);
+    auto x_main_module_705 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_704,
+        x_main_module_118);
+    auto x_main_module_706 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_705,
+        x_main_module_117,
+        x_main_module_116,
+        x_main_module_115,
+        x_main_module_114);
+    auto x_main_module_707 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_706);
+    auto x_main_module_708 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_701,
+        x_main_module_113);
+    auto x_main_module_709 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_708,
+        x_main_module_112,
+        x_main_module_111,
+        x_main_module_110,
+        x_main_module_109);
+    auto x_main_module_710 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_709);
+    auto x_main_module_711 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_710,
+        x_main_module_108);
+    auto x_main_module_712 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_711,
+        x_main_module_107,
+        x_main_module_106,
+        x_main_module_105,
+        x_main_module_104);
+    auto x_main_module_713 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_712);
+    auto x_main_module_714 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_713,
+        x_main_module_103);
+    auto x_main_module_715 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_714,
+        x_main_module_102,
+        x_main_module_101,
+        x_main_module_100,
+        x_main_module_99);
+    auto x_main_module_716 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_715);
+    auto x_main_module_717 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_716,
+        x_main_module_98);
+    auto x_main_module_718 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_717,
+        x_main_module_97,
+        x_main_module_96,
+        x_main_module_95,
+        x_main_module_94);
+    auto x_main_module_719 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_718);
+    auto x_main_module_720 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        x_main_module_701);
+    auto x_main_module_721 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_707,
+        x_main_module_719,
+        x_main_module_720);
+    auto x_main_module_722 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_721,
+        x_main_module_93);
+    auto x_main_module_723 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_722,
+        x_main_module_92,
+        x_main_module_91,
+        x_main_module_90,
+        x_main_module_89);
+    auto x_main_module_724 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_723);
+    auto x_main_module_725 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_721,
+        x_main_module_88);
+    auto x_main_module_726 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_725,
+        x_main_module_87,
+        x_main_module_86,
+        x_main_module_85,
+        x_main_module_84);
+    auto x_main_module_727 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_726);
+    auto x_main_module_728 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_727,
+        x_main_module_83);
+    auto x_main_module_729 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_728,
+        x_main_module_82,
+        x_main_module_81,
+        x_main_module_80,
+        x_main_module_79);
+    auto x_main_module_730 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_729);
+    auto x_main_module_731 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_727,
+        x_main_module_78);
+    auto x_main_module_732 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_731,
+        x_main_module_77,
+        x_main_module_76,
+        x_main_module_75,
+        x_main_module_74);
+    auto x_main_module_733 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_732);
+    auto x_main_module_734 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_730,
+        x_main_module_733);
+    auto x_main_module_735 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_721,
+        x_main_module_73);
+    auto x_main_module_736 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_735,
+        x_main_module_72,
+        x_main_module_71,
+        x_main_module_70,
+        x_main_module_69);
+    auto x_main_module_737 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_736);
+    auto x_main_module_738 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_737,
+        x_main_module_68);
+    auto x_main_module_739 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_738,
+        x_main_module_67,
+        x_main_module_66,
+        x_main_module_65,
+        x_main_module_64);
+    auto x_main_module_740 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_739);
+    auto x_main_module_741 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_740,
+        x_main_module_63);
+    auto x_main_module_742 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_741,
+        x_main_module_62,
+        x_main_module_61,
+        x_main_module_60,
+        x_main_module_59);
+    auto x_main_module_743 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_742);
+    auto x_main_module_744 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_740,
+        x_main_module_58);
+    auto x_main_module_745 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_744,
+        x_main_module_57,
+        x_main_module_56,
+        x_main_module_55,
+        x_main_module_54);
+    auto x_main_module_746 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_745);
+    auto x_main_module_747 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_743,
+        x_main_module_746);
+    auto x_main_module_748 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_721);
+    auto x_main_module_749 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_748,
+        x_main_module_53);
+    auto x_main_module_750 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_749,
+        x_main_module_52,
+        x_main_module_51,
+        x_main_module_50,
+        x_main_module_49);
+    auto x_main_module_751 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_750);
+    auto x_main_module_752 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_724,
+        x_main_module_734,
+        x_main_module_747,
+        x_main_module_751);
+    auto x_main_module_753 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_752,
+        x_main_module_48);
+    auto x_main_module_754 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_753,
+        x_main_module_47,
+        x_main_module_46,
+        x_main_module_45,
+        x_main_module_44);
+    auto x_main_module_755 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_754);
+    auto x_main_module_756 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_752,
+        x_main_module_43);
+    auto x_main_module_757 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_756,
+        x_main_module_42,
+        x_main_module_41,
+        x_main_module_40,
+        x_main_module_39);
+    auto x_main_module_758 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_757);
+    auto x_main_module_759 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_758,
+        x_main_module_38);
+    auto x_main_module_760 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_759,
+        x_main_module_37,
+        x_main_module_36,
+        x_main_module_35,
+        x_main_module_34);
+    auto x_main_module_761 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_760);
+    auto x_main_module_762 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_758,
+        x_main_module_33);
+    auto x_main_module_763 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_762,
+        x_main_module_32,
+        x_main_module_31,
+        x_main_module_30,
+        x_main_module_29);
+    auto x_main_module_764 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_763);
+    auto x_main_module_765 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_761,
+        x_main_module_764);
+    auto x_main_module_766 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_752,
+        x_main_module_28);
+    auto x_main_module_767 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_766,
+        x_main_module_27,
+        x_main_module_26,
+        x_main_module_25,
+        x_main_module_24);
+    auto x_main_module_768 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_767);
+    auto x_main_module_769 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_768,
+        x_main_module_23);
+    auto x_main_module_770 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_769,
+        x_main_module_22,
+        x_main_module_21,
+        x_main_module_20,
+        x_main_module_19);
+    auto x_main_module_771 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_770);
+    auto x_main_module_772 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_771,
+        x_main_module_18);
+    auto x_main_module_773 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_772,
+        x_main_module_17,
+        x_main_module_16,
+        x_main_module_15,
+        x_main_module_14);
+    auto x_main_module_774 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_773);
+    auto x_main_module_775 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_771,
+        x_main_module_13);
+    auto x_main_module_776 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_775,
+        x_main_module_12,
+        x_main_module_11,
+        x_main_module_10,
+        x_main_module_9);
+    auto x_main_module_777 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_776);
+    auto x_main_module_778 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_774,
+        x_main_module_777);
+    auto x_main_module_779 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_752);
+    auto x_main_module_780 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_779,
+        x_main_module_8);
+    auto x_main_module_781 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_780,
+        x_main_module_7,
+        x_main_module_6,
+        x_main_module_5,
+        x_main_module_4);
+    auto x_main_module_782 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_781);
+    auto x_main_module_783 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_755,
+        x_main_module_765,
+        x_main_module_778,
+        x_main_module_782);
+    auto x_main_module_784 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[8,8],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[0,0,0,0],\"stride\":[8,8]}")),
+        x_main_module_783);
+    auto x_main_module_785 =
+        mmain->add_instruction(migraphx::make_op("identity"), x_main_module_784);
+    auto x_main_module_786 = mmain->add_instruction(
+        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_785);
+    auto x_main_module_787 = mmain->add_instruction(
+        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
+        x_main_module_3);
+    auto x_main_module_788 =
+        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_786, x_main_module_787);
+    auto x_main_module_789 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        x_main_module_2);
+    auto x_main_module_790 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        x_main_module_0);
+    auto x_main_module_791 =
+        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_789, x_main_module_790);
+    auto x_main_module_792 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_788, x_main_module_791);
+    mmain->add_return({x_main_module_792});
 
     return p;
 }

--- a/src/driver/inceptionv3.cpp
+++ b/src/driver/inceptionv3.cpp
@@ -33,2832 +33,802 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program inceptionv3(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-    migraphx::module_ref mmain = p.get_main_module();
-    auto _x_main_module_0      = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-    auto _x_0                  = mmain->add_parameter(
-        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 299, 299}});
-    auto _x_main_module_2 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
-    auto _x_main_module_3 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
-    auto _x_main_module_4 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 3)));
-    auto _x_main_module_5 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 4));
-    auto _x_main_module_6 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 5));
-    auto _x_main_module_7  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 6)));
-    auto _x_main_module_8  = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 2048, 1, 1}}, 7));
-    auto _x_main_module_9  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 8)));
-    auto _x_main_module_10 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 9));
-    auto _x_main_module_11 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 10));
-    auto _x_main_module_12 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 11)));
-    auto _x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 12));
-    auto _x_main_module_14 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13)));
-    auto _x_main_module_15 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 14));
-    auto _x_main_module_16 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 15));
-    auto _x_main_module_17 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 16)));
-    auto _x_main_module_18 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 17));
-    auto _x_main_module_19 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 18)));
-    auto _x_main_module_20 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 19));
-    auto _x_main_module_21 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 20));
-    auto _x_main_module_22 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 21)));
-    auto _x_main_module_23 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 22));
-    auto _x_main_module_24 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 23)));
-    auto _x_main_module_25 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 24));
-    auto _x_main_module_26 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 25));
-    auto _x_main_module_27 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 26)));
-    auto _x_main_module_28 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {448, 2048, 1, 1}}, 27));
-    auto _x_main_module_29 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 28)));
-    auto _x_main_module_30 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 29)));
-    auto _x_main_module_31 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 30));
-    auto _x_main_module_32 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 31)));
-    auto _x_main_module_33 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 32));
-    auto _x_main_module_34 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 33)));
-    auto _x_main_module_35 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 34)));
-    auto _x_main_module_36 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 35));
-    auto _x_main_module_37 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 36)));
-    auto _x_main_module_38 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 37));
-    auto _x_main_module_39 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 38)));
-    auto _x_main_module_40 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 39));
-    auto _x_main_module_41 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 40));
-    auto _x_main_module_42 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 41)));
-    auto _x_main_module_43 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 2048, 1, 1}}, 42));
-    auto _x_main_module_44 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 43)));
-    auto _x_main_module_45 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 44));
-    auto _x_main_module_46 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 45));
-    auto _x_main_module_47 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 46)));
-    auto _x_main_module_48 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {320, 2048, 1, 1}}, 47));
-    auto _x_main_module_49 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 48)));
-    auto _x_main_module_50 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 49));
-    auto _x_main_module_51 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 50));
-    auto _x_main_module_52 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 51)));
-    auto _x_main_module_53 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 1280, 1, 1}}, 52));
-    auto _x_main_module_54 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 53)));
-    auto _x_main_module_55 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 54));
-    auto _x_main_module_56 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 55));
-    auto _x_main_module_57 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 56)));
-    auto _x_main_module_58 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 57));
-    auto _x_main_module_59 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 58)));
-    auto _x_main_module_60 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 59));
-    auto _x_main_module_61 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 60));
-    auto _x_main_module_62 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 61)));
-    auto _x_main_module_63 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 62));
-    auto _x_main_module_64 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 63)));
-    auto _x_main_module_65 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 64));
-    auto _x_main_module_66 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 65));
-    auto _x_main_module_67 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 66)));
-    auto _x_main_module_68 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 67));
-    auto _x_main_module_69 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 68)));
-    auto _x_main_module_70 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 69));
-    auto _x_main_module_71 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 70));
-    auto _x_main_module_72 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 71)));
-    auto _x_main_module_73 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {448, 1280, 1, 1}}, 72));
-    auto _x_main_module_74 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 73)));
-    auto _x_main_module_75 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 74));
-    auto _x_main_module_76 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 75));
-    auto _x_main_module_77 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 76)));
-    auto _x_main_module_78 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 77));
-    auto _x_main_module_79 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 78)));
-    auto _x_main_module_80 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 79));
-    auto _x_main_module_81 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 80));
-    auto _x_main_module_82 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 81)));
-    auto _x_main_module_83 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 82));
-    auto _x_main_module_84 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 83)));
-    auto _x_main_module_85 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 84));
-    auto _x_main_module_86 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 85));
-    auto _x_main_module_87 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 86)));
-    auto _x_main_module_88 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 1280, 1, 1}}, 87));
-    auto _x_main_module_89 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 88)));
-    auto _x_main_module_90 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 89));
-    auto _x_main_module_91 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 90));
-    auto _x_main_module_92 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 91)));
-    auto _x_main_module_93 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {320, 1280, 1, 1}}, 92));
-    auto _x_main_module_94 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 93)));
-    auto _x_main_module_95 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 94));
-    auto _x_main_module_96 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 95));
-    auto _x_main_module_97  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 96)));
-    auto _x_main_module_98  = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 3, 3}}, 97));
-    auto _x_main_module_99  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 98)));
-    auto _x_main_module_100 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 99));
-    auto _x_main_module_101 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 100));
-    auto _x_main_module_102 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 101)));
-    auto _x_main_module_103 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 102));
-    auto _x_main_module_104 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 103)));
-    auto _x_main_module_105 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 104));
-    auto _x_main_module_106 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 105));
-    auto _x_main_module_107 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 106)));
-    auto _x_main_module_108 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 107));
-    auto _x_main_module_109 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 108)));
-    auto _x_main_module_110 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 109));
-    auto _x_main_module_111 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 110));
-    auto _x_main_module_112 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 111)));
-    auto _x_main_module_113 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 112));
-    auto _x_main_module_114 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 113)));
-    auto _x_main_module_115 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 114));
-    auto _x_main_module_116 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 115));
-    auto _x_main_module_117 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 116)));
-    auto _x_main_module_118 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {320, 192, 3, 3}}, 117));
-    auto _x_main_module_119 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 118)));
-    auto _x_main_module_120 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 119));
-    auto _x_main_module_121 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 120));
-    auto _x_main_module_122 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 121)));
-    auto _x_main_module_123 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 122));
-    auto _x_main_module_124 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 123)));
-    auto _x_main_module_125 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 124));
-    auto _x_main_module_126 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 125));
-    auto _x_main_module_127 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 126)));
-    auto _x_main_module_128 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 127));
-    auto _x_main_module_129 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 128)));
-    auto _x_main_module_130 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 129));
-    auto _x_main_module_131 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 130));
-    auto _x_main_module_132 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 131)));
-    auto _x_main_module_133 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 132));
-    auto _x_main_module_134 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 133)));
-    auto _x_main_module_135 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 134));
-    auto _x_main_module_136 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 135));
-    auto _x_main_module_137 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 136)));
-    auto _x_main_module_138 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 137));
-    auto _x_main_module_139 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 138)));
-    auto _x_main_module_140 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 139));
-    auto _x_main_module_141 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 140));
-    auto _x_main_module_142 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 141)));
-    auto _x_main_module_143 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 142));
-    auto _x_main_module_144 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 143)));
-    auto _x_main_module_145 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 144));
-    auto _x_main_module_146 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 145));
-    auto _x_main_module_147 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 146)));
-    auto _x_main_module_148 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 147));
-    auto _x_main_module_149 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 148)));
-    auto _x_main_module_150 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 149));
-    auto _x_main_module_151 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 150));
-    auto _x_main_module_152 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 151)));
-    auto _x_main_module_153 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 152));
-    auto _x_main_module_154 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 153)));
-    auto _x_main_module_155 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 154));
-    auto _x_main_module_156 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 155));
-    auto _x_main_module_157 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 156)));
-    auto _x_main_module_158 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 157));
-    auto _x_main_module_159 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 158)));
-    auto _x_main_module_160 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 159));
-    auto _x_main_module_161 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 160));
-    auto _x_main_module_162 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 161)));
-    auto _x_main_module_163 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 162));
-    auto _x_main_module_164 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 163)));
-    auto _x_main_module_165 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 164));
-    auto _x_main_module_166 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 165));
-    auto _x_main_module_167 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 166)));
-    auto _x_main_module_168 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 167));
-    auto _x_main_module_169 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 168)));
-    auto _x_main_module_170 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 169));
-    auto _x_main_module_171 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 170));
-    auto _x_main_module_172 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 171)));
-    auto _x_main_module_173 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 172));
-    auto _x_main_module_174 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 173)));
-    auto _x_main_module_175 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 174));
-    auto _x_main_module_176 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 175));
-    auto _x_main_module_177 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 176)));
-    auto _x_main_module_178 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 177));
-    auto _x_main_module_179 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 178)));
-    auto _x_main_module_180 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 179));
-    auto _x_main_module_181 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 180));
-    auto _x_main_module_182 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 181)));
-    auto _x_main_module_183 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 182));
-    auto _x_main_module_184 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 183)));
-    auto _x_main_module_185 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 184));
-    auto _x_main_module_186 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 185));
-    auto _x_main_module_187 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 186)));
-    auto _x_main_module_188 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 187));
-    auto _x_main_module_189 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 188)));
-    auto _x_main_module_190 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 189));
-    auto _x_main_module_191 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 190));
-    auto _x_main_module_192 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 191)));
-    auto _x_main_module_193 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 192));
-    auto _x_main_module_194 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 193)));
-    auto _x_main_module_195 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 194));
-    auto _x_main_module_196 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 195));
-    auto _x_main_module_197 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 196)));
-    auto _x_main_module_198 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 197));
-    auto _x_main_module_199 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 198)));
-    auto _x_main_module_200 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 199));
-    auto _x_main_module_201 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 200));
-    auto _x_main_module_202 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 201)));
-    auto _x_main_module_203 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 202));
-    auto _x_main_module_204 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 203)));
-    auto _x_main_module_205 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 204));
-    auto _x_main_module_206 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 205));
-    auto _x_main_module_207 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 206)));
-    auto _x_main_module_208 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 207));
-    auto _x_main_module_209 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 208)));
-    auto _x_main_module_210 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 209));
-    auto _x_main_module_211 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 210));
-    auto _x_main_module_212 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 211)));
-    auto _x_main_module_213 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 212));
-    auto _x_main_module_214 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 213)));
-    auto _x_main_module_215 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 214));
-    auto _x_main_module_216 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 215));
-    auto _x_main_module_217 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 216)));
-    auto _x_main_module_218 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 217));
-    auto _x_main_module_219 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 218)));
-    auto _x_main_module_220 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 219));
-    auto _x_main_module_221 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 220));
-    auto _x_main_module_222 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 221)));
-    auto _x_main_module_223 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 222));
-    auto _x_main_module_224 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 223)));
-    auto _x_main_module_225 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 224));
-    auto _x_main_module_226 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 225));
-    auto _x_main_module_227 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 226)));
-    auto _x_main_module_228 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 227));
-    auto _x_main_module_229 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 228)));
-    auto _x_main_module_230 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 229));
-    auto _x_main_module_231 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 230));
-    auto _x_main_module_232 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 231)));
-    auto _x_main_module_233 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 232));
-    auto _x_main_module_234 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 233)));
-    auto _x_main_module_235 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 234));
-    auto _x_main_module_236 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 235));
-    auto _x_main_module_237 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 236)));
-    auto _x_main_module_238 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 237));
-    auto _x_main_module_239 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 238)));
-    auto _x_main_module_240 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 239));
-    auto _x_main_module_241 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 240));
-    auto _x_main_module_242 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 241)));
-    auto _x_main_module_243 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 242));
-    auto _x_main_module_244 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 243)));
-    auto _x_main_module_245 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 244));
-    auto _x_main_module_246 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 245));
-    auto _x_main_module_247 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 246)));
-    auto _x_main_module_248 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 247));
-    auto _x_main_module_249 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 248)));
-    auto _x_main_module_250 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 249));
-    auto _x_main_module_251 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 250));
-    auto _x_main_module_252 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 251)));
-    auto _x_main_module_253 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 252));
-    auto _x_main_module_254 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 253)));
-    auto _x_main_module_255 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 254));
-    auto _x_main_module_256 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 255));
-    auto _x_main_module_257 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 256)));
-    auto _x_main_module_258 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 257));
-    auto _x_main_module_259 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 258)));
-    auto _x_main_module_260 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 259));
-    auto _x_main_module_261 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 260));
-    auto _x_main_module_262 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 261)));
-    auto _x_main_module_263 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 262));
-    auto _x_main_module_264 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 263)));
-    auto _x_main_module_265 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 264));
-    auto _x_main_module_266 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 265));
-    auto _x_main_module_267 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 266)));
-    auto _x_main_module_268 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 267));
-    auto _x_main_module_269 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 268)));
-    auto _x_main_module_270 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 269));
-    auto _x_main_module_271 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 270));
-    auto _x_main_module_272 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 271)));
-    auto _x_main_module_273 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 272));
-    auto _x_main_module_274 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 273)));
-    auto _x_main_module_275 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 274));
-    auto _x_main_module_276 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 275));
-    auto _x_main_module_277 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 276)));
-    auto _x_main_module_278 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 277));
-    auto _x_main_module_279 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 278)));
-    auto _x_main_module_280 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 279));
-    auto _x_main_module_281 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 280));
-    auto _x_main_module_282 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 281)));
-    auto _x_main_module_283 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 128, 1, 7}}, 282));
-    auto _x_main_module_284 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 283)));
-    auto _x_main_module_285 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 284));
-    auto _x_main_module_286 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 285));
-    auto _x_main_module_287 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 286)));
-    auto _x_main_module_288 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 287));
-    auto _x_main_module_289 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 288)));
-    auto _x_main_module_290 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 289));
-    auto _x_main_module_291 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 290));
-    auto _x_main_module_292 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 291)));
-    auto _x_main_module_293 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 292));
-    auto _x_main_module_294 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 293)));
-    auto _x_main_module_295 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 294));
-    auto _x_main_module_296 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 295));
-    auto _x_main_module_297 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 296)));
-    auto _x_main_module_298 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 297));
-    auto _x_main_module_299 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 298)));
-    auto _x_main_module_300 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 299));
-    auto _x_main_module_301 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 300));
-    auto _x_main_module_302 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 301)));
-    auto _x_main_module_303 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 302));
-    auto _x_main_module_304 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 303)));
-    auto _x_main_module_305 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 304));
-    auto _x_main_module_306 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 305));
-    auto _x_main_module_307 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 306)));
-    auto _x_main_module_308 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 128, 7, 1}}, 307));
-    auto _x_main_module_309 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 308)));
-    auto _x_main_module_310 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 309));
-    auto _x_main_module_311 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 310));
-    auto _x_main_module_312 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 311)));
-    auto _x_main_module_313 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 312));
-    auto _x_main_module_314 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 313)));
-    auto _x_main_module_315 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 314));
-    auto _x_main_module_316 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 315));
-    auto _x_main_module_317 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 316)));
-    auto _x_main_module_318 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 317));
-    auto _x_main_module_319 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 318)));
-    auto _x_main_module_320 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 319));
-    auto _x_main_module_321 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 320));
-    auto _x_main_module_322 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 321)));
-    auto _x_main_module_323 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 322));
-    auto _x_main_module_324 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 323)));
-    auto _x_main_module_325 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 324));
-    auto _x_main_module_326 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 325));
-    auto _x_main_module_327 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 326)));
-    auto _x_main_module_328 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 327));
-    auto _x_main_module_329 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 328)));
-    auto _x_main_module_330 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 329));
-    auto _x_main_module_331 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 330));
-    auto _x_main_module_332 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 331)));
-    auto _x_main_module_333 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 332));
-    auto _x_main_module_334 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 333)));
-    auto _x_main_module_335 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 334));
-    auto _x_main_module_336 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 335));
-    auto _x_main_module_337 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 336)));
-    auto _x_main_module_338 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 337));
-    auto _x_main_module_339 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 338)));
-    auto _x_main_module_340 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 339));
-    auto _x_main_module_341 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 340));
-    auto _x_main_module_342 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 341)));
-    auto _x_main_module_343 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 288, 3, 3}}, 342));
-    auto _x_main_module_344 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 343)));
-    auto _x_main_module_345 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 344));
-    auto _x_main_module_346 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 345));
-    auto _x_main_module_347 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 346)));
-    auto _x_main_module_348 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 347));
-    auto _x_main_module_349 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 348)));
-    auto _x_main_module_350 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 349));
-    auto _x_main_module_351 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 350));
-    auto _x_main_module_352 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 351)));
-    auto _x_main_module_353 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 352));
-    auto _x_main_module_354 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 353)));
-    auto _x_main_module_355 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 354));
-    auto _x_main_module_356 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 355));
-    auto _x_main_module_357 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 356)));
-    auto _x_main_module_358 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 357));
-    auto _x_main_module_359 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 358)));
-    auto _x_main_module_360 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 359));
-    auto _x_main_module_361 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 360));
-    auto _x_main_module_362 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 361)));
-    auto _x_main_module_363 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 362));
-    auto _x_main_module_364 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 363)));
-    auto _x_main_module_365 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 364));
-    auto _x_main_module_366 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 365));
-    auto _x_main_module_367 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 366)));
-    auto _x_main_module_368 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 367));
-    auto _x_main_module_369 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 368)));
-    auto _x_main_module_370 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 369));
-    auto _x_main_module_371 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 370));
-    auto _x_main_module_372 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 371)));
-    auto _x_main_module_373 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {48, 288, 1, 1}}, 372));
-    auto _x_main_module_374 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 373)));
-    auto _x_main_module_375 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 374));
-    auto _x_main_module_376 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 375));
-    auto _x_main_module_377 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 376)));
-    auto _x_main_module_378 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 377));
-    auto _x_main_module_379 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 378)));
-    auto _x_main_module_380 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 379));
-    auto _x_main_module_381 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 380));
-    auto _x_main_module_382 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 381)));
-    auto _x_main_module_383 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 382));
-    auto _x_main_module_384 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 383)));
-    auto _x_main_module_385 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 384));
-    auto _x_main_module_386 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 385));
-    auto _x_main_module_387 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 386)));
-    auto _x_main_module_388 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 387));
-    auto _x_main_module_389 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 388)));
-    auto _x_main_module_390 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 389));
-    auto _x_main_module_391 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 390));
-    auto _x_main_module_392 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 391)));
-    auto _x_main_module_393 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 392));
-    auto _x_main_module_394 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 393)));
-    auto _x_main_module_395 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 394));
-    auto _x_main_module_396 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 395));
-    auto _x_main_module_397 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 396)));
-    auto _x_main_module_398 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 397));
-    auto _x_main_module_399 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 398)));
-    auto _x_main_module_400 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 399));
-    auto _x_main_module_401 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 400));
-    auto _x_main_module_402 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 401)));
-    auto _x_main_module_403 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 402));
-    auto _x_main_module_404 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 403)));
-    auto _x_main_module_405 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 404));
-    auto _x_main_module_406 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 405));
-    auto _x_main_module_407 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 406)));
-    auto _x_main_module_408 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {48, 256, 1, 1}}, 407));
-    auto _x_main_module_409 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 408)));
-    auto _x_main_module_410 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 409));
-    auto _x_main_module_411 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 410));
-    auto _x_main_module_412 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 411)));
-    auto _x_main_module_413 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 412));
-    auto _x_main_module_414 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 413)));
-    auto _x_main_module_415 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 414));
-    auto _x_main_module_416 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 415));
-    auto _x_main_module_417 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 416)));
-    auto _x_main_module_418 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {32, 192, 1, 1}}, 417));
-    auto _x_main_module_419 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 418)));
-    auto _x_main_module_420 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 419));
-    auto _x_main_module_421 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 420));
-    auto _x_main_module_422 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 421)));
-    auto _x_main_module_423 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 422));
-    auto _x_main_module_424 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 423)));
-    auto _x_main_module_425 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 424));
-    auto _x_main_module_426 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 425));
-    auto _x_main_module_427 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 426)));
-    auto _x_main_module_428 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 427));
-    auto _x_main_module_429 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 428)));
-    auto _x_main_module_430 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 429));
-    auto _x_main_module_431 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 430));
-    auto _x_main_module_432 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 431)));
-    auto _x_main_module_433 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 432));
-    auto _x_main_module_434 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 433)));
-    auto _x_main_module_435 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 434));
-    auto _x_main_module_436 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 435));
-    auto _x_main_module_437 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 436)));
-    auto _x_main_module_438 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 437));
-    auto _x_main_module_439 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 438)));
-    auto _x_main_module_440 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 439));
-    auto _x_main_module_441 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 440));
-    auto _x_main_module_442 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 441)));
-    auto _x_main_module_443 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {48, 192, 1, 1}}, 442));
-    auto _x_main_module_444 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 443)));
-    auto _x_main_module_445 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 444));
-    auto _x_main_module_446 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 445));
-    auto _x_main_module_447 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 446)));
-    auto _x_main_module_448 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 447));
-    auto _x_main_module_449 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 448)));
-    auto _x_main_module_450 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 449));
-    auto _x_main_module_451 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 450));
-    auto _x_main_module_452 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 451)));
-    auto _x_main_module_453 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 80, 3, 3}}, 452));
-    auto _x_main_module_454 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 453)));
-    auto _x_main_module_455 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 454));
-    auto _x_main_module_456 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 455));
-    auto _x_main_module_457 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 456)));
-    auto _x_main_module_458 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {80, 64, 1, 1}}, 457));
-    auto _x_main_module_459 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 458)));
-    auto _x_main_module_460 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 459));
-    auto _x_main_module_461 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 460));
-    auto _x_main_module_462 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 461)));
-    auto _x_main_module_463 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 32, 3, 3}}, 462));
-    auto _x_main_module_464 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 463)));
-    auto _x_main_module_465 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 464));
-    auto _x_main_module_466 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 465));
-    auto _x_main_module_467 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 466)));
-    auto _x_main_module_468 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {32, 32, 3, 3}}, 467));
-    auto _x_main_module_469 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 468)));
-    auto _x_main_module_470 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 469));
-    auto _x_main_module_471 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 470));
-    auto _x_main_module_472 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 471)));
-    auto _x_main_module_473 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {32, 3, 3, 3}}, 472));
-    auto _x_main_module_474 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        _x_0,
-        _x_main_module_473);
-    auto _x_main_module_475 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_474,
-        _x_main_module_472,
-        _x_main_module_471,
-        _x_main_module_470,
-        _x_main_module_469);
-    auto _x_main_module_476 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_475);
-    auto _x_main_module_477 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_476,
-        _x_main_module_468);
-    auto _x_main_module_478 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_477,
-        _x_main_module_467,
-        _x_main_module_466,
-        _x_main_module_465,
-        _x_main_module_464);
-    auto _x_main_module_479 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_478);
-    auto _x_main_module_480 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_479,
-        _x_main_module_463);
-    auto _x_main_module_481 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_480,
-        _x_main_module_462,
-        _x_main_module_461,
-        _x_main_module_460,
-        _x_main_module_459);
-    auto _x_main_module_482 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_481);
-    auto _x_main_module_483 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        _x_main_module_482);
-    auto _x_main_module_484 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_483,
-        _x_main_module_458);
-    auto _x_main_module_485 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_484,
-        _x_main_module_457,
-        _x_main_module_456,
-        _x_main_module_455,
-        _x_main_module_454);
-    auto _x_main_module_486 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_485);
-    auto _x_main_module_487 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_486,
-        _x_main_module_453);
-    auto _x_main_module_488 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_487,
-        _x_main_module_452,
-        _x_main_module_451,
-        _x_main_module_450,
-        _x_main_module_449);
-    auto _x_main_module_489 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_488);
-    auto _x_main_module_490 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        _x_main_module_489);
-    auto _x_main_module_491 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_490,
-        _x_main_module_448);
-    auto _x_main_module_492 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_491,
-        _x_main_module_447,
-        _x_main_module_446,
-        _x_main_module_445,
-        _x_main_module_444);
-    auto _x_main_module_493 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_492);
-    auto _x_main_module_494 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_490,
-        _x_main_module_443);
-    auto _x_main_module_495 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_494,
-        _x_main_module_442,
-        _x_main_module_441,
-        _x_main_module_440,
-        _x_main_module_439);
-    auto _x_main_module_496 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_495);
-    auto _x_main_module_497 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_496,
-        _x_main_module_438);
-    auto _x_main_module_498 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_497,
-        _x_main_module_437,
-        _x_main_module_436,
-        _x_main_module_435,
-        _x_main_module_434);
-    auto _x_main_module_499 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_498);
-    auto _x_main_module_500 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_490,
-        _x_main_module_433);
-    auto _x_main_module_501 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_500,
-        _x_main_module_432,
-        _x_main_module_431,
-        _x_main_module_430,
-        _x_main_module_429);
-    auto _x_main_module_502 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_501);
-    auto _x_main_module_503 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_502,
-        _x_main_module_428);
-    auto _x_main_module_504 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_503,
-        _x_main_module_427,
-        _x_main_module_426,
-        _x_main_module_425,
-        _x_main_module_424);
-    auto _x_main_module_505 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_504);
-    auto _x_main_module_506 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_505,
-        _x_main_module_423);
-    auto _x_main_module_507 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_506,
-        _x_main_module_422,
-        _x_main_module_421,
-        _x_main_module_420,
-        _x_main_module_419);
-    auto _x_main_module_508 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_507);
-    auto _x_main_module_509 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        _x_main_module_490);
-    auto _x_main_module_510 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_509,
-        _x_main_module_418);
-    auto _x_main_module_511 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_510,
-        _x_main_module_417,
-        _x_main_module_416,
-        _x_main_module_415,
-        _x_main_module_414);
-    auto _x_main_module_512 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_511);
-    auto _x_main_module_513 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_493,
-        _x_main_module_499,
-        _x_main_module_508,
-        _x_main_module_512);
-    auto _x_main_module_514 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_513,
-        _x_main_module_413);
-    auto _x_main_module_515 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_514,
-        _x_main_module_412,
-        _x_main_module_411,
-        _x_main_module_410,
-        _x_main_module_409);
-    auto _x_main_module_516 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_515);
-    auto _x_main_module_517 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_513,
-        _x_main_module_408);
-    auto _x_main_module_518 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_517,
-        _x_main_module_407,
-        _x_main_module_406,
-        _x_main_module_405,
-        _x_main_module_404);
-    auto _x_main_module_519 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_518);
-    auto _x_main_module_520 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_519,
-        _x_main_module_403);
-    auto _x_main_module_521 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_520,
-        _x_main_module_402,
-        _x_main_module_401,
-        _x_main_module_400,
-        _x_main_module_399);
-    auto _x_main_module_522 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_521);
-    auto _x_main_module_523 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_513,
-        _x_main_module_398);
-    auto _x_main_module_524 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_523,
-        _x_main_module_397,
-        _x_main_module_396,
-        _x_main_module_395,
-        _x_main_module_394);
-    auto _x_main_module_525 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_524);
-    auto _x_main_module_526 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_525,
-        _x_main_module_393);
-    auto _x_main_module_527 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_526,
-        _x_main_module_392,
-        _x_main_module_391,
-        _x_main_module_390,
-        _x_main_module_389);
-    auto _x_main_module_528 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_527);
-    auto _x_main_module_529 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_528,
-        _x_main_module_388);
-    auto _x_main_module_530 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_529,
-        _x_main_module_387,
-        _x_main_module_386,
-        _x_main_module_385,
-        _x_main_module_384);
-    auto _x_main_module_531 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_530);
-    auto _x_main_module_532 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        _x_main_module_513);
-    auto _x_main_module_533 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_532,
-        _x_main_module_383);
-    auto _x_main_module_534 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_533,
-        _x_main_module_382,
-        _x_main_module_381,
-        _x_main_module_380,
-        _x_main_module_379);
-    auto _x_main_module_535 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_534);
-    auto _x_main_module_536 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_516,
-        _x_main_module_522,
-        _x_main_module_531,
-        _x_main_module_535);
-    auto _x_main_module_537 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_536,
-        _x_main_module_378);
-    auto _x_main_module_538 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_537,
-        _x_main_module_377,
-        _x_main_module_376,
-        _x_main_module_375,
-        _x_main_module_374);
-    auto _x_main_module_539 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_538);
-    auto _x_main_module_540 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_536,
-        _x_main_module_373);
-    auto _x_main_module_541 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_540,
-        _x_main_module_372,
-        _x_main_module_371,
-        _x_main_module_370,
-        _x_main_module_369);
-    auto _x_main_module_542 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_541);
-    auto _x_main_module_543 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_542,
-        _x_main_module_368);
-    auto _x_main_module_544 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_543,
-        _x_main_module_367,
-        _x_main_module_366,
-        _x_main_module_365,
-        _x_main_module_364);
-    auto _x_main_module_545 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_544);
-    auto _x_main_module_546 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_536,
-        _x_main_module_363);
-    auto _x_main_module_547 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_546,
-        _x_main_module_362,
-        _x_main_module_361,
-        _x_main_module_360,
-        _x_main_module_359);
-    auto _x_main_module_548 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_547);
-    auto _x_main_module_549 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_548,
-        _x_main_module_358);
-    auto _x_main_module_550 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_549,
-        _x_main_module_357,
-        _x_main_module_356,
-        _x_main_module_355,
-        _x_main_module_354);
-    auto _x_main_module_551 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_550);
-    auto _x_main_module_552 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_551,
-        _x_main_module_353);
-    auto _x_main_module_553 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_552,
-        _x_main_module_352,
-        _x_main_module_351,
-        _x_main_module_350,
-        _x_main_module_349);
-    auto _x_main_module_554 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_553);
-    auto _x_main_module_555 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        _x_main_module_536);
-    auto _x_main_module_556 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_555,
-        _x_main_module_348);
-    auto _x_main_module_557 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_556,
-        _x_main_module_347,
-        _x_main_module_346,
-        _x_main_module_345,
-        _x_main_module_344);
-    auto _x_main_module_558 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_557);
-    auto _x_main_module_559 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_539,
-        _x_main_module_545,
-        _x_main_module_554,
-        _x_main_module_558);
-    auto _x_main_module_560 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_559,
-        _x_main_module_343);
-    auto _x_main_module_561 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_560,
-        _x_main_module_342,
-        _x_main_module_341,
-        _x_main_module_340,
-        _x_main_module_339);
-    auto _x_main_module_562 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_561);
-    auto _x_main_module_563 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_559,
-        _x_main_module_338);
-    auto _x_main_module_564 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_563,
-        _x_main_module_337,
-        _x_main_module_336,
-        _x_main_module_335,
-        _x_main_module_334);
-    auto _x_main_module_565 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_564);
-    auto _x_main_module_566 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_565,
-        _x_main_module_333);
-    auto _x_main_module_567 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_566,
-        _x_main_module_332,
-        _x_main_module_331,
-        _x_main_module_330,
-        _x_main_module_329);
-    auto _x_main_module_568 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_567);
-    auto _x_main_module_569 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_568,
-        _x_main_module_328);
-    auto _x_main_module_570 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_569,
-        _x_main_module_327,
-        _x_main_module_326,
-        _x_main_module_325,
-        _x_main_module_324);
-    auto _x_main_module_571 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_570);
-    auto _x_main_module_572 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        _x_main_module_559);
-    auto _x_main_module_573 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_562,
-        _x_main_module_571,
-        _x_main_module_572);
-    auto _x_main_module_574 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_573,
-        _x_main_module_323);
-    auto _x_main_module_575 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_574,
-        _x_main_module_322,
-        _x_main_module_321,
-        _x_main_module_320,
-        _x_main_module_319);
-    auto _x_main_module_576 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_575);
-    auto _x_main_module_577 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_573,
-        _x_main_module_318);
-    auto _x_main_module_578 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_577,
-        _x_main_module_317,
-        _x_main_module_316,
-        _x_main_module_315,
-        _x_main_module_314);
-    auto _x_main_module_579 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_578);
-    auto _x_main_module_580 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_579,
-        _x_main_module_313);
-    auto _x_main_module_581 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_580,
-        _x_main_module_312,
-        _x_main_module_311,
-        _x_main_module_310,
-        _x_main_module_309);
-    auto _x_main_module_582 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_581);
-    auto _x_main_module_583 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_582,
-        _x_main_module_308);
-    auto _x_main_module_584 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_583,
-        _x_main_module_307,
-        _x_main_module_306,
-        _x_main_module_305,
-        _x_main_module_304);
-    auto _x_main_module_585 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_584);
-    auto _x_main_module_586 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_573,
-        _x_main_module_303);
-    auto _x_main_module_587 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_586,
-        _x_main_module_302,
-        _x_main_module_301,
-        _x_main_module_300,
-        _x_main_module_299);
-    auto _x_main_module_588 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_587);
-    auto _x_main_module_589 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_588,
-        _x_main_module_298);
-    auto _x_main_module_590 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_589,
-        _x_main_module_297,
-        _x_main_module_296,
-        _x_main_module_295,
-        _x_main_module_294);
-    auto _x_main_module_591 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_590);
-    auto _x_main_module_592 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_591,
-        _x_main_module_293);
-    auto _x_main_module_593 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_592,
-        _x_main_module_292,
-        _x_main_module_291,
-        _x_main_module_290,
-        _x_main_module_289);
-    auto _x_main_module_594 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_593);
-    auto _x_main_module_595 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_594,
-        _x_main_module_288);
-    auto _x_main_module_596 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_595,
-        _x_main_module_287,
-        _x_main_module_286,
-        _x_main_module_285,
-        _x_main_module_284);
-    auto _x_main_module_597 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_596);
-    auto _x_main_module_598 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_597,
-        _x_main_module_283);
-    auto _x_main_module_599 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_598,
-        _x_main_module_282,
-        _x_main_module_281,
-        _x_main_module_280,
-        _x_main_module_279);
-    auto _x_main_module_600 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_599);
-    auto _x_main_module_601 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        _x_main_module_573);
-    auto _x_main_module_602 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_601,
-        _x_main_module_278);
-    auto _x_main_module_603 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_602,
-        _x_main_module_277,
-        _x_main_module_276,
-        _x_main_module_275,
-        _x_main_module_274);
-    auto _x_main_module_604 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_603);
-    auto _x_main_module_605 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_576,
-        _x_main_module_585,
-        _x_main_module_600,
-        _x_main_module_604);
-    auto _x_main_module_606 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_605,
-        _x_main_module_273);
-    auto _x_main_module_607 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_606,
-        _x_main_module_272,
-        _x_main_module_271,
-        _x_main_module_270,
-        _x_main_module_269);
-    auto _x_main_module_608 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_607);
-    auto _x_main_module_609 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_605,
-        _x_main_module_268);
-    auto _x_main_module_610 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_609,
-        _x_main_module_267,
-        _x_main_module_266,
-        _x_main_module_265,
-        _x_main_module_264);
-    auto _x_main_module_611 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_610);
-    auto _x_main_module_612 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_611,
-        _x_main_module_263);
-    auto _x_main_module_613 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_612,
-        _x_main_module_262,
-        _x_main_module_261,
-        _x_main_module_260,
-        _x_main_module_259);
-    auto _x_main_module_614 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_613);
-    auto _x_main_module_615 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_614,
-        _x_main_module_258);
-    auto _x_main_module_616 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_615,
-        _x_main_module_257,
-        _x_main_module_256,
-        _x_main_module_255,
-        _x_main_module_254);
-    auto _x_main_module_617 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_616);
-    auto _x_main_module_618 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_605,
-        _x_main_module_253);
-    auto _x_main_module_619 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_618,
-        _x_main_module_252,
-        _x_main_module_251,
-        _x_main_module_250,
-        _x_main_module_249);
-    auto _x_main_module_620 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_619);
-    auto _x_main_module_621 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_620,
-        _x_main_module_248);
-    auto _x_main_module_622 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_621,
-        _x_main_module_247,
-        _x_main_module_246,
-        _x_main_module_245,
-        _x_main_module_244);
-    auto _x_main_module_623 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_622);
-    auto _x_main_module_624 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_623,
-        _x_main_module_243);
-    auto _x_main_module_625 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_624,
-        _x_main_module_242,
-        _x_main_module_241,
-        _x_main_module_240,
-        _x_main_module_239);
-    auto _x_main_module_626 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_625);
-    auto _x_main_module_627 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_626,
-        _x_main_module_238);
-    auto _x_main_module_628 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_627,
-        _x_main_module_237,
-        _x_main_module_236,
-        _x_main_module_235,
-        _x_main_module_234);
-    auto _x_main_module_629 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_628);
-    auto _x_main_module_630 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_629,
-        _x_main_module_233);
-    auto _x_main_module_631 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_630,
-        _x_main_module_232,
-        _x_main_module_231,
-        _x_main_module_230,
-        _x_main_module_229);
-    auto _x_main_module_632 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_631);
-    auto _x_main_module_633 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        _x_main_module_605);
-    auto _x_main_module_634 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_633,
-        _x_main_module_228);
-    auto _x_main_module_635 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_634,
-        _x_main_module_227,
-        _x_main_module_226,
-        _x_main_module_225,
-        _x_main_module_224);
-    auto _x_main_module_636 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_635);
-    auto _x_main_module_637 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_608,
-        _x_main_module_617,
-        _x_main_module_632,
-        _x_main_module_636);
-    auto _x_main_module_638 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_637,
-        _x_main_module_223);
-    auto _x_main_module_639 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_638,
-        _x_main_module_222,
-        _x_main_module_221,
-        _x_main_module_220,
-        _x_main_module_219);
-    auto _x_main_module_640 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_639);
-    auto _x_main_module_641 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_637,
-        _x_main_module_218);
-    auto _x_main_module_642 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_641,
-        _x_main_module_217,
-        _x_main_module_216,
-        _x_main_module_215,
-        _x_main_module_214);
-    auto _x_main_module_643 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_642);
-    auto _x_main_module_644 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_643,
-        _x_main_module_213);
-    auto _x_main_module_645 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_644,
-        _x_main_module_212,
-        _x_main_module_211,
-        _x_main_module_210,
-        _x_main_module_209);
-    auto _x_main_module_646 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_645);
-    auto _x_main_module_647 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_646,
-        _x_main_module_208);
-    auto _x_main_module_648 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_647,
-        _x_main_module_207,
-        _x_main_module_206,
-        _x_main_module_205,
-        _x_main_module_204);
-    auto _x_main_module_649 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_648);
-    auto _x_main_module_650 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_637,
-        _x_main_module_203);
-    auto _x_main_module_651 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_650,
-        _x_main_module_202,
-        _x_main_module_201,
-        _x_main_module_200,
-        _x_main_module_199);
-    auto _x_main_module_652 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_651);
-    auto _x_main_module_653 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_652,
-        _x_main_module_198);
-    auto _x_main_module_654 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_653,
-        _x_main_module_197,
-        _x_main_module_196,
-        _x_main_module_195,
-        _x_main_module_194);
-    auto _x_main_module_655 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_654);
-    auto _x_main_module_656 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_655,
-        _x_main_module_193);
-    auto _x_main_module_657 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_656,
-        _x_main_module_192,
-        _x_main_module_191,
-        _x_main_module_190,
-        _x_main_module_189);
-    auto _x_main_module_658 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_657);
-    auto _x_main_module_659 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_658,
-        _x_main_module_188);
-    auto _x_main_module_660 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_659,
-        _x_main_module_187,
-        _x_main_module_186,
-        _x_main_module_185,
-        _x_main_module_184);
-    auto _x_main_module_661 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_660);
-    auto _x_main_module_662 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_661,
-        _x_main_module_183);
-    auto _x_main_module_663 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_662,
-        _x_main_module_182,
-        _x_main_module_181,
-        _x_main_module_180,
-        _x_main_module_179);
-    auto _x_main_module_664 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_663);
-    auto _x_main_module_665 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        _x_main_module_637);
-    auto _x_main_module_666 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_665,
-        _x_main_module_178);
-    auto _x_main_module_667 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_666,
-        _x_main_module_177,
-        _x_main_module_176,
-        _x_main_module_175,
-        _x_main_module_174);
-    auto _x_main_module_668 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_667);
-    auto _x_main_module_669 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_640,
-        _x_main_module_649,
-        _x_main_module_664,
-        _x_main_module_668);
-    auto _x_main_module_670 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_669,
-        _x_main_module_173);
-    auto _x_main_module_671 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_670,
-        _x_main_module_172,
-        _x_main_module_171,
-        _x_main_module_170,
-        _x_main_module_169);
-    auto _x_main_module_672 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_671);
-    auto _x_main_module_673 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_669,
-        _x_main_module_168);
-    auto _x_main_module_674 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_673,
-        _x_main_module_167,
-        _x_main_module_166,
-        _x_main_module_165,
-        _x_main_module_164);
-    auto _x_main_module_675 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_674);
-    auto _x_main_module_676 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_675,
-        _x_main_module_163);
-    auto _x_main_module_677 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_676,
-        _x_main_module_162,
-        _x_main_module_161,
-        _x_main_module_160,
-        _x_main_module_159);
-    auto _x_main_module_678 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_677);
-    auto _x_main_module_679 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_678,
-        _x_main_module_158);
-    auto _x_main_module_680 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_679,
-        _x_main_module_157,
-        _x_main_module_156,
-        _x_main_module_155,
-        _x_main_module_154);
-    auto _x_main_module_681 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_680);
-    auto _x_main_module_682 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_669,
-        _x_main_module_153);
-    auto _x_main_module_683 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_682,
-        _x_main_module_152,
-        _x_main_module_151,
-        _x_main_module_150,
-        _x_main_module_149);
-    auto _x_main_module_684 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_683);
-    auto _x_main_module_685 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_684,
-        _x_main_module_148);
-    auto _x_main_module_686 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_685,
-        _x_main_module_147,
-        _x_main_module_146,
-        _x_main_module_145,
-        _x_main_module_144);
-    auto _x_main_module_687 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_686);
-    auto _x_main_module_688 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_687,
-        _x_main_module_143);
-    auto _x_main_module_689 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_688,
-        _x_main_module_142,
-        _x_main_module_141,
-        _x_main_module_140,
-        _x_main_module_139);
-    auto _x_main_module_690 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_689);
-    auto _x_main_module_691 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_690,
-        _x_main_module_138);
-    auto _x_main_module_692 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_691,
-        _x_main_module_137,
-        _x_main_module_136,
-        _x_main_module_135,
-        _x_main_module_134);
-    auto _x_main_module_693 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_692);
-    auto _x_main_module_694 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_693,
-        _x_main_module_133);
-    auto _x_main_module_695 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_694,
-        _x_main_module_132,
-        _x_main_module_131,
-        _x_main_module_130,
-        _x_main_module_129);
-    auto _x_main_module_696 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_695);
-    auto _x_main_module_697 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        _x_main_module_669);
-    auto _x_main_module_698 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_697,
-        _x_main_module_128);
-    auto _x_main_module_699 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_698,
-        _x_main_module_127,
-        _x_main_module_126,
-        _x_main_module_125,
-        _x_main_module_124);
-    auto _x_main_module_700 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_699);
-    auto _x_main_module_701 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_672,
-        _x_main_module_681,
-        _x_main_module_696,
-        _x_main_module_700);
-    auto _x_main_module_702 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_701,
-        _x_main_module_123);
-    auto _x_main_module_703 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_702,
-        _x_main_module_122,
-        _x_main_module_121,
-        _x_main_module_120,
-        _x_main_module_119);
-    auto _x_main_module_704 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_703);
-    auto _x_main_module_705 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_704,
-        _x_main_module_118);
-    auto _x_main_module_706 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_705,
-        _x_main_module_117,
-        _x_main_module_116,
-        _x_main_module_115,
-        _x_main_module_114);
-    auto _x_main_module_707 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_706);
-    auto _x_main_module_708 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_701,
-        _x_main_module_113);
-    auto _x_main_module_709 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_708,
-        _x_main_module_112,
-        _x_main_module_111,
-        _x_main_module_110,
-        _x_main_module_109);
-    auto _x_main_module_710 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_709);
-    auto _x_main_module_711 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_710,
-        _x_main_module_108);
-    auto _x_main_module_712 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_711,
-        _x_main_module_107,
-        _x_main_module_106,
-        _x_main_module_105,
-        _x_main_module_104);
-    auto _x_main_module_713 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_712);
-    auto _x_main_module_714 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_713,
-        _x_main_module_103);
-    auto _x_main_module_715 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_714,
-        _x_main_module_102,
-        _x_main_module_101,
-        _x_main_module_100,
-        _x_main_module_99);
-    auto _x_main_module_716 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_715);
-    auto _x_main_module_717 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_716,
-        _x_main_module_98);
-    auto _x_main_module_718 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_717,
-        _x_main_module_97,
-        _x_main_module_96,
-        _x_main_module_95,
-        _x_main_module_94);
-    auto _x_main_module_719 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_718);
-    auto _x_main_module_720 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
-        _x_main_module_701);
-    auto _x_main_module_721 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_707,
-        _x_main_module_719,
-        _x_main_module_720);
-    auto _x_main_module_722 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_721,
-        _x_main_module_93);
-    auto _x_main_module_723 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_722,
-        _x_main_module_92,
-        _x_main_module_91,
-        _x_main_module_90,
-        _x_main_module_89);
-    auto _x_main_module_724 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_723);
-    auto _x_main_module_725 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_721,
-        _x_main_module_88);
-    auto _x_main_module_726 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_725,
-        _x_main_module_87,
-        _x_main_module_86,
-        _x_main_module_85,
-        _x_main_module_84);
-    auto _x_main_module_727 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_726);
-    auto _x_main_module_728 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_727,
-        _x_main_module_83);
-    auto _x_main_module_729 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_728,
-        _x_main_module_82,
-        _x_main_module_81,
-        _x_main_module_80,
-        _x_main_module_79);
-    auto _x_main_module_730 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_729);
-    auto _x_main_module_731 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_727,
-        _x_main_module_78);
-    auto _x_main_module_732 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_731,
-        _x_main_module_77,
-        _x_main_module_76,
-        _x_main_module_75,
-        _x_main_module_74);
-    auto _x_main_module_733 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_732);
-    auto _x_main_module_734 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_730,
-        _x_main_module_733);
-    auto _x_main_module_735 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_721,
-        _x_main_module_73);
-    auto _x_main_module_736 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_735,
-        _x_main_module_72,
-        _x_main_module_71,
-        _x_main_module_70,
-        _x_main_module_69);
-    auto _x_main_module_737 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_736);
-    auto _x_main_module_738 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_737,
-        _x_main_module_68);
-    auto _x_main_module_739 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_738,
-        _x_main_module_67,
-        _x_main_module_66,
-        _x_main_module_65,
-        _x_main_module_64);
-    auto _x_main_module_740 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_739);
-    auto _x_main_module_741 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_740,
-        _x_main_module_63);
-    auto _x_main_module_742 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_741,
-        _x_main_module_62,
-        _x_main_module_61,
-        _x_main_module_60,
-        _x_main_module_59);
-    auto _x_main_module_743 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_742);
-    auto _x_main_module_744 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_740,
-        _x_main_module_58);
-    auto _x_main_module_745 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_744,
-        _x_main_module_57,
-        _x_main_module_56,
-        _x_main_module_55,
-        _x_main_module_54);
-    auto _x_main_module_746 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_745);
-    auto _x_main_module_747 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_743,
-        _x_main_module_746);
-    auto _x_main_module_748 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        _x_main_module_721);
-    auto _x_main_module_749 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_748,
-        _x_main_module_53);
-    auto _x_main_module_750 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_749,
-        _x_main_module_52,
-        _x_main_module_51,
-        _x_main_module_50,
-        _x_main_module_49);
-    auto _x_main_module_751 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_750);
-    auto _x_main_module_752 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_724,
-        _x_main_module_734,
-        _x_main_module_747,
-        _x_main_module_751);
-    auto _x_main_module_753 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_752,
-        _x_main_module_48);
-    auto _x_main_module_754 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_753,
-        _x_main_module_47,
-        _x_main_module_46,
-        _x_main_module_45,
-        _x_main_module_44);
-    auto _x_main_module_755 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_754);
-    auto _x_main_module_756 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_752,
-        _x_main_module_43);
-    auto _x_main_module_757 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_756,
-        _x_main_module_42,
-        _x_main_module_41,
-        _x_main_module_40,
-        _x_main_module_39);
-    auto _x_main_module_758 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_757);
-    auto _x_main_module_759 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_758,
-        _x_main_module_38);
-    auto _x_main_module_760 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_759,
-        _x_main_module_37,
-        _x_main_module_36,
-        _x_main_module_35,
-        _x_main_module_34);
-    auto _x_main_module_761 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_760);
-    auto _x_main_module_762 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_758,
-        _x_main_module_33);
-    auto _x_main_module_763 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_762,
-        _x_main_module_32,
-        _x_main_module_31,
-        _x_main_module_30,
-        _x_main_module_29);
-    auto _x_main_module_764 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_763);
-    auto _x_main_module_765 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_761,
-        _x_main_module_764);
-    auto _x_main_module_766 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_752,
-        _x_main_module_28);
-    auto _x_main_module_767 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_766,
-        _x_main_module_27,
-        _x_main_module_26,
-        _x_main_module_25,
-        _x_main_module_24);
-    auto _x_main_module_768 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_767);
-    auto _x_main_module_769 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_768,
-        _x_main_module_23);
-    auto _x_main_module_770 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_769,
-        _x_main_module_22,
-        _x_main_module_21,
-        _x_main_module_20,
-        _x_main_module_19);
-    auto _x_main_module_771 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_770);
-    auto _x_main_module_772 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_771,
-        _x_main_module_18);
-    auto _x_main_module_773 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_772,
-        _x_main_module_17,
-        _x_main_module_16,
-        _x_main_module_15,
-        _x_main_module_14);
-    auto _x_main_module_774 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_773);
-    auto _x_main_module_775 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_771,
-        _x_main_module_13);
-    auto _x_main_module_776 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_775,
-        _x_main_module_12,
-        _x_main_module_11,
-        _x_main_module_10,
-        _x_main_module_9);
-    auto _x_main_module_777 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_776);
-    auto _x_main_module_778 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_774,
-        _x_main_module_777);
-    auto _x_main_module_779 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
-        _x_main_module_752);
-    auto _x_main_module_780 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_779,
-        _x_main_module_8);
-    auto _x_main_module_781 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_780,
-        _x_main_module_7,
-        _x_main_module_6,
-        _x_main_module_5,
-        _x_main_module_4);
-    auto _x_main_module_782 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_781);
-    auto _x_main_module_783 = mmain->add_instruction(
-        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_755,
-        _x_main_module_765,
-        _x_main_module_778,
-        _x_main_module_782);
-    auto _x_main_module_784 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[8,8],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[0,0,0,0],\"stride\":[8,8]}")),
-        _x_main_module_783);
-    auto _x_main_module_785 =
-        mmain->add_instruction(migraphx::make_op("identity"), _x_main_module_784);
-    auto _x_main_module_786 = mmain->add_instruction(
-        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_785);
-    auto _x_main_module_787 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
-        _x_main_module_3);
-    auto _x_main_module_788 =
-        mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_786, _x_main_module_787);
-    auto _x_main_module_789 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        _x_main_module_2);
-    auto _x_main_module_790 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        _x_main_module_0);
-    auto _x_main_module_791 =
-        mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_789, _x_main_module_790);
-    auto _x_main_module_792 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_788, _x_main_module_791);
-    mmain->add_return({_x_main_module_792});
+migraphx::module_ref mmain = p.get_main_module();
+auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 299, 299}});
+auto x_main_module_2 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
+auto x_main_module_3 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
+auto x_main_module_4 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 3)));
+auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 4));
+auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 5));
+auto x_main_module_7 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 6)));
+auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 2048, 1, 1}}, 7));
+auto x_main_module_9 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 8)));
+auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 9));
+auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 10));
+auto x_main_module_12 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 11)));
+auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 12));
+auto x_main_module_14 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13)));
+auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 14));
+auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 15));
+auto x_main_module_17 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 16)));
+auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 17));
+auto x_main_module_19 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 18)));
+auto x_main_module_20 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 19));
+auto x_main_module_21 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 20));
+auto x_main_module_22 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 21)));
+auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 22));
+auto x_main_module_24 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 23)));
+auto x_main_module_25 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 24));
+auto x_main_module_26 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 25));
+auto x_main_module_27 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 26)));
+auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448, 2048, 1, 1}}, 27));
+auto x_main_module_29 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 28)));
+auto x_main_module_30 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 29)));
+auto x_main_module_31 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 30));
+auto x_main_module_32 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 31)));
+auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 32));
+auto x_main_module_34 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 33)));
+auto x_main_module_35 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 34)));
+auto x_main_module_36 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 35));
+auto x_main_module_37 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 36)));
+auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 37));
+auto x_main_module_39 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 38)));
+auto x_main_module_40 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 39));
+auto x_main_module_41 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 40));
+auto x_main_module_42 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 41)));
+auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 2048, 1, 1}}, 42));
+auto x_main_module_44 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 43)));
+auto x_main_module_45 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 44));
+auto x_main_module_46 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 45));
+auto x_main_module_47 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 46)));
+auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 2048, 1, 1}}, 47));
+auto x_main_module_49 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 48)));
+auto x_main_module_50 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 49));
+auto x_main_module_51 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 50));
+auto x_main_module_52 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 51)));
+auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 1280, 1, 1}}, 52));
+auto x_main_module_54 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 53)));
+auto x_main_module_55 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 54));
+auto x_main_module_56 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 55));
+auto x_main_module_57 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 56)));
+auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 57));
+auto x_main_module_59 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 58)));
+auto x_main_module_60 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 59));
+auto x_main_module_61 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 60));
+auto x_main_module_62 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 61)));
+auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 62));
+auto x_main_module_64 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 63)));
+auto x_main_module_65 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 64));
+auto x_main_module_66 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 65));
+auto x_main_module_67 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 66)));
+auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 67));
+auto x_main_module_69 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 68)));
+auto x_main_module_70 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 69));
+auto x_main_module_71 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 70));
+auto x_main_module_72 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 71)));
+auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448, 1280, 1, 1}}, 72));
+auto x_main_module_74 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 73)));
+auto x_main_module_75 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 74));
+auto x_main_module_76 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 75));
+auto x_main_module_77 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 76)));
+auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 77));
+auto x_main_module_79 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 78)));
+auto x_main_module_80 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 79));
+auto x_main_module_81 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 80));
+auto x_main_module_82 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 81)));
+auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 82));
+auto x_main_module_84 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 83)));
+auto x_main_module_85 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 84));
+auto x_main_module_86 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 85));
+auto x_main_module_87 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 86)));
+auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 1280, 1, 1}}, 87));
+auto x_main_module_89 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 88)));
+auto x_main_module_90 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 89));
+auto x_main_module_91 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 90));
+auto x_main_module_92 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 91)));
+auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 1280, 1, 1}}, 92));
+auto x_main_module_94 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 93)));
+auto x_main_module_95 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 94));
+auto x_main_module_96 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 95));
+auto x_main_module_97 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 96)));
+auto x_main_module_98 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 3, 3}}, 97));
+auto x_main_module_99 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 98)));
+auto x_main_module_100 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 99));
+auto x_main_module_101 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 100));
+auto x_main_module_102 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 101)));
+auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 102));
+auto x_main_module_104 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 103)));
+auto x_main_module_105 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 104));
+auto x_main_module_106 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 105));
+auto x_main_module_107 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 106)));
+auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 107));
+auto x_main_module_109 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 108)));
+auto x_main_module_110 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 109));
+auto x_main_module_111 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 110));
+auto x_main_module_112 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 111)));
+auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 112));
+auto x_main_module_114 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 113)));
+auto x_main_module_115 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 114));
+auto x_main_module_116 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 115));
+auto x_main_module_117 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 116)));
+auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 192, 3, 3}}, 117));
+auto x_main_module_119 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 118)));
+auto x_main_module_120 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 119));
+auto x_main_module_121 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 120));
+auto x_main_module_122 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 121)));
+auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 122));
+auto x_main_module_124 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 123)));
+auto x_main_module_125 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 124));
+auto x_main_module_126 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 125));
+auto x_main_module_127 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 126)));
+auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 127));
+auto x_main_module_129 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 128)));
+auto x_main_module_130 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 129));
+auto x_main_module_131 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 130));
+auto x_main_module_132 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 131)));
+auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 132));
+auto x_main_module_134 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 133)));
+auto x_main_module_135 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 134));
+auto x_main_module_136 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 135));
+auto x_main_module_137 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 136)));
+auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 137));
+auto x_main_module_139 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 138)));
+auto x_main_module_140 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 139));
+auto x_main_module_141 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 140));
+auto x_main_module_142 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 141)));
+auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 142));
+auto x_main_module_144 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 143)));
+auto x_main_module_145 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 144));
+auto x_main_module_146 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 145));
+auto x_main_module_147 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 146)));
+auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 147));
+auto x_main_module_149 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 148)));
+auto x_main_module_150 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 149));
+auto x_main_module_151 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 150));
+auto x_main_module_152 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 151)));
+auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 152));
+auto x_main_module_154 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 153)));
+auto x_main_module_155 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 154));
+auto x_main_module_156 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 155));
+auto x_main_module_157 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 156)));
+auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 157));
+auto x_main_module_159 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 158)));
+auto x_main_module_160 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 159));
+auto x_main_module_161 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 160));
+auto x_main_module_162 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 161)));
+auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 162));
+auto x_main_module_164 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 163)));
+auto x_main_module_165 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 164));
+auto x_main_module_166 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 165));
+auto x_main_module_167 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 166)));
+auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 167));
+auto x_main_module_169 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 168)));
+auto x_main_module_170 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 169));
+auto x_main_module_171 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 170));
+auto x_main_module_172 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 171)));
+auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 172));
+auto x_main_module_174 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 173)));
+auto x_main_module_175 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 174));
+auto x_main_module_176 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 175));
+auto x_main_module_177 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 176)));
+auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 177));
+auto x_main_module_179 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 178)));
+auto x_main_module_180 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 179));
+auto x_main_module_181 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 180));
+auto x_main_module_182 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 181)));
+auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 182));
+auto x_main_module_184 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 183)));
+auto x_main_module_185 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 184));
+auto x_main_module_186 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 185));
+auto x_main_module_187 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 186)));
+auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 187));
+auto x_main_module_189 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 188)));
+auto x_main_module_190 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 189));
+auto x_main_module_191 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 190));
+auto x_main_module_192 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 191)));
+auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 192));
+auto x_main_module_194 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 193)));
+auto x_main_module_195 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 194));
+auto x_main_module_196 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 195));
+auto x_main_module_197 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 196)));
+auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 197));
+auto x_main_module_199 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 198)));
+auto x_main_module_200 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 199));
+auto x_main_module_201 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 200));
+auto x_main_module_202 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 201)));
+auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 202));
+auto x_main_module_204 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 203)));
+auto x_main_module_205 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 204));
+auto x_main_module_206 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 205));
+auto x_main_module_207 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 206)));
+auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 207));
+auto x_main_module_209 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 208)));
+auto x_main_module_210 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 209));
+auto x_main_module_211 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 210));
+auto x_main_module_212 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 211)));
+auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 212));
+auto x_main_module_214 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 213)));
+auto x_main_module_215 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 214));
+auto x_main_module_216 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 215));
+auto x_main_module_217 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 216)));
+auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 217));
+auto x_main_module_219 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 218)));
+auto x_main_module_220 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 219));
+auto x_main_module_221 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 220));
+auto x_main_module_222 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 221)));
+auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 222));
+auto x_main_module_224 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 223)));
+auto x_main_module_225 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 224));
+auto x_main_module_226 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 225));
+auto x_main_module_227 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 226)));
+auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 227));
+auto x_main_module_229 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 228)));
+auto x_main_module_230 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 229));
+auto x_main_module_231 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 230));
+auto x_main_module_232 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 231)));
+auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 232));
+auto x_main_module_234 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 233)));
+auto x_main_module_235 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 234));
+auto x_main_module_236 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 235));
+auto x_main_module_237 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 236)));
+auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 237));
+auto x_main_module_239 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 238)));
+auto x_main_module_240 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 239));
+auto x_main_module_241 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 240));
+auto x_main_module_242 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 241)));
+auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 242));
+auto x_main_module_244 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 243)));
+auto x_main_module_245 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 244));
+auto x_main_module_246 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 245));
+auto x_main_module_247 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 246)));
+auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 247));
+auto x_main_module_249 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 248)));
+auto x_main_module_250 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 249));
+auto x_main_module_251 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 250));
+auto x_main_module_252 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 251)));
+auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 252));
+auto x_main_module_254 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 253)));
+auto x_main_module_255 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 254));
+auto x_main_module_256 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 255));
+auto x_main_module_257 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 256)));
+auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 257));
+auto x_main_module_259 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 258)));
+auto x_main_module_260 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 259));
+auto x_main_module_261 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 260));
+auto x_main_module_262 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 261)));
+auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 262));
+auto x_main_module_264 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 263)));
+auto x_main_module_265 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 264));
+auto x_main_module_266 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 265));
+auto x_main_module_267 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 266)));
+auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 267));
+auto x_main_module_269 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 268)));
+auto x_main_module_270 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 269));
+auto x_main_module_271 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 270));
+auto x_main_module_272 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 271)));
+auto x_main_module_273 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 272));
+auto x_main_module_274 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 273)));
+auto x_main_module_275 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 274));
+auto x_main_module_276 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 275));
+auto x_main_module_277 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 276)));
+auto x_main_module_278 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 277));
+auto x_main_module_279 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 278)));
+auto x_main_module_280 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 279));
+auto x_main_module_281 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 280));
+auto x_main_module_282 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 281)));
+auto x_main_module_283 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 128, 1, 7}}, 282));
+auto x_main_module_284 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 283)));
+auto x_main_module_285 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 284));
+auto x_main_module_286 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 285));
+auto x_main_module_287 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 286)));
+auto x_main_module_288 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 287));
+auto x_main_module_289 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 288)));
+auto x_main_module_290 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 289));
+auto x_main_module_291 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 290));
+auto x_main_module_292 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 291)));
+auto x_main_module_293 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 292));
+auto x_main_module_294 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 293)));
+auto x_main_module_295 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 294));
+auto x_main_module_296 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 295));
+auto x_main_module_297 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 296)));
+auto x_main_module_298 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 297));
+auto x_main_module_299 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 298)));
+auto x_main_module_300 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 299));
+auto x_main_module_301 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 300));
+auto x_main_module_302 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 301)));
+auto x_main_module_303 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 302));
+auto x_main_module_304 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 303)));
+auto x_main_module_305 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 304));
+auto x_main_module_306 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 305));
+auto x_main_module_307 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 306)));
+auto x_main_module_308 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 128, 7, 1}}, 307));
+auto x_main_module_309 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 308)));
+auto x_main_module_310 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 309));
+auto x_main_module_311 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 310));
+auto x_main_module_312 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 311)));
+auto x_main_module_313 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 312));
+auto x_main_module_314 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 313)));
+auto x_main_module_315 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 314));
+auto x_main_module_316 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 315));
+auto x_main_module_317 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 316)));
+auto x_main_module_318 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 317));
+auto x_main_module_319 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 318)));
+auto x_main_module_320 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 319));
+auto x_main_module_321 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 320));
+auto x_main_module_322 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 321)));
+auto x_main_module_323 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 322));
+auto x_main_module_324 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 323)));
+auto x_main_module_325 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 324));
+auto x_main_module_326 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 325));
+auto x_main_module_327 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 326)));
+auto x_main_module_328 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 327));
+auto x_main_module_329 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 328)));
+auto x_main_module_330 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 329));
+auto x_main_module_331 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 330));
+auto x_main_module_332 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 331)));
+auto x_main_module_333 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 332));
+auto x_main_module_334 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 333)));
+auto x_main_module_335 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 334));
+auto x_main_module_336 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 335));
+auto x_main_module_337 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 336)));
+auto x_main_module_338 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 337));
+auto x_main_module_339 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 338)));
+auto x_main_module_340 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 339));
+auto x_main_module_341 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 340));
+auto x_main_module_342 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 341)));
+auto x_main_module_343 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 288, 3, 3}}, 342));
+auto x_main_module_344 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 343)));
+auto x_main_module_345 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 344));
+auto x_main_module_346 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 345));
+auto x_main_module_347 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 346)));
+auto x_main_module_348 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 347));
+auto x_main_module_349 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 348)));
+auto x_main_module_350 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 349));
+auto x_main_module_351 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 350));
+auto x_main_module_352 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 351)));
+auto x_main_module_353 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 352));
+auto x_main_module_354 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 353)));
+auto x_main_module_355 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 354));
+auto x_main_module_356 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 355));
+auto x_main_module_357 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 356)));
+auto x_main_module_358 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 357));
+auto x_main_module_359 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 358)));
+auto x_main_module_360 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 359));
+auto x_main_module_361 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 360));
+auto x_main_module_362 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 361)));
+auto x_main_module_363 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 362));
+auto x_main_module_364 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 363)));
+auto x_main_module_365 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 364));
+auto x_main_module_366 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 365));
+auto x_main_module_367 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 366)));
+auto x_main_module_368 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 367));
+auto x_main_module_369 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 368)));
+auto x_main_module_370 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 369));
+auto x_main_module_371 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 370));
+auto x_main_module_372 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 371)));
+auto x_main_module_373 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 288, 1, 1}}, 372));
+auto x_main_module_374 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 373)));
+auto x_main_module_375 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 374));
+auto x_main_module_376 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 375));
+auto x_main_module_377 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 376)));
+auto x_main_module_378 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 377));
+auto x_main_module_379 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 378)));
+auto x_main_module_380 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 379));
+auto x_main_module_381 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 380));
+auto x_main_module_382 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 381)));
+auto x_main_module_383 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 382));
+auto x_main_module_384 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 383)));
+auto x_main_module_385 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 384));
+auto x_main_module_386 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 385));
+auto x_main_module_387 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 386)));
+auto x_main_module_388 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 387));
+auto x_main_module_389 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 388)));
+auto x_main_module_390 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 389));
+auto x_main_module_391 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 390));
+auto x_main_module_392 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 391)));
+auto x_main_module_393 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 392));
+auto x_main_module_394 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 393)));
+auto x_main_module_395 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 394));
+auto x_main_module_396 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 395));
+auto x_main_module_397 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 396)));
+auto x_main_module_398 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 397));
+auto x_main_module_399 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 398)));
+auto x_main_module_400 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 399));
+auto x_main_module_401 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 400));
+auto x_main_module_402 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 401)));
+auto x_main_module_403 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 402));
+auto x_main_module_404 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 403)));
+auto x_main_module_405 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 404));
+auto x_main_module_406 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 405));
+auto x_main_module_407 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 406)));
+auto x_main_module_408 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 256, 1, 1}}, 407));
+auto x_main_module_409 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 408)));
+auto x_main_module_410 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 409));
+auto x_main_module_411 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 410));
+auto x_main_module_412 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 411)));
+auto x_main_module_413 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 412));
+auto x_main_module_414 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 413)));
+auto x_main_module_415 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 414));
+auto x_main_module_416 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 415));
+auto x_main_module_417 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 416)));
+auto x_main_module_418 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 192, 1, 1}}, 417));
+auto x_main_module_419 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 418)));
+auto x_main_module_420 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 419));
+auto x_main_module_421 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 420));
+auto x_main_module_422 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 421)));
+auto x_main_module_423 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 422));
+auto x_main_module_424 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 423)));
+auto x_main_module_425 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 424));
+auto x_main_module_426 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 425));
+auto x_main_module_427 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 426)));
+auto x_main_module_428 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 427));
+auto x_main_module_429 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 428)));
+auto x_main_module_430 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 429));
+auto x_main_module_431 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 430));
+auto x_main_module_432 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 431)));
+auto x_main_module_433 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 432));
+auto x_main_module_434 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 433)));
+auto x_main_module_435 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 434));
+auto x_main_module_436 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 435));
+auto x_main_module_437 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 436)));
+auto x_main_module_438 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 437));
+auto x_main_module_439 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 438)));
+auto x_main_module_440 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 439));
+auto x_main_module_441 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 440));
+auto x_main_module_442 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 441)));
+auto x_main_module_443 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 192, 1, 1}}, 442));
+auto x_main_module_444 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 443)));
+auto x_main_module_445 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 444));
+auto x_main_module_446 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 445));
+auto x_main_module_447 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 446)));
+auto x_main_module_448 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 447));
+auto x_main_module_449 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 448)));
+auto x_main_module_450 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 449));
+auto x_main_module_451 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 450));
+auto x_main_module_452 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 451)));
+auto x_main_module_453 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 80, 3, 3}}, 452));
+auto x_main_module_454 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 453)));
+auto x_main_module_455 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 454));
+auto x_main_module_456 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 455));
+auto x_main_module_457 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 456)));
+auto x_main_module_458 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80, 64, 1, 1}}, 457));
+auto x_main_module_459 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 458)));
+auto x_main_module_460 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 459));
+auto x_main_module_461 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 460));
+auto x_main_module_462 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 461)));
+auto x_main_module_463 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 32, 3, 3}}, 462));
+auto x_main_module_464 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 463)));
+auto x_main_module_465 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 464));
+auto x_main_module_466 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 465));
+auto x_main_module_467 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 466)));
+auto x_main_module_468 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 32, 3, 3}}, 467));
+auto x_main_module_469 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 468)));
+auto x_main_module_470 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 469));
+auto x_main_module_471 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 470));
+auto x_main_module_472 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 471)));
+auto x_main_module_473 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 3, 3, 3}}, 472));
+auto x_main_module_474 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_0, x_main_module_473);
+auto x_main_module_475 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_474, x_main_module_472, x_main_module_471, x_main_module_470, x_main_module_469);
+auto x_main_module_476 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_475);
+auto x_main_module_477 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_476, x_main_module_468);
+auto x_main_module_478 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_477, x_main_module_467, x_main_module_466, x_main_module_465, x_main_module_464);
+auto x_main_module_479 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_478);
+auto x_main_module_480 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_479, x_main_module_463);
+auto x_main_module_481 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_480, x_main_module_462, x_main_module_461, x_main_module_460, x_main_module_459);
+auto x_main_module_482 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_481);
+auto x_main_module_483 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_482);
+auto x_main_module_484 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_483, x_main_module_458);
+auto x_main_module_485 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_484, x_main_module_457, x_main_module_456, x_main_module_455, x_main_module_454);
+auto x_main_module_486 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_485);
+auto x_main_module_487 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_486, x_main_module_453);
+auto x_main_module_488 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_487, x_main_module_452, x_main_module_451, x_main_module_450, x_main_module_449);
+auto x_main_module_489 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_488);
+auto x_main_module_490 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_489);
+auto x_main_module_491 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_490, x_main_module_448);
+auto x_main_module_492 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_491, x_main_module_447, x_main_module_446, x_main_module_445, x_main_module_444);
+auto x_main_module_493 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_492);
+auto x_main_module_494 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_490, x_main_module_443);
+auto x_main_module_495 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_494, x_main_module_442, x_main_module_441, x_main_module_440, x_main_module_439);
+auto x_main_module_496 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_495);
+auto x_main_module_497 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_496, x_main_module_438);
+auto x_main_module_498 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_497, x_main_module_437, x_main_module_436, x_main_module_435, x_main_module_434);
+auto x_main_module_499 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_498);
+auto x_main_module_500 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_490, x_main_module_433);
+auto x_main_module_501 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_500, x_main_module_432, x_main_module_431, x_main_module_430, x_main_module_429);
+auto x_main_module_502 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_501);
+auto x_main_module_503 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_502, x_main_module_428);
+auto x_main_module_504 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_503, x_main_module_427, x_main_module_426, x_main_module_425, x_main_module_424);
+auto x_main_module_505 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_504);
+auto x_main_module_506 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_505, x_main_module_423);
+auto x_main_module_507 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_506, x_main_module_422, x_main_module_421, x_main_module_420, x_main_module_419);
+auto x_main_module_508 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_507);
+auto x_main_module_509 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_490);
+auto x_main_module_510 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_509, x_main_module_418);
+auto x_main_module_511 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_510, x_main_module_417, x_main_module_416, x_main_module_415, x_main_module_414);
+auto x_main_module_512 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_511);
+auto x_main_module_513 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_493, x_main_module_499, x_main_module_508, x_main_module_512);
+auto x_main_module_514 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_513, x_main_module_413);
+auto x_main_module_515 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_514, x_main_module_412, x_main_module_411, x_main_module_410, x_main_module_409);
+auto x_main_module_516 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_515);
+auto x_main_module_517 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_513, x_main_module_408);
+auto x_main_module_518 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_517, x_main_module_407, x_main_module_406, x_main_module_405, x_main_module_404);
+auto x_main_module_519 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_518);
+auto x_main_module_520 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_519, x_main_module_403);
+auto x_main_module_521 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_520, x_main_module_402, x_main_module_401, x_main_module_400, x_main_module_399);
+auto x_main_module_522 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_521);
+auto x_main_module_523 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_513, x_main_module_398);
+auto x_main_module_524 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_523, x_main_module_397, x_main_module_396, x_main_module_395, x_main_module_394);
+auto x_main_module_525 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_524);
+auto x_main_module_526 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_525, x_main_module_393);
+auto x_main_module_527 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_526, x_main_module_392, x_main_module_391, x_main_module_390, x_main_module_389);
+auto x_main_module_528 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_527);
+auto x_main_module_529 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_528, x_main_module_388);
+auto x_main_module_530 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_529, x_main_module_387, x_main_module_386, x_main_module_385, x_main_module_384);
+auto x_main_module_531 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_530);
+auto x_main_module_532 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_513);
+auto x_main_module_533 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_532, x_main_module_383);
+auto x_main_module_534 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_533, x_main_module_382, x_main_module_381, x_main_module_380, x_main_module_379);
+auto x_main_module_535 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_534);
+auto x_main_module_536 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_516, x_main_module_522, x_main_module_531, x_main_module_535);
+auto x_main_module_537 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_536, x_main_module_378);
+auto x_main_module_538 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_537, x_main_module_377, x_main_module_376, x_main_module_375, x_main_module_374);
+auto x_main_module_539 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_538);
+auto x_main_module_540 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_536, x_main_module_373);
+auto x_main_module_541 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_540, x_main_module_372, x_main_module_371, x_main_module_370, x_main_module_369);
+auto x_main_module_542 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_541);
+auto x_main_module_543 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_542, x_main_module_368);
+auto x_main_module_544 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_543, x_main_module_367, x_main_module_366, x_main_module_365, x_main_module_364);
+auto x_main_module_545 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_544);
+auto x_main_module_546 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_536, x_main_module_363);
+auto x_main_module_547 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_546, x_main_module_362, x_main_module_361, x_main_module_360, x_main_module_359);
+auto x_main_module_548 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_547);
+auto x_main_module_549 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_548, x_main_module_358);
+auto x_main_module_550 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_549, x_main_module_357, x_main_module_356, x_main_module_355, x_main_module_354);
+auto x_main_module_551 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_550);
+auto x_main_module_552 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_551, x_main_module_353);
+auto x_main_module_553 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_552, x_main_module_352, x_main_module_351, x_main_module_350, x_main_module_349);
+auto x_main_module_554 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_553);
+auto x_main_module_555 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_536);
+auto x_main_module_556 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_555, x_main_module_348);
+auto x_main_module_557 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_556, x_main_module_347, x_main_module_346, x_main_module_345, x_main_module_344);
+auto x_main_module_558 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_557);
+auto x_main_module_559 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_539, x_main_module_545, x_main_module_554, x_main_module_558);
+auto x_main_module_560 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_559, x_main_module_343);
+auto x_main_module_561 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_560, x_main_module_342, x_main_module_341, x_main_module_340, x_main_module_339);
+auto x_main_module_562 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_561);
+auto x_main_module_563 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_559, x_main_module_338);
+auto x_main_module_564 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_563, x_main_module_337, x_main_module_336, x_main_module_335, x_main_module_334);
+auto x_main_module_565 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_564);
+auto x_main_module_566 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_565, x_main_module_333);
+auto x_main_module_567 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_566, x_main_module_332, x_main_module_331, x_main_module_330, x_main_module_329);
+auto x_main_module_568 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_567);
+auto x_main_module_569 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_568, x_main_module_328);
+auto x_main_module_570 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_569, x_main_module_327, x_main_module_326, x_main_module_325, x_main_module_324);
+auto x_main_module_571 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_570);
+auto x_main_module_572 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_559);
+auto x_main_module_573 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_562, x_main_module_571, x_main_module_572);
+auto x_main_module_574 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_573, x_main_module_323);
+auto x_main_module_575 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_574, x_main_module_322, x_main_module_321, x_main_module_320, x_main_module_319);
+auto x_main_module_576 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_575);
+auto x_main_module_577 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_573, x_main_module_318);
+auto x_main_module_578 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_577, x_main_module_317, x_main_module_316, x_main_module_315, x_main_module_314);
+auto x_main_module_579 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_578);
+auto x_main_module_580 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_579, x_main_module_313);
+auto x_main_module_581 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_580, x_main_module_312, x_main_module_311, x_main_module_310, x_main_module_309);
+auto x_main_module_582 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_581);
+auto x_main_module_583 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_582, x_main_module_308);
+auto x_main_module_584 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_583, x_main_module_307, x_main_module_306, x_main_module_305, x_main_module_304);
+auto x_main_module_585 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_584);
+auto x_main_module_586 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_573, x_main_module_303);
+auto x_main_module_587 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_586, x_main_module_302, x_main_module_301, x_main_module_300, x_main_module_299);
+auto x_main_module_588 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_587);
+auto x_main_module_589 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_588, x_main_module_298);
+auto x_main_module_590 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_589, x_main_module_297, x_main_module_296, x_main_module_295, x_main_module_294);
+auto x_main_module_591 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_590);
+auto x_main_module_592 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_591, x_main_module_293);
+auto x_main_module_593 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_592, x_main_module_292, x_main_module_291, x_main_module_290, x_main_module_289);
+auto x_main_module_594 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_593);
+auto x_main_module_595 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_594, x_main_module_288);
+auto x_main_module_596 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_595, x_main_module_287, x_main_module_286, x_main_module_285, x_main_module_284);
+auto x_main_module_597 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_596);
+auto x_main_module_598 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_597, x_main_module_283);
+auto x_main_module_599 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_598, x_main_module_282, x_main_module_281, x_main_module_280, x_main_module_279);
+auto x_main_module_600 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_599);
+auto x_main_module_601 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_573);
+auto x_main_module_602 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_601, x_main_module_278);
+auto x_main_module_603 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_602, x_main_module_277, x_main_module_276, x_main_module_275, x_main_module_274);
+auto x_main_module_604 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_603);
+auto x_main_module_605 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_576, x_main_module_585, x_main_module_600, x_main_module_604);
+auto x_main_module_606 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_605, x_main_module_273);
+auto x_main_module_607 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_606, x_main_module_272, x_main_module_271, x_main_module_270, x_main_module_269);
+auto x_main_module_608 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_607);
+auto x_main_module_609 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_605, x_main_module_268);
+auto x_main_module_610 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_609, x_main_module_267, x_main_module_266, x_main_module_265, x_main_module_264);
+auto x_main_module_611 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_610);
+auto x_main_module_612 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_611, x_main_module_263);
+auto x_main_module_613 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_612, x_main_module_262, x_main_module_261, x_main_module_260, x_main_module_259);
+auto x_main_module_614 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_613);
+auto x_main_module_615 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_614, x_main_module_258);
+auto x_main_module_616 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_615, x_main_module_257, x_main_module_256, x_main_module_255, x_main_module_254);
+auto x_main_module_617 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_616);
+auto x_main_module_618 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_605, x_main_module_253);
+auto x_main_module_619 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_618, x_main_module_252, x_main_module_251, x_main_module_250, x_main_module_249);
+auto x_main_module_620 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_619);
+auto x_main_module_621 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_620, x_main_module_248);
+auto x_main_module_622 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_621, x_main_module_247, x_main_module_246, x_main_module_245, x_main_module_244);
+auto x_main_module_623 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_622);
+auto x_main_module_624 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_623, x_main_module_243);
+auto x_main_module_625 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_624, x_main_module_242, x_main_module_241, x_main_module_240, x_main_module_239);
+auto x_main_module_626 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_625);
+auto x_main_module_627 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_626, x_main_module_238);
+auto x_main_module_628 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_627, x_main_module_237, x_main_module_236, x_main_module_235, x_main_module_234);
+auto x_main_module_629 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_628);
+auto x_main_module_630 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_629, x_main_module_233);
+auto x_main_module_631 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_630, x_main_module_232, x_main_module_231, x_main_module_230, x_main_module_229);
+auto x_main_module_632 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_631);
+auto x_main_module_633 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_605);
+auto x_main_module_634 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_633, x_main_module_228);
+auto x_main_module_635 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_634, x_main_module_227, x_main_module_226, x_main_module_225, x_main_module_224);
+auto x_main_module_636 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_635);
+auto x_main_module_637 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_608, x_main_module_617, x_main_module_632, x_main_module_636);
+auto x_main_module_638 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_637, x_main_module_223);
+auto x_main_module_639 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_638, x_main_module_222, x_main_module_221, x_main_module_220, x_main_module_219);
+auto x_main_module_640 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_639);
+auto x_main_module_641 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_637, x_main_module_218);
+auto x_main_module_642 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_641, x_main_module_217, x_main_module_216, x_main_module_215, x_main_module_214);
+auto x_main_module_643 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_642);
+auto x_main_module_644 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_643, x_main_module_213);
+auto x_main_module_645 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_644, x_main_module_212, x_main_module_211, x_main_module_210, x_main_module_209);
+auto x_main_module_646 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_645);
+auto x_main_module_647 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_646, x_main_module_208);
+auto x_main_module_648 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_647, x_main_module_207, x_main_module_206, x_main_module_205, x_main_module_204);
+auto x_main_module_649 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_648);
+auto x_main_module_650 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_637, x_main_module_203);
+auto x_main_module_651 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_650, x_main_module_202, x_main_module_201, x_main_module_200, x_main_module_199);
+auto x_main_module_652 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_651);
+auto x_main_module_653 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_652, x_main_module_198);
+auto x_main_module_654 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_653, x_main_module_197, x_main_module_196, x_main_module_195, x_main_module_194);
+auto x_main_module_655 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_654);
+auto x_main_module_656 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_655, x_main_module_193);
+auto x_main_module_657 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_656, x_main_module_192, x_main_module_191, x_main_module_190, x_main_module_189);
+auto x_main_module_658 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_657);
+auto x_main_module_659 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_658, x_main_module_188);
+auto x_main_module_660 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_659, x_main_module_187, x_main_module_186, x_main_module_185, x_main_module_184);
+auto x_main_module_661 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_660);
+auto x_main_module_662 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_661, x_main_module_183);
+auto x_main_module_663 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_662, x_main_module_182, x_main_module_181, x_main_module_180, x_main_module_179);
+auto x_main_module_664 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_663);
+auto x_main_module_665 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_637);
+auto x_main_module_666 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_665, x_main_module_178);
+auto x_main_module_667 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_666, x_main_module_177, x_main_module_176, x_main_module_175, x_main_module_174);
+auto x_main_module_668 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_667);
+auto x_main_module_669 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_640, x_main_module_649, x_main_module_664, x_main_module_668);
+auto x_main_module_670 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_669, x_main_module_173);
+auto x_main_module_671 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_670, x_main_module_172, x_main_module_171, x_main_module_170, x_main_module_169);
+auto x_main_module_672 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_671);
+auto x_main_module_673 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_669, x_main_module_168);
+auto x_main_module_674 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_673, x_main_module_167, x_main_module_166, x_main_module_165, x_main_module_164);
+auto x_main_module_675 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_674);
+auto x_main_module_676 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_675, x_main_module_163);
+auto x_main_module_677 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_676, x_main_module_162, x_main_module_161, x_main_module_160, x_main_module_159);
+auto x_main_module_678 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_677);
+auto x_main_module_679 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_678, x_main_module_158);
+auto x_main_module_680 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_679, x_main_module_157, x_main_module_156, x_main_module_155, x_main_module_154);
+auto x_main_module_681 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_680);
+auto x_main_module_682 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_669, x_main_module_153);
+auto x_main_module_683 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_682, x_main_module_152, x_main_module_151, x_main_module_150, x_main_module_149);
+auto x_main_module_684 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_683);
+auto x_main_module_685 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_684, x_main_module_148);
+auto x_main_module_686 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_685, x_main_module_147, x_main_module_146, x_main_module_145, x_main_module_144);
+auto x_main_module_687 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_686);
+auto x_main_module_688 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_687, x_main_module_143);
+auto x_main_module_689 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_688, x_main_module_142, x_main_module_141, x_main_module_140, x_main_module_139);
+auto x_main_module_690 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_689);
+auto x_main_module_691 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_690, x_main_module_138);
+auto x_main_module_692 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_691, x_main_module_137, x_main_module_136, x_main_module_135, x_main_module_134);
+auto x_main_module_693 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_692);
+auto x_main_module_694 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_693, x_main_module_133);
+auto x_main_module_695 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_694, x_main_module_132, x_main_module_131, x_main_module_130, x_main_module_129);
+auto x_main_module_696 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_695);
+auto x_main_module_697 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_669);
+auto x_main_module_698 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_697, x_main_module_128);
+auto x_main_module_699 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_698, x_main_module_127, x_main_module_126, x_main_module_125, x_main_module_124);
+auto x_main_module_700 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_699);
+auto x_main_module_701 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_672, x_main_module_681, x_main_module_696, x_main_module_700);
+auto x_main_module_702 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_701, x_main_module_123);
+auto x_main_module_703 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_702, x_main_module_122, x_main_module_121, x_main_module_120, x_main_module_119);
+auto x_main_module_704 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_703);
+auto x_main_module_705 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_704, x_main_module_118);
+auto x_main_module_706 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_705, x_main_module_117, x_main_module_116, x_main_module_115, x_main_module_114);
+auto x_main_module_707 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_706);
+auto x_main_module_708 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_701, x_main_module_113);
+auto x_main_module_709 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_708, x_main_module_112, x_main_module_111, x_main_module_110, x_main_module_109);
+auto x_main_module_710 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_709);
+auto x_main_module_711 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_710, x_main_module_108);
+auto x_main_module_712 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_711, x_main_module_107, x_main_module_106, x_main_module_105, x_main_module_104);
+auto x_main_module_713 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_712);
+auto x_main_module_714 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_713, x_main_module_103);
+auto x_main_module_715 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_714, x_main_module_102, x_main_module_101, x_main_module_100, x_main_module_99);
+auto x_main_module_716 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_715);
+auto x_main_module_717 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_716, x_main_module_98);
+auto x_main_module_718 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_717, x_main_module_97, x_main_module_96, x_main_module_95, x_main_module_94);
+auto x_main_module_719 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_718);
+auto x_main_module_720 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_701);
+auto x_main_module_721 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_707, x_main_module_719, x_main_module_720);
+auto x_main_module_722 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_721, x_main_module_93);
+auto x_main_module_723 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_722, x_main_module_92, x_main_module_91, x_main_module_90, x_main_module_89);
+auto x_main_module_724 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_723);
+auto x_main_module_725 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_721, x_main_module_88);
+auto x_main_module_726 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_725, x_main_module_87, x_main_module_86, x_main_module_85, x_main_module_84);
+auto x_main_module_727 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_726);
+auto x_main_module_728 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_727, x_main_module_83);
+auto x_main_module_729 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_728, x_main_module_82, x_main_module_81, x_main_module_80, x_main_module_79);
+auto x_main_module_730 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_729);
+auto x_main_module_731 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_727, x_main_module_78);
+auto x_main_module_732 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_731, x_main_module_77, x_main_module_76, x_main_module_75, x_main_module_74);
+auto x_main_module_733 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_732);
+auto x_main_module_734 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_730, x_main_module_733);
+auto x_main_module_735 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_721, x_main_module_73);
+auto x_main_module_736 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_735, x_main_module_72, x_main_module_71, x_main_module_70, x_main_module_69);
+auto x_main_module_737 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_736);
+auto x_main_module_738 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_737, x_main_module_68);
+auto x_main_module_739 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_738, x_main_module_67, x_main_module_66, x_main_module_65, x_main_module_64);
+auto x_main_module_740 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_739);
+auto x_main_module_741 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_740, x_main_module_63);
+auto x_main_module_742 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_741, x_main_module_62, x_main_module_61, x_main_module_60, x_main_module_59);
+auto x_main_module_743 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_742);
+auto x_main_module_744 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_740, x_main_module_58);
+auto x_main_module_745 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_744, x_main_module_57, x_main_module_56, x_main_module_55, x_main_module_54);
+auto x_main_module_746 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_745);
+auto x_main_module_747 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_743, x_main_module_746);
+auto x_main_module_748 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_721);
+auto x_main_module_749 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_748, x_main_module_53);
+auto x_main_module_750 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_749, x_main_module_52, x_main_module_51, x_main_module_50, x_main_module_49);
+auto x_main_module_751 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_750);
+auto x_main_module_752 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_724, x_main_module_734, x_main_module_747, x_main_module_751);
+auto x_main_module_753 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_752, x_main_module_48);
+auto x_main_module_754 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_753, x_main_module_47, x_main_module_46, x_main_module_45, x_main_module_44);
+auto x_main_module_755 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_754);
+auto x_main_module_756 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_752, x_main_module_43);
+auto x_main_module_757 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_756, x_main_module_42, x_main_module_41, x_main_module_40, x_main_module_39);
+auto x_main_module_758 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_757);
+auto x_main_module_759 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_758, x_main_module_38);
+auto x_main_module_760 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_759, x_main_module_37, x_main_module_36, x_main_module_35, x_main_module_34);
+auto x_main_module_761 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_760);
+auto x_main_module_762 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_758, x_main_module_33);
+auto x_main_module_763 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_762, x_main_module_32, x_main_module_31, x_main_module_30, x_main_module_29);
+auto x_main_module_764 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_763);
+auto x_main_module_765 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_761, x_main_module_764);
+auto x_main_module_766 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_752, x_main_module_28);
+auto x_main_module_767 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_766, x_main_module_27, x_main_module_26, x_main_module_25, x_main_module_24);
+auto x_main_module_768 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_767);
+auto x_main_module_769 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_768, x_main_module_23);
+auto x_main_module_770 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_769, x_main_module_22, x_main_module_21, x_main_module_20, x_main_module_19);
+auto x_main_module_771 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_770);
+auto x_main_module_772 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_771, x_main_module_18);
+auto x_main_module_773 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_772, x_main_module_17, x_main_module_16, x_main_module_15, x_main_module_14);
+auto x_main_module_774 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_773);
+auto x_main_module_775 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_771, x_main_module_13);
+auto x_main_module_776 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_775, x_main_module_12, x_main_module_11, x_main_module_10, x_main_module_9);
+auto x_main_module_777 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_776);
+auto x_main_module_778 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_774, x_main_module_777);
+auto x_main_module_779 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_752);
+auto x_main_module_780 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_779, x_main_module_8);
+auto x_main_module_781 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_780, x_main_module_7, x_main_module_6, x_main_module_5, x_main_module_4);
+auto x_main_module_782 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_781);
+auto x_main_module_783 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_755, x_main_module_765, x_main_module_778, x_main_module_782);
+auto x_main_module_784 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[8,8],\"lp_order\":2,\"mode\":0,\"padding\":[0,0,0,0],\"stride\":[8,8]}")), x_main_module_783);
+auto x_main_module_785 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_784);
+auto x_main_module_786 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), x_main_module_785);
+auto x_main_module_787 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_3);
+auto x_main_module_788 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_786, x_main_module_787);
+auto x_main_module_789 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_2);
+auto x_main_module_790 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_0);
+auto x_main_module_791 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_789, x_main_module_790);
+auto x_main_module_792 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_788, x_main_module_791);
+mmain->add_return({x_main_module_792});
+
 
     return p;
 }

--- a/src/driver/inceptionv3.cpp
+++ b/src/driver/inceptionv3.cpp
@@ -27,1916 +27,808 @@
 #include <migraphx/generate.hpp>
 #include <migraphx/json.hpp>
 #include "models.hpp"
-
 namespace migraphx {
 namespace driver {
 inline namespace MIGRAPHX_INLINE_NS {
-
 migraphx::program inceptionv3(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-    migraphx::module_ref mmain = p.get_main_module();
-    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-    auto x_input_1             = mmain->add_parameter(
-        "input.1", migraphx::shape{migraphx::shape::float_type, {batch, 3, 299, 299}});
-    auto x_main_module_2 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 1));
-    auto x_main_module_3 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 2));
-    auto x_main_module_4 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 3));
-    auto x_main_module_5 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 4));
-    auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 5));
-    auto x_main_module_7 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 6));
-    auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 7));
-    auto x_main_module_9 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 8));
-    auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 288, 3, 3}}, 9));
-    auto x_main_module_11 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 10));
-    auto x_main_module_12 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 11));
-    auto x_main_module_13 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 12));
-    auto x_main_module_14 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 13));
-    auto x_main_module_15 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 14));
-    auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 15));
-    auto x_main_module_17 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 16));
-    auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 17));
-    auto x_main_module_19 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 18));
-    auto x_main_module_20 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 19));
-    auto x_main_module_21 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 20));
-    auto x_main_module_22 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {48, 288, 1, 1}}, 21));
-    auto x_main_module_23 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 22));
-    auto x_main_module_24 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 23));
-    auto x_main_module_25 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 24));
-    auto x_main_module_26 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 25));
-    auto x_main_module_27 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 26));
-    auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 27));
-    auto x_main_module_29 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 28));
-    auto x_main_module_30 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 29));
-    auto x_main_module_31 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 30));
-    auto x_main_module_32 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 31));
-    auto x_main_module_33 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 32));
-    auto x_main_module_34 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 33));
-    auto x_main_module_35 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 34));
-    auto x_main_module_36 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {48, 256, 1, 1}}, 35));
-    auto x_main_module_37 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 36));
-    auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 37));
-    auto x_main_module_39 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 38));
-    auto x_main_module_40 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {32, 192, 1, 1}}, 39));
-    auto x_main_module_41 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 40));
-    auto x_main_module_42 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 41));
-    auto x_main_module_43 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 42));
-    auto x_main_module_44 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 43));
-    auto x_main_module_45 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 44));
-    auto x_main_module_46 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 45));
-    auto x_main_module_47 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 46));
-    auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 47));
-    auto x_main_module_49 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 48));
-    auto x_main_module_50 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {48, 192, 1, 1}}, 49));
-    auto x_main_module_51 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 50));
-    auto x_main_module_52 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 51));
-    auto x_main_module_53 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 52));
-    auto x_main_module_54 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 80, 3, 3}}, 53));
-    auto x_main_module_55 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 54));
-    auto x_main_module_56 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {80, 64, 1, 1}}, 55));
-    auto x_main_module_57 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 56));
-    auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 32, 3, 3}}, 57));
-    auto x_main_module_59 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 58));
-    auto x_main_module_60 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {32, 32, 3, 3}}, 59));
-    auto x_main_module_61 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 60));
-    auto x_main_module_62 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {32, 3, 3, 3}}, 61));
-    auto x_main_module_63 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 62));
-    auto x_main_module_64 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 2048, 1, 1}}, 63));
-    auto x_main_module_65 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 64));
-    auto x_main_module_66 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 65));
-    auto x_main_module_67 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 66));
-    auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 67));
-    auto x_main_module_69 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 68));
-    auto x_main_module_70 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 69));
-    auto x_main_module_71 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 70));
-    auto x_main_module_72 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {448, 2048, 1, 1}}, 71));
-    auto x_main_module_73 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 72));
-    auto x_main_module_74 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 73));
-    auto x_main_module_75 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 74));
-    auto x_main_module_76 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 75));
-    auto x_main_module_77 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 76));
-    auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 2048, 1, 1}}, 77));
-    auto x_main_module_79 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 78));
-    auto x_main_module_80 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {320, 2048, 1, 1}}, 79));
-    auto x_main_module_81 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 80));
-    auto x_main_module_82 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 1280, 1, 1}}, 81));
-    auto x_main_module_83 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 82));
-    auto x_main_module_84 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 83));
-    auto x_main_module_85 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 84));
-    auto x_main_module_86 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 85));
-    auto x_main_module_87 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 86));
-    auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 87));
-    auto x_main_module_89 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 88));
-    auto x_main_module_90 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {448, 1280, 1, 1}}, 89));
-    auto x_main_module_91 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 90));
-    auto x_main_module_92 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 91));
-    auto x_main_module_93 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 92));
-    auto x_main_module_94 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 93));
-    auto x_main_module_95 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 94));
-    auto x_main_module_96 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {384, 1280, 1, 1}}, 95));
-    auto x_main_module_97 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 96));
-    auto x_main_module_98 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {320, 1280, 1, 1}}, 97));
-    auto x_main_module_99 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 98));
-    auto x_main_module_100 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 3, 3}}, 99));
-    auto x_main_module_101 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 100));
-    auto x_main_module_102 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 101));
-    auto x_main_module_103 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 102));
-    auto x_main_module_104 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 103));
-    auto x_main_module_105 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 104));
-    auto x_main_module_106 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 105));
-    auto x_main_module_107 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 106));
-    auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {320, 192, 3, 3}}, 107));
-    auto x_main_module_109 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 108));
-    auto x_main_module_110 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 109));
-    auto x_main_module_111 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 110));
-    auto x_main_module_112 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 111));
-    auto x_main_module_113 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 112));
-    auto x_main_module_114 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 113));
-    auto x_main_module_115 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 114));
-    auto x_main_module_116 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 115));
-    auto x_main_module_117 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 116));
-    auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 117));
-    auto x_main_module_119 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 118));
-    auto x_main_module_120 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 119));
-    auto x_main_module_121 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 120));
-    auto x_main_module_122 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 121));
-    auto x_main_module_123 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 122));
-    auto x_main_module_124 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 123));
-    auto x_main_module_125 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 124));
-    auto x_main_module_126 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 125));
-    auto x_main_module_127 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 126));
-    auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 127));
-    auto x_main_module_129 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 128));
-    auto x_main_module_130 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 129));
-    auto x_main_module_131 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 130));
-    auto x_main_module_132 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 131));
-    auto x_main_module_133 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 132));
-    auto x_main_module_134 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 133));
-    auto x_main_module_135 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 134));
-    auto x_main_module_136 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 135));
-    auto x_main_module_137 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 136));
-    auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 137));
-    auto x_main_module_139 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 138));
-    auto x_main_module_140 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 139));
-    auto x_main_module_141 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 140));
-    auto x_main_module_142 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 141));
-    auto x_main_module_143 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 142));
-    auto x_main_module_144 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 143));
-    auto x_main_module_145 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 144));
-    auto x_main_module_146 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 145));
-    auto x_main_module_147 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 146));
-    auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 147));
-    auto x_main_module_149 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 148));
-    auto x_main_module_150 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 149));
-    auto x_main_module_151 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 150));
-    auto x_main_module_152 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 151));
-    auto x_main_module_153 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 152));
-    auto x_main_module_154 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 153));
-    auto x_main_module_155 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 154));
-    auto x_main_module_156 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 155));
-    auto x_main_module_157 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 156));
-    auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 157));
-    auto x_main_module_159 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 158));
-    auto x_main_module_160 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 159));
-    auto x_main_module_161 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 160));
-    auto x_main_module_162 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 161));
-    auto x_main_module_163 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 162));
-    auto x_main_module_164 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 163));
-    auto x_main_module_165 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 164));
-    auto x_main_module_166 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 165));
-    auto x_main_module_167 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 166));
-    auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 167));
-    auto x_main_module_169 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 168));
-    auto x_main_module_170 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 169));
-    auto x_main_module_171 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 170));
-    auto x_main_module_172 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 171));
-    auto x_main_module_173 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 172));
-    auto x_main_module_174 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 128, 1, 7}}, 173));
-    auto x_main_module_175 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 174));
-    auto x_main_module_176 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 175));
-    auto x_main_module_177 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 176));
-    auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 177));
-    auto x_main_module_179 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 178));
-    auto x_main_module_180 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 179));
-    auto x_main_module_181 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 180));
-    auto x_main_module_182 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 181));
-    auto x_main_module_183 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 182));
-    auto x_main_module_184 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 128, 7, 1}}, 183));
-    auto x_main_module_185 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 184));
-    auto x_main_module_186 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 185));
-    auto x_main_module_187 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 186));
-    auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 187));
-    auto x_main_module_189 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 188));
-    auto x_main_module_190 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 189));
-    auto x_main_module_191 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 190));
-    auto x_main_module_192 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2]}")),
-        x_input_1,
-        x_main_module_62);
-    auto x_main_module_193 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,32,149,149]}")),
-        x_main_module_61);
-    auto x_main_module_194 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_192, x_main_module_193);
-    auto x_main_module_195 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_194);
-    auto x_main_module_196 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_195,
-        x_main_module_60);
-    auto x_main_module_197 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,32,147,147]}")),
-        x_main_module_59);
-    auto x_main_module_198 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_196, x_main_module_197);
-    auto x_main_module_199 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_198);
-    auto x_main_module_200 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_199,
-        x_main_module_58);
-    auto x_main_module_201 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,147,147]}")),
-        x_main_module_57);
-    auto x_main_module_202 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_200, x_main_module_201);
-    auto x_main_module_203 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_202);
-    auto x_main_module_204 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}")),
-        x_main_module_203);
-    auto x_main_module_205 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_204,
-        x_main_module_56);
-    auto x_main_module_206 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,80,73,73]}")),
-        x_main_module_55);
-    auto x_main_module_207 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_205, x_main_module_206);
-    auto x_main_module_208 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_207);
-    auto x_main_module_209 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_208,
-        x_main_module_54);
-    auto x_main_module_210 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,71,71]}")),
-        x_main_module_53);
-    auto x_main_module_211 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_209, x_main_module_210);
-    auto x_main_module_212 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_211);
-    auto x_main_module_213 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}")),
-        x_main_module_212);
-    auto x_main_module_214 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_213,
-        x_main_module_52);
-    auto x_main_module_215 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,35,35]}")),
-        x_main_module_51);
-    auto x_main_module_216 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_214, x_main_module_215);
-    auto x_main_module_217 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_216);
-    auto x_main_module_218 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_213,
-        x_main_module_50);
-    auto x_main_module_219 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,48,35,35]}")),
-        x_main_module_49);
-    auto x_main_module_220 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_218, x_main_module_219);
-    auto x_main_module_221 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_220);
-    auto x_main_module_222 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[1,1]}")),
-        x_main_module_221,
-        x_main_module_48);
-    auto x_main_module_223 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,35,35]}")),
-        x_main_module_47);
-    auto x_main_module_224 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_222, x_main_module_223);
-    auto x_main_module_225 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_224);
-    auto x_main_module_226 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_213,
-        x_main_module_46);
-    auto x_main_module_227 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,35,35]}")),
-        x_main_module_45);
-    auto x_main_module_228 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_226, x_main_module_227);
-    auto x_main_module_229 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_228);
-    auto x_main_module_230 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_229,
-        x_main_module_44);
-    auto x_main_module_231 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,96,35,35]}")),
-        x_main_module_43);
-    auto x_main_module_232 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_230, x_main_module_231);
-    auto x_main_module_233 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_232);
-    auto x_main_module_234 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_233,
-        x_main_module_42);
-    auto x_main_module_235 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,96,35,35]}")),
-        x_main_module_41);
-    auto x_main_module_236 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_234, x_main_module_235);
-    auto x_main_module_237 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_236);
-    auto x_main_module_238 = mmain->add_instruction(
-        migraphx::make_op("pad",
-                          migraphx::from_json_string("{mode:0,pads:[0,0,1,1,0,0,1,1],value:0.0}")),
-        x_main_module_213);
-    auto x_main_module_239 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[0,0,0,0],stride:[1,1]}")),
-        x_main_module_238);
-    auto x_main_module_240 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_239,
-        x_main_module_40);
-    auto x_main_module_241 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,32,35,35]}")),
-        x_main_module_39);
-    auto x_main_module_242 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_240, x_main_module_241);
-    auto x_main_module_243 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_242);
-    auto x_main_module_244 =
-        mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{axis:1}")),
-                               x_main_module_217,
-                               x_main_module_225,
-                               x_main_module_237,
-                               x_main_module_243);
-    auto x_main_module_245 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_244,
-        x_main_module_38);
-    auto x_main_module_246 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,35,35]}")),
-        x_main_module_37);
-    auto x_main_module_247 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_245, x_main_module_246);
-    auto x_main_module_248 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_247);
-    auto x_main_module_249 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_244,
-        x_main_module_36);
-    auto x_main_module_250 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,48,35,35]}")),
-        x_main_module_35);
-    auto x_main_module_251 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_249, x_main_module_250);
-    auto x_main_module_252 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_251);
-    auto x_main_module_253 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[1,1]}")),
-        x_main_module_252,
-        x_main_module_34);
-    auto x_main_module_254 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,35,35]}")),
-        x_main_module_33);
-    auto x_main_module_255 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_253, x_main_module_254);
-    auto x_main_module_256 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_255);
-    auto x_main_module_257 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_244,
-        x_main_module_32);
-    auto x_main_module_258 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,35,35]}")),
-        x_main_module_31);
-    auto x_main_module_259 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_257, x_main_module_258);
-    auto x_main_module_260 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_259);
-    auto x_main_module_261 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_260,
-        x_main_module_30);
-    auto x_main_module_262 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,96,35,35]}")),
-        x_main_module_29);
-    auto x_main_module_263 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_261, x_main_module_262);
-    auto x_main_module_264 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_263);
-    auto x_main_module_265 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_264,
-        x_main_module_28);
-    auto x_main_module_266 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,96,35,35]}")),
-        x_main_module_27);
-    auto x_main_module_267 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_265, x_main_module_266);
-    auto x_main_module_268 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_267);
-    auto x_main_module_269 = mmain->add_instruction(
-        migraphx::make_op("pad",
-                          migraphx::from_json_string("{mode:0,pads:[0,0,1,1,0,0,1,1],value:0.0}")),
-        x_main_module_244);
-    auto x_main_module_270 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[0,0,0,0],stride:[1,1]}")),
-        x_main_module_269);
-    auto x_main_module_271 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_270,
-        x_main_module_26);
-    auto x_main_module_272 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,35,35]}")),
-        x_main_module_25);
-    auto x_main_module_273 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_271, x_main_module_272);
-    auto x_main_module_274 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_273);
-    auto x_main_module_275 =
-        mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{axis:1}")),
-                               x_main_module_248,
-                               x_main_module_256,
-                               x_main_module_268,
-                               x_main_module_274);
-    auto x_main_module_276 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_275,
-        x_main_module_24);
-    auto x_main_module_277 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,35,35]}")),
-        x_main_module_23);
-    auto x_main_module_278 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_276, x_main_module_277);
-    auto x_main_module_279 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_278);
-    auto x_main_module_280 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_275,
-        x_main_module_22);
-    auto x_main_module_281 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,48,35,35]}")),
-        x_main_module_21);
-    auto x_main_module_282 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_280, x_main_module_281);
-    auto x_main_module_283 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_282);
-    auto x_main_module_284 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[1,1]}")),
-        x_main_module_283,
-        x_main_module_20);
-    auto x_main_module_285 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,35,35]}")),
-        x_main_module_19);
-    auto x_main_module_286 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_284, x_main_module_285);
-    auto x_main_module_287 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_286);
-    auto x_main_module_288 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_275,
-        x_main_module_18);
-    auto x_main_module_289 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,35,35]}")),
-        x_main_module_17);
-    auto x_main_module_290 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_288, x_main_module_289);
-    auto x_main_module_291 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_290);
-    auto x_main_module_292 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_291,
-        x_main_module_16);
-    auto x_main_module_293 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,96,35,35]}")),
-        x_main_module_15);
-    auto x_main_module_294 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_292, x_main_module_293);
-    auto x_main_module_295 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_294);
-    auto x_main_module_296 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_295,
-        x_main_module_14);
-    auto x_main_module_297 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,96,35,35]}")),
-        x_main_module_13);
-    auto x_main_module_298 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_296, x_main_module_297);
-    auto x_main_module_299 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_298);
-    auto x_main_module_300 = mmain->add_instruction(
-        migraphx::make_op("pad",
-                          migraphx::from_json_string("{mode:0,pads:[0,0,1,1,0,0,1,1],value:0.0}")),
-        x_main_module_275);
-    auto x_main_module_301 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[0,0,0,0],stride:[1,1]}")),
-        x_main_module_300);
-    auto x_main_module_302 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_301,
-        x_main_module_12);
-    auto x_main_module_303 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,35,35]}")),
-        x_main_module_11);
-    auto x_main_module_304 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_302, x_main_module_303);
-    auto x_main_module_305 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_304);
-    auto x_main_module_306 =
-        mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{axis:1}")),
-                               x_main_module_279,
-                               x_main_module_287,
-                               x_main_module_299,
-                               x_main_module_305);
-    auto x_main_module_307 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2]}")),
-        x_main_module_306,
-        x_main_module_10);
-    auto x_main_module_308 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,384,17,17]}")),
-        x_main_module_9);
-    auto x_main_module_309 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_307, x_main_module_308);
-    auto x_main_module_310 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_309);
-    auto x_main_module_311 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_306,
-        x_main_module_8);
-    auto x_main_module_312 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,35,35]}")),
-        x_main_module_7);
-    auto x_main_module_313 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_311, x_main_module_312);
-    auto x_main_module_314 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_313);
-    auto x_main_module_315 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_314,
-        x_main_module_6);
-    auto x_main_module_316 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,96,35,35]}")),
-        x_main_module_5);
-    auto x_main_module_317 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_315, x_main_module_316);
-    auto x_main_module_318 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_317);
-    auto x_main_module_319 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2]}")),
-        x_main_module_318,
-        x_main_module_4);
-    auto x_main_module_320 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,96,17,17]}")),
-        x_main_module_191);
-    auto x_main_module_321 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_319, x_main_module_320);
-    auto x_main_module_322 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_321);
-    auto x_main_module_323 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}")),
-        x_main_module_306);
-    auto x_main_module_324 =
-        mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{axis:1}")),
-                               x_main_module_310,
-                               x_main_module_322,
-                               x_main_module_323);
-    auto x_main_module_325 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_324,
-        x_main_module_190);
-    auto x_main_module_326 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_189);
-    auto x_main_module_327 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_325, x_main_module_326);
-    auto x_main_module_328 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_327);
-    auto x_main_module_329 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_324,
-        x_main_module_188);
-    auto x_main_module_330 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,128,17,17]}")),
-        x_main_module_187);
-    auto x_main_module_331 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_329, x_main_module_330);
-    auto x_main_module_332 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_331);
-    auto x_main_module_333 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1]}")),
-        x_main_module_332,
-        x_main_module_186);
-    auto x_main_module_334 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,128,17,17]}")),
-        x_main_module_185);
-    auto x_main_module_335 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_333, x_main_module_334);
-    auto x_main_module_336 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_335);
-    auto x_main_module_337 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_336,
-        x_main_module_184);
-    auto x_main_module_338 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_183);
-    auto x_main_module_339 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_337, x_main_module_338);
-    auto x_main_module_340 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_339);
-    auto x_main_module_341 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_324,
-        x_main_module_182);
-    auto x_main_module_342 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,128,17,17]}")),
-        x_main_module_181);
-    auto x_main_module_343 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_341, x_main_module_342);
-    auto x_main_module_344 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_343);
-    auto x_main_module_345 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_344,
-        x_main_module_180);
-    auto x_main_module_346 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,128,17,17]}")),
-        x_main_module_179);
-    auto x_main_module_347 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_345, x_main_module_346);
-    auto x_main_module_348 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_347);
-    auto x_main_module_349 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1]}")),
-        x_main_module_348,
-        x_main_module_178);
-    auto x_main_module_350 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,128,17,17]}")),
-        x_main_module_177);
-    auto x_main_module_351 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_349, x_main_module_350);
-    auto x_main_module_352 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_351);
-    auto x_main_module_353 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_352,
-        x_main_module_176);
-    auto x_main_module_354 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,128,17,17]}")),
-        x_main_module_175);
-    auto x_main_module_355 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_353, x_main_module_354);
-    auto x_main_module_356 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_355);
-    auto x_main_module_357 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1]}")),
-        x_main_module_356,
-        x_main_module_174);
-    auto x_main_module_358 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_173);
-    auto x_main_module_359 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_357, x_main_module_358);
-    auto x_main_module_360 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_359);
-    auto x_main_module_361 = mmain->add_instruction(
-        migraphx::make_op("pad",
-                          migraphx::from_json_string("{mode:0,pads:[0,0,1,1,0,0,1,1],value:0.0}")),
-        x_main_module_324);
-    auto x_main_module_362 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[0,0,0,0],stride:[1,1]}")),
-        x_main_module_361);
-    auto x_main_module_363 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_362,
-        x_main_module_172);
-    auto x_main_module_364 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_171);
-    auto x_main_module_365 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_363, x_main_module_364);
-    auto x_main_module_366 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_365);
-    auto x_main_module_367 =
-        mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{axis:1}")),
-                               x_main_module_328,
-                               x_main_module_340,
-                               x_main_module_360,
-                               x_main_module_366);
-    auto x_main_module_368 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_367,
-        x_main_module_170);
-    auto x_main_module_369 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_169);
-    auto x_main_module_370 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_368, x_main_module_369);
-    auto x_main_module_371 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_370);
-    auto x_main_module_372 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_367,
-        x_main_module_168);
-    auto x_main_module_373 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,160,17,17]}")),
-        x_main_module_167);
-    auto x_main_module_374 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_372, x_main_module_373);
-    auto x_main_module_375 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_374);
-    auto x_main_module_376 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1]}")),
-        x_main_module_375,
-        x_main_module_166);
-    auto x_main_module_377 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,160,17,17]}")),
-        x_main_module_165);
-    auto x_main_module_378 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_376, x_main_module_377);
-    auto x_main_module_379 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_378);
-    auto x_main_module_380 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_379,
-        x_main_module_164);
-    auto x_main_module_381 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_163);
-    auto x_main_module_382 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_380, x_main_module_381);
-    auto x_main_module_383 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_382);
-    auto x_main_module_384 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_367,
-        x_main_module_162);
-    auto x_main_module_385 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,160,17,17]}")),
-        x_main_module_161);
-    auto x_main_module_386 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_384, x_main_module_385);
-    auto x_main_module_387 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_386);
-    auto x_main_module_388 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_387,
-        x_main_module_160);
-    auto x_main_module_389 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,160,17,17]}")),
-        x_main_module_159);
-    auto x_main_module_390 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_388, x_main_module_389);
-    auto x_main_module_391 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_390);
-    auto x_main_module_392 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1]}")),
-        x_main_module_391,
-        x_main_module_158);
-    auto x_main_module_393 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,160,17,17]}")),
-        x_main_module_157);
-    auto x_main_module_394 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_392, x_main_module_393);
-    auto x_main_module_395 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_394);
-    auto x_main_module_396 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_395,
-        x_main_module_156);
-    auto x_main_module_397 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,160,17,17]}")),
-        x_main_module_155);
-    auto x_main_module_398 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_396, x_main_module_397);
-    auto x_main_module_399 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_398);
-    auto x_main_module_400 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1]}")),
-        x_main_module_399,
-        x_main_module_154);
-    auto x_main_module_401 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_153);
-    auto x_main_module_402 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_400, x_main_module_401);
-    auto x_main_module_403 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_402);
-    auto x_main_module_404 = mmain->add_instruction(
-        migraphx::make_op("pad",
-                          migraphx::from_json_string("{mode:0,pads:[0,0,1,1,0,0,1,1],value:0.0}")),
-        x_main_module_367);
-    auto x_main_module_405 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[0,0,0,0],stride:[1,1]}")),
-        x_main_module_404);
-    auto x_main_module_406 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_405,
-        x_main_module_152);
-    auto x_main_module_407 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_151);
-    auto x_main_module_408 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_406, x_main_module_407);
-    auto x_main_module_409 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_408);
-    auto x_main_module_410 =
-        mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{axis:1}")),
-                               x_main_module_371,
-                               x_main_module_383,
-                               x_main_module_403,
-                               x_main_module_409);
-    auto x_main_module_411 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_410,
-        x_main_module_150);
-    auto x_main_module_412 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_149);
-    auto x_main_module_413 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_411, x_main_module_412);
-    auto x_main_module_414 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_413);
-    auto x_main_module_415 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_410,
-        x_main_module_148);
-    auto x_main_module_416 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,160,17,17]}")),
-        x_main_module_147);
-    auto x_main_module_417 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_415, x_main_module_416);
-    auto x_main_module_418 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_417);
-    auto x_main_module_419 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1]}")),
-        x_main_module_418,
-        x_main_module_146);
-    auto x_main_module_420 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,160,17,17]}")),
-        x_main_module_145);
-    auto x_main_module_421 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_419, x_main_module_420);
-    auto x_main_module_422 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_421);
-    auto x_main_module_423 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_422,
-        x_main_module_144);
-    auto x_main_module_424 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_143);
-    auto x_main_module_425 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_423, x_main_module_424);
-    auto x_main_module_426 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_425);
-    auto x_main_module_427 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_410,
-        x_main_module_142);
-    auto x_main_module_428 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,160,17,17]}")),
-        x_main_module_141);
-    auto x_main_module_429 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_427, x_main_module_428);
-    auto x_main_module_430 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_429);
-    auto x_main_module_431 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_430,
-        x_main_module_140);
-    auto x_main_module_432 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,160,17,17]}")),
-        x_main_module_139);
-    auto x_main_module_433 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_431, x_main_module_432);
-    auto x_main_module_434 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_433);
-    auto x_main_module_435 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1]}")),
-        x_main_module_434,
-        x_main_module_138);
-    auto x_main_module_436 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,160,17,17]}")),
-        x_main_module_137);
-    auto x_main_module_437 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_435, x_main_module_436);
-    auto x_main_module_438 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_437);
-    auto x_main_module_439 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_438,
-        x_main_module_136);
-    auto x_main_module_440 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,160,17,17]}")),
-        x_main_module_135);
-    auto x_main_module_441 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_439, x_main_module_440);
-    auto x_main_module_442 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_441);
-    auto x_main_module_443 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1]}")),
-        x_main_module_442,
-        x_main_module_134);
-    auto x_main_module_444 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_133);
-    auto x_main_module_445 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_443, x_main_module_444);
-    auto x_main_module_446 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_445);
-    auto x_main_module_447 = mmain->add_instruction(
-        migraphx::make_op("pad",
-                          migraphx::from_json_string("{mode:0,pads:[0,0,1,1,0,0,1,1],value:0.0}")),
-        x_main_module_410);
-    auto x_main_module_448 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[0,0,0,0],stride:[1,1]}")),
-        x_main_module_447);
-    auto x_main_module_449 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_448,
-        x_main_module_132);
-    auto x_main_module_450 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_131);
-    auto x_main_module_451 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_449, x_main_module_450);
-    auto x_main_module_452 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_451);
-    auto x_main_module_453 =
-        mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{axis:1}")),
-                               x_main_module_414,
-                               x_main_module_426,
-                               x_main_module_446,
-                               x_main_module_452);
-    auto x_main_module_454 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_453,
-        x_main_module_130);
-    auto x_main_module_455 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_129);
-    auto x_main_module_456 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_454, x_main_module_455);
-    auto x_main_module_457 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_456);
-    auto x_main_module_458 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_453,
-        x_main_module_128);
-    auto x_main_module_459 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_127);
-    auto x_main_module_460 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_458, x_main_module_459);
-    auto x_main_module_461 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_460);
-    auto x_main_module_462 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1]}")),
-        x_main_module_461,
-        x_main_module_126);
-    auto x_main_module_463 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_125);
-    auto x_main_module_464 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_462, x_main_module_463);
-    auto x_main_module_465 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_464);
-    auto x_main_module_466 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_465,
-        x_main_module_124);
-    auto x_main_module_467 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_123);
-    auto x_main_module_468 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_466, x_main_module_467);
-    auto x_main_module_469 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_468);
-    auto x_main_module_470 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_453,
-        x_main_module_122);
-    auto x_main_module_471 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_121);
-    auto x_main_module_472 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_470, x_main_module_471);
-    auto x_main_module_473 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_472);
-    auto x_main_module_474 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_473,
-        x_main_module_120);
-    auto x_main_module_475 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_119);
-    auto x_main_module_476 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_474, x_main_module_475);
-    auto x_main_module_477 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_476);
-    auto x_main_module_478 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1]}")),
-        x_main_module_477,
-        x_main_module_118);
-    auto x_main_module_479 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_117);
-    auto x_main_module_480 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_478, x_main_module_479);
-    auto x_main_module_481 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_480);
-    auto x_main_module_482 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_481,
-        x_main_module_116);
-    auto x_main_module_483 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_115);
-    auto x_main_module_484 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_482, x_main_module_483);
-    auto x_main_module_485 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_484);
-    auto x_main_module_486 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1]}")),
-        x_main_module_485,
-        x_main_module_114);
-    auto x_main_module_487 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_113);
-    auto x_main_module_488 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_486, x_main_module_487);
-    auto x_main_module_489 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_488);
-    auto x_main_module_490 = mmain->add_instruction(
-        migraphx::make_op("pad",
-                          migraphx::from_json_string("{mode:0,pads:[0,0,1,1,0,0,1,1],value:0.0}")),
-        x_main_module_453);
-    auto x_main_module_491 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[0,0,0,0],stride:[1,1]}")),
-        x_main_module_490);
-    auto x_main_module_492 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_491,
-        x_main_module_112);
-    auto x_main_module_493 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_111);
-    auto x_main_module_494 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_492, x_main_module_493);
-    auto x_main_module_495 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_494);
-    auto x_main_module_496 =
-        mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{axis:1}")),
-                               x_main_module_457,
-                               x_main_module_469,
-                               x_main_module_489,
-                               x_main_module_495);
-    auto x_main_module_497 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_496,
-        x_main_module_110);
-    auto x_main_module_498 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_109);
-    auto x_main_module_499 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_497, x_main_module_498);
-    auto x_main_module_500 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_499);
-    auto x_main_module_501 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2]}")),
-        x_main_module_500,
-        x_main_module_108);
-    auto x_main_module_502 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,320,8,8]}")),
-        x_main_module_107);
-    auto x_main_module_503 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_501, x_main_module_502);
-    auto x_main_module_504 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_503);
-    auto x_main_module_505 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_496,
-        x_main_module_106);
-    auto x_main_module_506 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_105);
-    auto x_main_module_507 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_505, x_main_module_506);
-    auto x_main_module_508 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_507);
-    auto x_main_module_509 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1]}")),
-        x_main_module_508,
-        x_main_module_104);
-    auto x_main_module_510 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_103);
-    auto x_main_module_511 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_509, x_main_module_510);
-    auto x_main_module_512 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_511);
-    auto x_main_module_513 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_512,
-        x_main_module_102);
-    auto x_main_module_514 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,192,17,17]}")),
-        x_main_module_101);
-    auto x_main_module_515 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_513, x_main_module_514);
-    auto x_main_module_516 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_515);
-    auto x_main_module_517 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2]}")),
-        x_main_module_516,
-        x_main_module_100);
-    auto x_main_module_518 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,192,8,8]}")),
-        x_main_module_99);
-    auto x_main_module_519 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_517, x_main_module_518);
-    auto x_main_module_520 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_519);
-    auto x_main_module_521 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}")),
-        x_main_module_496);
-    auto x_main_module_522 =
-        mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{axis:1}")),
-                               x_main_module_504,
-                               x_main_module_520,
-                               x_main_module_521);
-    auto x_main_module_523 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_522,
-        x_main_module_98);
-    auto x_main_module_524 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,320,8,8]}")),
-        x_main_module_97);
-    auto x_main_module_525 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_523, x_main_module_524);
-    auto x_main_module_526 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_525);
-    auto x_main_module_527 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_522,
-        x_main_module_96);
-    auto x_main_module_528 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,384,8,8]}")),
-        x_main_module_95);
-    auto x_main_module_529 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_527, x_main_module_528);
-    auto x_main_module_530 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_529);
-    auto x_main_module_531 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,1,0,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_530,
-        x_main_module_94);
-    auto x_main_module_532 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,384,8,8]}")),
-        x_main_module_93);
-    auto x_main_module_533 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_531, x_main_module_532);
-    auto x_main_module_534 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_533);
-    auto x_main_module_535 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,0,1,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_530,
-        x_main_module_92);
-    auto x_main_module_536 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,384,8,8]}")),
-        x_main_module_91);
-    auto x_main_module_537 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_535, x_main_module_536);
-    auto x_main_module_538 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_537);
-    auto x_main_module_539 =
-        mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{axis:1}")),
-                               x_main_module_534,
-                               x_main_module_538);
-    auto x_main_module_540 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_522,
-        x_main_module_90);
-    auto x_main_module_541 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,448,8,8]}")),
-        x_main_module_89);
-    auto x_main_module_542 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_540, x_main_module_541);
-    auto x_main_module_543 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_542);
-    auto x_main_module_544 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_543,
-        x_main_module_88);
-    auto x_main_module_545 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,384,8,8]}")),
-        x_main_module_87);
-    auto x_main_module_546 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_544, x_main_module_545);
-    auto x_main_module_547 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_546);
-    auto x_main_module_548 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,1,0,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_547,
-        x_main_module_86);
-    auto x_main_module_549 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,384,8,8]}")),
-        x_main_module_85);
-    auto x_main_module_550 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_548, x_main_module_549);
-    auto x_main_module_551 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_550);
-    auto x_main_module_552 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,0,1,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_547,
-        x_main_module_84);
-    auto x_main_module_553 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,384,8,8]}")),
-        x_main_module_83);
-    auto x_main_module_554 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_552, x_main_module_553);
-    auto x_main_module_555 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_554);
-    auto x_main_module_556 =
-        mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{axis:1}")),
-                               x_main_module_551,
-                               x_main_module_555);
-    auto x_main_module_557 = mmain->add_instruction(
-        migraphx::make_op("pad",
-                          migraphx::from_json_string("{mode:0,pads:[0,0,1,1,0,0,1,1],value:0.0}")),
-        x_main_module_522);
-    auto x_main_module_558 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[0,0,0,0],stride:[1,1]}")),
-        x_main_module_557);
-    auto x_main_module_559 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_558,
-        x_main_module_82);
-    auto x_main_module_560 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,192,8,8]}")),
-        x_main_module_81);
-    auto x_main_module_561 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_559, x_main_module_560);
-    auto x_main_module_562 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_561);
-    auto x_main_module_563 =
-        mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{axis:1}")),
-                               x_main_module_526,
-                               x_main_module_539,
-                               x_main_module_556,
-                               x_main_module_562);
-    auto x_main_module_564 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_563,
-        x_main_module_80);
-    auto x_main_module_565 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,320,8,8]}")),
-        x_main_module_79);
-    auto x_main_module_566 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_564, x_main_module_565);
-    auto x_main_module_567 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_566);
-    auto x_main_module_568 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_563,
-        x_main_module_78);
-    auto x_main_module_569 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,384,8,8]}")),
-        x_main_module_77);
-    auto x_main_module_570 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_568, x_main_module_569);
-    auto x_main_module_571 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_570);
-    auto x_main_module_572 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,1,0,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_571,
-        x_main_module_76);
-    auto x_main_module_573 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,384,8,8]}")),
-        x_main_module_75);
-    auto x_main_module_574 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_572, x_main_module_573);
-    auto x_main_module_575 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_574);
-    auto x_main_module_576 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,0,1,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_571,
-        x_main_module_74);
-    auto x_main_module_577 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,384,8,8]}")),
-        x_main_module_73);
-    auto x_main_module_578 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_576, x_main_module_577);
-    auto x_main_module_579 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_578);
-    auto x_main_module_580 =
-        mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{axis:1}")),
-                               x_main_module_575,
-                               x_main_module_579);
-    auto x_main_module_581 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_563,
-        x_main_module_72);
-    auto x_main_module_582 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,448,8,8]}")),
-        x_main_module_71);
-    auto x_main_module_583 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_581, x_main_module_582);
-    auto x_main_module_584 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_583);
-    auto x_main_module_585 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_584,
-        x_main_module_70);
-    auto x_main_module_586 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,384,8,8]}")),
-        x_main_module_69);
-    auto x_main_module_587 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_585, x_main_module_586);
-    auto x_main_module_588 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_587);
-    auto x_main_module_589 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,1,0,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_588,
-        x_main_module_68);
-    auto x_main_module_590 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,384,8,8]}")),
-        x_main_module_67);
-    auto x_main_module_591 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_589, x_main_module_590);
-    auto x_main_module_592 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_591);
-    auto x_main_module_593 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,0,1,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_588,
-        x_main_module_66);
-    auto x_main_module_594 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,384,8,8]}")),
-        x_main_module_65);
-    auto x_main_module_595 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_593, x_main_module_594);
-    auto x_main_module_596 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_595);
-    auto x_main_module_597 =
-        mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{axis:1}")),
-                               x_main_module_592,
-                               x_main_module_596);
-    auto x_main_module_598 = mmain->add_instruction(
-        migraphx::make_op("pad",
-                          migraphx::from_json_string("{mode:0,pads:[0,0,1,1,0,0,1,1],value:0.0}")),
-        x_main_module_563);
-    auto x_main_module_599 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[0,0,0,0],stride:[1,1]}")),
-        x_main_module_598);
-    auto x_main_module_600 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_599,
-        x_main_module_64);
-    auto x_main_module_601 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,192,8,8]}")),
-        x_main_module_63);
-    auto x_main_module_602 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_600, x_main_module_601);
-    auto x_main_module_603 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_602);
-    auto x_main_module_604 =
-        mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{axis:1}")),
-                               x_main_module_567,
-                               x_main_module_580,
-                               x_main_module_597,
-                               x_main_module_603);
-    auto x_main_module_605 =
-        mmain->add_instruction(migraphx::make_op("identity"), x_main_module_604);
-    auto x_main_module_606 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[8,8],lp_order:2,mode:0,padding:[0,0,0,0],stride:[8,8]}")),
-        x_main_module_605);
-    auto x_main_module_607 = mmain->add_instruction(
-        migraphx::make_op("reshape", migraphx::from_json_string("{dims:[1,-1]}")),
-        x_main_module_606);
-    auto x_main_module_608 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{permutation:[1,0]}")),
-        x_main_module_2);
-    auto x_main_module_609 =
-        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_607, x_main_module_608);
-    auto x_main_module_610 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{out_lens:[1,1000]}")),
-        x_main_module_3);
-    auto x_main_module_611 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{out_lens:[1,1000]}")),
-        x_main_module_0);
-    auto x_main_module_612 =
-        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_610, x_main_module_611);
-    auto x_main_module_613 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_609, x_main_module_612);
-    mmain->add_return({x_main_module_613});
+migraphx::module_ref mmain = p.get_main_module();
+auto _x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+auto _x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 299, 299}});
+auto _x_main_module_2 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
+auto _x_main_module_3 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
+auto _x_main_module_4 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 3)));
+auto _x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 4));
+auto _x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 5));
+auto _x_main_module_7 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 6)));
+auto _x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 2048, 1, 1}}, 7));
+auto _x_main_module_9 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 8)));
+auto _x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 9));
+auto _x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 10));
+auto _x_main_module_12 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 11)));
+auto _x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 12));
+auto _x_main_module_14 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13)));
+auto _x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 14));
+auto _x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 15));
+auto _x_main_module_17 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 16)));
+auto _x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 17));
+auto _x_main_module_19 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 18)));
+auto _x_main_module_20 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 19));
+auto _x_main_module_21 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 20));
+auto _x_main_module_22 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 21)));
+auto _x_main_module_23 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 22));
+auto _x_main_module_24 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 23)));
+auto _x_main_module_25 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 24));
+auto _x_main_module_26 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 25));
+auto _x_main_module_27 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 26)));
+auto _x_main_module_28 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448, 2048, 1, 1}}, 27));
+auto _x_main_module_29 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 28)));
+auto _x_main_module_30 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 29)));
+auto _x_main_module_31 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 30));
+auto _x_main_module_32 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 31)));
+auto _x_main_module_33 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 32));
+auto _x_main_module_34 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 33)));
+auto _x_main_module_35 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 34)));
+auto _x_main_module_36 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 35));
+auto _x_main_module_37 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 36)));
+auto _x_main_module_38 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 37));
+auto _x_main_module_39 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 38)));
+auto _x_main_module_40 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 39));
+auto _x_main_module_41 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 40));
+auto _x_main_module_42 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 41)));
+auto _x_main_module_43 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 2048, 1, 1}}, 42));
+auto _x_main_module_44 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 43)));
+auto _x_main_module_45 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 44));
+auto _x_main_module_46 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 45));
+auto _x_main_module_47 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 46)));
+auto _x_main_module_48 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 2048, 1, 1}}, 47));
+auto _x_main_module_49 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 48)));
+auto _x_main_module_50 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 49));
+auto _x_main_module_51 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 50));
+auto _x_main_module_52 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 51)));
+auto _x_main_module_53 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 1280, 1, 1}}, 52));
+auto _x_main_module_54 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 53)));
+auto _x_main_module_55 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 54));
+auto _x_main_module_56 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 55));
+auto _x_main_module_57 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 56)));
+auto _x_main_module_58 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 57));
+auto _x_main_module_59 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 58)));
+auto _x_main_module_60 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 59));
+auto _x_main_module_61 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 60));
+auto _x_main_module_62 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 61)));
+auto _x_main_module_63 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 62));
+auto _x_main_module_64 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 63)));
+auto _x_main_module_65 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 64));
+auto _x_main_module_66 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 65));
+auto _x_main_module_67 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 66)));
+auto _x_main_module_68 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 67));
+auto _x_main_module_69 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 68)));
+auto _x_main_module_70 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 69));
+auto _x_main_module_71 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 70));
+auto _x_main_module_72 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 71)));
+auto _x_main_module_73 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448, 1280, 1, 1}}, 72));
+auto _x_main_module_74 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 73)));
+auto _x_main_module_75 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 74));
+auto _x_main_module_76 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 75));
+auto _x_main_module_77 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 76)));
+auto _x_main_module_78 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 77));
+auto _x_main_module_79 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 78)));
+auto _x_main_module_80 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 79));
+auto _x_main_module_81 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 80));
+auto _x_main_module_82 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 81)));
+auto _x_main_module_83 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 82));
+auto _x_main_module_84 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 83)));
+auto _x_main_module_85 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 84));
+auto _x_main_module_86 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 85));
+auto _x_main_module_87 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 86)));
+auto _x_main_module_88 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 1280, 1, 1}}, 87));
+auto _x_main_module_89 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 88)));
+auto _x_main_module_90 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 89));
+auto _x_main_module_91 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 90));
+auto _x_main_module_92 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 91)));
+auto _x_main_module_93 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 1280, 1, 1}}, 92));
+auto _x_main_module_94 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 93)));
+auto _x_main_module_95 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 94));
+auto _x_main_module_96 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 95));
+auto _x_main_module_97 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 96)));
+auto _x_main_module_98 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 3, 3}}, 97));
+auto _x_main_module_99 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 98)));
+auto _x_main_module_100 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 99));
+auto _x_main_module_101 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 100));
+auto _x_main_module_102 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 101)));
+auto _x_main_module_103 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 102));
+auto _x_main_module_104 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 103)));
+auto _x_main_module_105 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 104));
+auto _x_main_module_106 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 105));
+auto _x_main_module_107 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 106)));
+auto _x_main_module_108 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 107));
+auto _x_main_module_109 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 108)));
+auto _x_main_module_110 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 109));
+auto _x_main_module_111 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 110));
+auto _x_main_module_112 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 111)));
+auto _x_main_module_113 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 112));
+auto _x_main_module_114 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 113)));
+auto _x_main_module_115 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 114));
+auto _x_main_module_116 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 115));
+auto _x_main_module_117 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 116)));
+auto _x_main_module_118 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 192, 3, 3}}, 117));
+auto _x_main_module_119 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 118)));
+auto _x_main_module_120 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 119));
+auto _x_main_module_121 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 120));
+auto _x_main_module_122 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 121)));
+auto _x_main_module_123 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 122));
+auto _x_main_module_124 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 123)));
+auto _x_main_module_125 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 124));
+auto _x_main_module_126 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 125));
+auto _x_main_module_127 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 126)));
+auto _x_main_module_128 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 127));
+auto _x_main_module_129 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 128)));
+auto _x_main_module_130 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 129));
+auto _x_main_module_131 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 130));
+auto _x_main_module_132 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 131)));
+auto _x_main_module_133 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 132));
+auto _x_main_module_134 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 133)));
+auto _x_main_module_135 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 134));
+auto _x_main_module_136 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 135));
+auto _x_main_module_137 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 136)));
+auto _x_main_module_138 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 137));
+auto _x_main_module_139 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 138)));
+auto _x_main_module_140 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 139));
+auto _x_main_module_141 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 140));
+auto _x_main_module_142 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 141)));
+auto _x_main_module_143 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 142));
+auto _x_main_module_144 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 143)));
+auto _x_main_module_145 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 144));
+auto _x_main_module_146 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 145));
+auto _x_main_module_147 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 146)));
+auto _x_main_module_148 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 147));
+auto _x_main_module_149 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 148)));
+auto _x_main_module_150 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 149));
+auto _x_main_module_151 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 150));
+auto _x_main_module_152 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 151)));
+auto _x_main_module_153 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 152));
+auto _x_main_module_154 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 153)));
+auto _x_main_module_155 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 154));
+auto _x_main_module_156 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 155));
+auto _x_main_module_157 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 156)));
+auto _x_main_module_158 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 157));
+auto _x_main_module_159 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 158)));
+auto _x_main_module_160 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 159));
+auto _x_main_module_161 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 160));
+auto _x_main_module_162 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 161)));
+auto _x_main_module_163 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 162));
+auto _x_main_module_164 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 163)));
+auto _x_main_module_165 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 164));
+auto _x_main_module_166 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 165));
+auto _x_main_module_167 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 166)));
+auto _x_main_module_168 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 167));
+auto _x_main_module_169 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 168)));
+auto _x_main_module_170 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 169));
+auto _x_main_module_171 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 170));
+auto _x_main_module_172 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 171)));
+auto _x_main_module_173 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 172));
+auto _x_main_module_174 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 173)));
+auto _x_main_module_175 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 174));
+auto _x_main_module_176 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 175));
+auto _x_main_module_177 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 176)));
+auto _x_main_module_178 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 177));
+auto _x_main_module_179 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 178)));
+auto _x_main_module_180 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 179));
+auto _x_main_module_181 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 180));
+auto _x_main_module_182 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 181)));
+auto _x_main_module_183 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 182));
+auto _x_main_module_184 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 183)));
+auto _x_main_module_185 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 184));
+auto _x_main_module_186 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 185));
+auto _x_main_module_187 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 186)));
+auto _x_main_module_188 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 187));
+auto _x_main_module_189 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 188)));
+auto _x_main_module_190 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 189));
+auto _x_main_module_191 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 190));
+auto _x_main_module_192 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 191)));
+auto _x_main_module_193 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 192));
+auto _x_main_module_194 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 193)));
+auto _x_main_module_195 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 194));
+auto _x_main_module_196 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 195));
+auto _x_main_module_197 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 196)));
+auto _x_main_module_198 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 197));
+auto _x_main_module_199 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 198)));
+auto _x_main_module_200 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 199));
+auto _x_main_module_201 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 200));
+auto _x_main_module_202 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 201)));
+auto _x_main_module_203 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 202));
+auto _x_main_module_204 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 203)));
+auto _x_main_module_205 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 204));
+auto _x_main_module_206 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 205));
+auto _x_main_module_207 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 206)));
+auto _x_main_module_208 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 207));
+auto _x_main_module_209 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 208)));
+auto _x_main_module_210 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 209));
+auto _x_main_module_211 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 210));
+auto _x_main_module_212 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 211)));
+auto _x_main_module_213 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 212));
+auto _x_main_module_214 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 213)));
+auto _x_main_module_215 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 214));
+auto _x_main_module_216 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 215));
+auto _x_main_module_217 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 216)));
+auto _x_main_module_218 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 217));
+auto _x_main_module_219 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 218)));
+auto _x_main_module_220 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 219));
+auto _x_main_module_221 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 220));
+auto _x_main_module_222 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 221)));
+auto _x_main_module_223 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 222));
+auto _x_main_module_224 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 223)));
+auto _x_main_module_225 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 224));
+auto _x_main_module_226 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 225));
+auto _x_main_module_227 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 226)));
+auto _x_main_module_228 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 227));
+auto _x_main_module_229 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 228)));
+auto _x_main_module_230 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 229));
+auto _x_main_module_231 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 230));
+auto _x_main_module_232 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 231)));
+auto _x_main_module_233 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 232));
+auto _x_main_module_234 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 233)));
+auto _x_main_module_235 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 234));
+auto _x_main_module_236 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 235));
+auto _x_main_module_237 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 236)));
+auto _x_main_module_238 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 237));
+auto _x_main_module_239 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 238)));
+auto _x_main_module_240 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 239));
+auto _x_main_module_241 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 240));
+auto _x_main_module_242 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 241)));
+auto _x_main_module_243 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 242));
+auto _x_main_module_244 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 243)));
+auto _x_main_module_245 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 244));
+auto _x_main_module_246 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 245));
+auto _x_main_module_247 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 246)));
+auto _x_main_module_248 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 247));
+auto _x_main_module_249 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 248)));
+auto _x_main_module_250 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 249));
+auto _x_main_module_251 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 250));
+auto _x_main_module_252 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 251)));
+auto _x_main_module_253 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 252));
+auto _x_main_module_254 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 253)));
+auto _x_main_module_255 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 254));
+auto _x_main_module_256 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 255));
+auto _x_main_module_257 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 256)));
+auto _x_main_module_258 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 257));
+auto _x_main_module_259 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 258)));
+auto _x_main_module_260 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 259));
+auto _x_main_module_261 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 260));
+auto _x_main_module_262 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 261)));
+auto _x_main_module_263 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 262));
+auto _x_main_module_264 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 263)));
+auto _x_main_module_265 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 264));
+auto _x_main_module_266 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 265));
+auto _x_main_module_267 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 266)));
+auto _x_main_module_268 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 267));
+auto _x_main_module_269 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 268)));
+auto _x_main_module_270 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 269));
+auto _x_main_module_271 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 270));
+auto _x_main_module_272 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 271)));
+auto _x_main_module_273 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 272));
+auto _x_main_module_274 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 273)));
+auto _x_main_module_275 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 274));
+auto _x_main_module_276 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 275));
+auto _x_main_module_277 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 276)));
+auto _x_main_module_278 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 277));
+auto _x_main_module_279 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 278)));
+auto _x_main_module_280 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 279));
+auto _x_main_module_281 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 280));
+auto _x_main_module_282 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 281)));
+auto _x_main_module_283 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 128, 1, 7}}, 282));
+auto _x_main_module_284 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 283)));
+auto _x_main_module_285 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 284));
+auto _x_main_module_286 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 285));
+auto _x_main_module_287 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 286)));
+auto _x_main_module_288 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 287));
+auto _x_main_module_289 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 288)));
+auto _x_main_module_290 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 289));
+auto _x_main_module_291 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 290));
+auto _x_main_module_292 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 291)));
+auto _x_main_module_293 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 292));
+auto _x_main_module_294 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 293)));
+auto _x_main_module_295 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 294));
+auto _x_main_module_296 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 295));
+auto _x_main_module_297 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 296)));
+auto _x_main_module_298 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 297));
+auto _x_main_module_299 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 298)));
+auto _x_main_module_300 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 299));
+auto _x_main_module_301 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 300));
+auto _x_main_module_302 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 301)));
+auto _x_main_module_303 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 302));
+auto _x_main_module_304 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 303)));
+auto _x_main_module_305 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 304));
+auto _x_main_module_306 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 305));
+auto _x_main_module_307 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 306)));
+auto _x_main_module_308 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 128, 7, 1}}, 307));
+auto _x_main_module_309 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 308)));
+auto _x_main_module_310 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 309));
+auto _x_main_module_311 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 310));
+auto _x_main_module_312 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 311)));
+auto _x_main_module_313 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 312));
+auto _x_main_module_314 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 313)));
+auto _x_main_module_315 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 314));
+auto _x_main_module_316 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 315));
+auto _x_main_module_317 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 316)));
+auto _x_main_module_318 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 317));
+auto _x_main_module_319 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 318)));
+auto _x_main_module_320 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 319));
+auto _x_main_module_321 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 320));
+auto _x_main_module_322 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 321)));
+auto _x_main_module_323 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 322));
+auto _x_main_module_324 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 323)));
+auto _x_main_module_325 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 324));
+auto _x_main_module_326 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 325));
+auto _x_main_module_327 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 326)));
+auto _x_main_module_328 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 327));
+auto _x_main_module_329 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 328)));
+auto _x_main_module_330 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 329));
+auto _x_main_module_331 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 330));
+auto _x_main_module_332 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 331)));
+auto _x_main_module_333 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 332));
+auto _x_main_module_334 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 333)));
+auto _x_main_module_335 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 334));
+auto _x_main_module_336 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 335));
+auto _x_main_module_337 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 336)));
+auto _x_main_module_338 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 337));
+auto _x_main_module_339 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 338)));
+auto _x_main_module_340 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 339));
+auto _x_main_module_341 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 340));
+auto _x_main_module_342 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 341)));
+auto _x_main_module_343 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 288, 3, 3}}, 342));
+auto _x_main_module_344 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 343)));
+auto _x_main_module_345 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 344));
+auto _x_main_module_346 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 345));
+auto _x_main_module_347 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 346)));
+auto _x_main_module_348 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 347));
+auto _x_main_module_349 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 348)));
+auto _x_main_module_350 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 349));
+auto _x_main_module_351 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 350));
+auto _x_main_module_352 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 351)));
+auto _x_main_module_353 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 352));
+auto _x_main_module_354 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 353)));
+auto _x_main_module_355 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 354));
+auto _x_main_module_356 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 355));
+auto _x_main_module_357 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 356)));
+auto _x_main_module_358 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 357));
+auto _x_main_module_359 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 358)));
+auto _x_main_module_360 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 359));
+auto _x_main_module_361 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 360));
+auto _x_main_module_362 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 361)));
+auto _x_main_module_363 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 362));
+auto _x_main_module_364 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 363)));
+auto _x_main_module_365 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 364));
+auto _x_main_module_366 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 365));
+auto _x_main_module_367 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 366)));
+auto _x_main_module_368 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 367));
+auto _x_main_module_369 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 368)));
+auto _x_main_module_370 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 369));
+auto _x_main_module_371 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 370));
+auto _x_main_module_372 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 371)));
+auto _x_main_module_373 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 288, 1, 1}}, 372));
+auto _x_main_module_374 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 373)));
+auto _x_main_module_375 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 374));
+auto _x_main_module_376 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 375));
+auto _x_main_module_377 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 376)));
+auto _x_main_module_378 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 377));
+auto _x_main_module_379 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 378)));
+auto _x_main_module_380 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 379));
+auto _x_main_module_381 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 380));
+auto _x_main_module_382 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 381)));
+auto _x_main_module_383 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 382));
+auto _x_main_module_384 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 383)));
+auto _x_main_module_385 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 384));
+auto _x_main_module_386 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 385));
+auto _x_main_module_387 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 386)));
+auto _x_main_module_388 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 387));
+auto _x_main_module_389 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 388)));
+auto _x_main_module_390 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 389));
+auto _x_main_module_391 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 390));
+auto _x_main_module_392 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 391)));
+auto _x_main_module_393 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 392));
+auto _x_main_module_394 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 393)));
+auto _x_main_module_395 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 394));
+auto _x_main_module_396 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 395));
+auto _x_main_module_397 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 396)));
+auto _x_main_module_398 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 397));
+auto _x_main_module_399 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 398)));
+auto _x_main_module_400 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 399));
+auto _x_main_module_401 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 400));
+auto _x_main_module_402 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 401)));
+auto _x_main_module_403 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 402));
+auto _x_main_module_404 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 403)));
+auto _x_main_module_405 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 404));
+auto _x_main_module_406 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 405));
+auto _x_main_module_407 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 406)));
+auto _x_main_module_408 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 256, 1, 1}}, 407));
+auto _x_main_module_409 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 408)));
+auto _x_main_module_410 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 409));
+auto _x_main_module_411 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 410));
+auto _x_main_module_412 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 411)));
+auto _x_main_module_413 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 412));
+auto _x_main_module_414 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 413)));
+auto _x_main_module_415 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 414));
+auto _x_main_module_416 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 415));
+auto _x_main_module_417 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 416)));
+auto _x_main_module_418 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 192, 1, 1}}, 417));
+auto _x_main_module_419 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 418)));
+auto _x_main_module_420 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 419));
+auto _x_main_module_421 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 420));
+auto _x_main_module_422 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 421)));
+auto _x_main_module_423 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 422));
+auto _x_main_module_424 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 423)));
+auto _x_main_module_425 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 424));
+auto _x_main_module_426 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 425));
+auto _x_main_module_427 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 426)));
+auto _x_main_module_428 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 427));
+auto _x_main_module_429 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 428)));
+auto _x_main_module_430 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 429));
+auto _x_main_module_431 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 430));
+auto _x_main_module_432 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 431)));
+auto _x_main_module_433 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 432));
+auto _x_main_module_434 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 433)));
+auto _x_main_module_435 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 434));
+auto _x_main_module_436 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 435));
+auto _x_main_module_437 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 436)));
+auto _x_main_module_438 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 437));
+auto _x_main_module_439 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 438)));
+auto _x_main_module_440 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 439));
+auto _x_main_module_441 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 440));
+auto _x_main_module_442 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 441)));
+auto _x_main_module_443 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 192, 1, 1}}, 442));
+auto _x_main_module_444 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 443)));
+auto _x_main_module_445 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 444));
+auto _x_main_module_446 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 445));
+auto _x_main_module_447 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 446)));
+auto _x_main_module_448 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 447));
+auto _x_main_module_449 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 448)));
+auto _x_main_module_450 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 449));
+auto _x_main_module_451 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 450));
+auto _x_main_module_452 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 451)));
+auto _x_main_module_453 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 80, 3, 3}}, 452));
+auto _x_main_module_454 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 453)));
+auto _x_main_module_455 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 454));
+auto _x_main_module_456 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 455));
+auto _x_main_module_457 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 456)));
+auto _x_main_module_458 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80, 64, 1, 1}}, 457));
+auto _x_main_module_459 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 458)));
+auto _x_main_module_460 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 459));
+auto _x_main_module_461 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 460));
+auto _x_main_module_462 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 461)));
+auto _x_main_module_463 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 32, 3, 3}}, 462));
+auto _x_main_module_464 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 463)));
+auto _x_main_module_465 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 464));
+auto _x_main_module_466 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 465));
+auto _x_main_module_467 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 466)));
+auto _x_main_module_468 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 32, 3, 3}}, 467));
+auto _x_main_module_469 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 468)));
+auto _x_main_module_470 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 469));
+auto _x_main_module_471 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 470));
+auto _x_main_module_472 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 471)));
+auto _x_main_module_473 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 3, 3, 3}}, 472));
+auto _x_main_module_474 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_0, _x_main_module_473);
+auto _x_main_module_475 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_474, _x_main_module_472, _x_main_module_471, _x_main_module_470, _x_main_module_469);
+auto _x_main_module_476 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_475);
+auto _x_main_module_477 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_476, _x_main_module_468);
+auto _x_main_module_478 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_477, _x_main_module_467, _x_main_module_466, _x_main_module_465, _x_main_module_464);
+auto _x_main_module_479 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_478);
+auto _x_main_module_480 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_479, _x_main_module_463);
+auto _x_main_module_481 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_480, _x_main_module_462, _x_main_module_461, _x_main_module_460, _x_main_module_459);
+auto _x_main_module_482 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_481);
+auto _x_main_module_483 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), _x_main_module_482);
+auto _x_main_module_484 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_483, _x_main_module_458);
+auto _x_main_module_485 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_484, _x_main_module_457, _x_main_module_456, _x_main_module_455, _x_main_module_454);
+auto _x_main_module_486 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_485);
+auto _x_main_module_487 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_486, _x_main_module_453);
+auto _x_main_module_488 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_487, _x_main_module_452, _x_main_module_451, _x_main_module_450, _x_main_module_449);
+auto _x_main_module_489 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_488);
+auto _x_main_module_490 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), _x_main_module_489);
+auto _x_main_module_491 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_490, _x_main_module_448);
+auto _x_main_module_492 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_491, _x_main_module_447, _x_main_module_446, _x_main_module_445, _x_main_module_444);
+auto _x_main_module_493 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_492);
+auto _x_main_module_494 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_490, _x_main_module_443);
+auto _x_main_module_495 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_494, _x_main_module_442, _x_main_module_441, _x_main_module_440, _x_main_module_439);
+auto _x_main_module_496 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_495);
+auto _x_main_module_497 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_496, _x_main_module_438);
+auto _x_main_module_498 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_497, _x_main_module_437, _x_main_module_436, _x_main_module_435, _x_main_module_434);
+auto _x_main_module_499 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_498);
+auto _x_main_module_500 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_490, _x_main_module_433);
+auto _x_main_module_501 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_500, _x_main_module_432, _x_main_module_431, _x_main_module_430, _x_main_module_429);
+auto _x_main_module_502 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_501);
+auto _x_main_module_503 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_502, _x_main_module_428);
+auto _x_main_module_504 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_503, _x_main_module_427, _x_main_module_426, _x_main_module_425, _x_main_module_424);
+auto _x_main_module_505 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_504);
+auto _x_main_module_506 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_505, _x_main_module_423);
+auto _x_main_module_507 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_506, _x_main_module_422, _x_main_module_421, _x_main_module_420, _x_main_module_419);
+auto _x_main_module_508 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_507);
+auto _x_main_module_509 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_490);
+auto _x_main_module_510 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_509, _x_main_module_418);
+auto _x_main_module_511 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_510, _x_main_module_417, _x_main_module_416, _x_main_module_415, _x_main_module_414);
+auto _x_main_module_512 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_511);
+auto _x_main_module_513 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_493, _x_main_module_499, _x_main_module_508, _x_main_module_512);
+auto _x_main_module_514 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_513, _x_main_module_413);
+auto _x_main_module_515 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_514, _x_main_module_412, _x_main_module_411, _x_main_module_410, _x_main_module_409);
+auto _x_main_module_516 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_515);
+auto _x_main_module_517 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_513, _x_main_module_408);
+auto _x_main_module_518 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_517, _x_main_module_407, _x_main_module_406, _x_main_module_405, _x_main_module_404);
+auto _x_main_module_519 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_518);
+auto _x_main_module_520 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_519, _x_main_module_403);
+auto _x_main_module_521 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_520, _x_main_module_402, _x_main_module_401, _x_main_module_400, _x_main_module_399);
+auto _x_main_module_522 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_521);
+auto _x_main_module_523 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_513, _x_main_module_398);
+auto _x_main_module_524 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_523, _x_main_module_397, _x_main_module_396, _x_main_module_395, _x_main_module_394);
+auto _x_main_module_525 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_524);
+auto _x_main_module_526 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_525, _x_main_module_393);
+auto _x_main_module_527 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_526, _x_main_module_392, _x_main_module_391, _x_main_module_390, _x_main_module_389);
+auto _x_main_module_528 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_527);
+auto _x_main_module_529 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_528, _x_main_module_388);
+auto _x_main_module_530 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_529, _x_main_module_387, _x_main_module_386, _x_main_module_385, _x_main_module_384);
+auto _x_main_module_531 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_530);
+auto _x_main_module_532 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_513);
+auto _x_main_module_533 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_532, _x_main_module_383);
+auto _x_main_module_534 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_533, _x_main_module_382, _x_main_module_381, _x_main_module_380, _x_main_module_379);
+auto _x_main_module_535 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_534);
+auto _x_main_module_536 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_516, _x_main_module_522, _x_main_module_531, _x_main_module_535);
+auto _x_main_module_537 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_536, _x_main_module_378);
+auto _x_main_module_538 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_537, _x_main_module_377, _x_main_module_376, _x_main_module_375, _x_main_module_374);
+auto _x_main_module_539 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_538);
+auto _x_main_module_540 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_536, _x_main_module_373);
+auto _x_main_module_541 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_540, _x_main_module_372, _x_main_module_371, _x_main_module_370, _x_main_module_369);
+auto _x_main_module_542 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_541);
+auto _x_main_module_543 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_542, _x_main_module_368);
+auto _x_main_module_544 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_543, _x_main_module_367, _x_main_module_366, _x_main_module_365, _x_main_module_364);
+auto _x_main_module_545 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_544);
+auto _x_main_module_546 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_536, _x_main_module_363);
+auto _x_main_module_547 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_546, _x_main_module_362, _x_main_module_361, _x_main_module_360, _x_main_module_359);
+auto _x_main_module_548 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_547);
+auto _x_main_module_549 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_548, _x_main_module_358);
+auto _x_main_module_550 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_549, _x_main_module_357, _x_main_module_356, _x_main_module_355, _x_main_module_354);
+auto _x_main_module_551 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_550);
+auto _x_main_module_552 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_551, _x_main_module_353);
+auto _x_main_module_553 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_552, _x_main_module_352, _x_main_module_351, _x_main_module_350, _x_main_module_349);
+auto _x_main_module_554 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_553);
+auto _x_main_module_555 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_536);
+auto _x_main_module_556 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_555, _x_main_module_348);
+auto _x_main_module_557 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_556, _x_main_module_347, _x_main_module_346, _x_main_module_345, _x_main_module_344);
+auto _x_main_module_558 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_557);
+auto _x_main_module_559 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_539, _x_main_module_545, _x_main_module_554, _x_main_module_558);
+auto _x_main_module_560 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_559, _x_main_module_343);
+auto _x_main_module_561 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_560, _x_main_module_342, _x_main_module_341, _x_main_module_340, _x_main_module_339);
+auto _x_main_module_562 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_561);
+auto _x_main_module_563 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_559, _x_main_module_338);
+auto _x_main_module_564 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_563, _x_main_module_337, _x_main_module_336, _x_main_module_335, _x_main_module_334);
+auto _x_main_module_565 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_564);
+auto _x_main_module_566 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_565, _x_main_module_333);
+auto _x_main_module_567 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_566, _x_main_module_332, _x_main_module_331, _x_main_module_330, _x_main_module_329);
+auto _x_main_module_568 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_567);
+auto _x_main_module_569 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_568, _x_main_module_328);
+auto _x_main_module_570 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_569, _x_main_module_327, _x_main_module_326, _x_main_module_325, _x_main_module_324);
+auto _x_main_module_571 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_570);
+auto _x_main_module_572 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), _x_main_module_559);
+auto _x_main_module_573 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_562, _x_main_module_571, _x_main_module_572);
+auto _x_main_module_574 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_573, _x_main_module_323);
+auto _x_main_module_575 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_574, _x_main_module_322, _x_main_module_321, _x_main_module_320, _x_main_module_319);
+auto _x_main_module_576 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_575);
+auto _x_main_module_577 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_573, _x_main_module_318);
+auto _x_main_module_578 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_577, _x_main_module_317, _x_main_module_316, _x_main_module_315, _x_main_module_314);
+auto _x_main_module_579 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_578);
+auto _x_main_module_580 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_579, _x_main_module_313);
+auto _x_main_module_581 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_580, _x_main_module_312, _x_main_module_311, _x_main_module_310, _x_main_module_309);
+auto _x_main_module_582 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_581);
+auto _x_main_module_583 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_582, _x_main_module_308);
+auto _x_main_module_584 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_583, _x_main_module_307, _x_main_module_306, _x_main_module_305, _x_main_module_304);
+auto _x_main_module_585 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_584);
+auto _x_main_module_586 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_573, _x_main_module_303);
+auto _x_main_module_587 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_586, _x_main_module_302, _x_main_module_301, _x_main_module_300, _x_main_module_299);
+auto _x_main_module_588 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_587);
+auto _x_main_module_589 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_588, _x_main_module_298);
+auto _x_main_module_590 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_589, _x_main_module_297, _x_main_module_296, _x_main_module_295, _x_main_module_294);
+auto _x_main_module_591 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_590);
+auto _x_main_module_592 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_591, _x_main_module_293);
+auto _x_main_module_593 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_592, _x_main_module_292, _x_main_module_291, _x_main_module_290, _x_main_module_289);
+auto _x_main_module_594 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_593);
+auto _x_main_module_595 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_594, _x_main_module_288);
+auto _x_main_module_596 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_595, _x_main_module_287, _x_main_module_286, _x_main_module_285, _x_main_module_284);
+auto _x_main_module_597 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_596);
+auto _x_main_module_598 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_597, _x_main_module_283);
+auto _x_main_module_599 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_598, _x_main_module_282, _x_main_module_281, _x_main_module_280, _x_main_module_279);
+auto _x_main_module_600 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_599);
+auto _x_main_module_601 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_573);
+auto _x_main_module_602 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_601, _x_main_module_278);
+auto _x_main_module_603 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_602, _x_main_module_277, _x_main_module_276, _x_main_module_275, _x_main_module_274);
+auto _x_main_module_604 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_603);
+auto _x_main_module_605 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_576, _x_main_module_585, _x_main_module_600, _x_main_module_604);
+auto _x_main_module_606 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_605, _x_main_module_273);
+auto _x_main_module_607 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_606, _x_main_module_272, _x_main_module_271, _x_main_module_270, _x_main_module_269);
+auto _x_main_module_608 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_607);
+auto _x_main_module_609 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_605, _x_main_module_268);
+auto _x_main_module_610 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_609, _x_main_module_267, _x_main_module_266, _x_main_module_265, _x_main_module_264);
+auto _x_main_module_611 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_610);
+auto _x_main_module_612 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_611, _x_main_module_263);
+auto _x_main_module_613 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_612, _x_main_module_262, _x_main_module_261, _x_main_module_260, _x_main_module_259);
+auto _x_main_module_614 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_613);
+auto _x_main_module_615 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_614, _x_main_module_258);
+auto _x_main_module_616 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_615, _x_main_module_257, _x_main_module_256, _x_main_module_255, _x_main_module_254);
+auto _x_main_module_617 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_616);
+auto _x_main_module_618 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_605, _x_main_module_253);
+auto _x_main_module_619 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_618, _x_main_module_252, _x_main_module_251, _x_main_module_250, _x_main_module_249);
+auto _x_main_module_620 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_619);
+auto _x_main_module_621 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_620, _x_main_module_248);
+auto _x_main_module_622 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_621, _x_main_module_247, _x_main_module_246, _x_main_module_245, _x_main_module_244);
+auto _x_main_module_623 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_622);
+auto _x_main_module_624 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_623, _x_main_module_243);
+auto _x_main_module_625 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_624, _x_main_module_242, _x_main_module_241, _x_main_module_240, _x_main_module_239);
+auto _x_main_module_626 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_625);
+auto _x_main_module_627 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_626, _x_main_module_238);
+auto _x_main_module_628 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_627, _x_main_module_237, _x_main_module_236, _x_main_module_235, _x_main_module_234);
+auto _x_main_module_629 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_628);
+auto _x_main_module_630 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_629, _x_main_module_233);
+auto _x_main_module_631 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_630, _x_main_module_232, _x_main_module_231, _x_main_module_230, _x_main_module_229);
+auto _x_main_module_632 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_631);
+auto _x_main_module_633 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_605);
+auto _x_main_module_634 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_633, _x_main_module_228);
+auto _x_main_module_635 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_634, _x_main_module_227, _x_main_module_226, _x_main_module_225, _x_main_module_224);
+auto _x_main_module_636 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_635);
+auto _x_main_module_637 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_608, _x_main_module_617, _x_main_module_632, _x_main_module_636);
+auto _x_main_module_638 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_637, _x_main_module_223);
+auto _x_main_module_639 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_638, _x_main_module_222, _x_main_module_221, _x_main_module_220, _x_main_module_219);
+auto _x_main_module_640 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_639);
+auto _x_main_module_641 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_637, _x_main_module_218);
+auto _x_main_module_642 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_641, _x_main_module_217, _x_main_module_216, _x_main_module_215, _x_main_module_214);
+auto _x_main_module_643 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_642);
+auto _x_main_module_644 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_643, _x_main_module_213);
+auto _x_main_module_645 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_644, _x_main_module_212, _x_main_module_211, _x_main_module_210, _x_main_module_209);
+auto _x_main_module_646 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_645);
+auto _x_main_module_647 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_646, _x_main_module_208);
+auto _x_main_module_648 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_647, _x_main_module_207, _x_main_module_206, _x_main_module_205, _x_main_module_204);
+auto _x_main_module_649 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_648);
+auto _x_main_module_650 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_637, _x_main_module_203);
+auto _x_main_module_651 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_650, _x_main_module_202, _x_main_module_201, _x_main_module_200, _x_main_module_199);
+auto _x_main_module_652 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_651);
+auto _x_main_module_653 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_652, _x_main_module_198);
+auto _x_main_module_654 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_653, _x_main_module_197, _x_main_module_196, _x_main_module_195, _x_main_module_194);
+auto _x_main_module_655 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_654);
+auto _x_main_module_656 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_655, _x_main_module_193);
+auto _x_main_module_657 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_656, _x_main_module_192, _x_main_module_191, _x_main_module_190, _x_main_module_189);
+auto _x_main_module_658 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_657);
+auto _x_main_module_659 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_658, _x_main_module_188);
+auto _x_main_module_660 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_659, _x_main_module_187, _x_main_module_186, _x_main_module_185, _x_main_module_184);
+auto _x_main_module_661 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_660);
+auto _x_main_module_662 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_661, _x_main_module_183);
+auto _x_main_module_663 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_662, _x_main_module_182, _x_main_module_181, _x_main_module_180, _x_main_module_179);
+auto _x_main_module_664 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_663);
+auto _x_main_module_665 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_637);
+auto _x_main_module_666 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_665, _x_main_module_178);
+auto _x_main_module_667 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_666, _x_main_module_177, _x_main_module_176, _x_main_module_175, _x_main_module_174);
+auto _x_main_module_668 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_667);
+auto _x_main_module_669 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_640, _x_main_module_649, _x_main_module_664, _x_main_module_668);
+auto _x_main_module_670 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_669, _x_main_module_173);
+auto _x_main_module_671 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_670, _x_main_module_172, _x_main_module_171, _x_main_module_170, _x_main_module_169);
+auto _x_main_module_672 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_671);
+auto _x_main_module_673 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_669, _x_main_module_168);
+auto _x_main_module_674 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_673, _x_main_module_167, _x_main_module_166, _x_main_module_165, _x_main_module_164);
+auto _x_main_module_675 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_674);
+auto _x_main_module_676 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_675, _x_main_module_163);
+auto _x_main_module_677 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_676, _x_main_module_162, _x_main_module_161, _x_main_module_160, _x_main_module_159);
+auto _x_main_module_678 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_677);
+auto _x_main_module_679 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_678, _x_main_module_158);
+auto _x_main_module_680 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_679, _x_main_module_157, _x_main_module_156, _x_main_module_155, _x_main_module_154);
+auto _x_main_module_681 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_680);
+auto _x_main_module_682 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_669, _x_main_module_153);
+auto _x_main_module_683 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_682, _x_main_module_152, _x_main_module_151, _x_main_module_150, _x_main_module_149);
+auto _x_main_module_684 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_683);
+auto _x_main_module_685 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_684, _x_main_module_148);
+auto _x_main_module_686 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_685, _x_main_module_147, _x_main_module_146, _x_main_module_145, _x_main_module_144);
+auto _x_main_module_687 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_686);
+auto _x_main_module_688 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_687, _x_main_module_143);
+auto _x_main_module_689 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_688, _x_main_module_142, _x_main_module_141, _x_main_module_140, _x_main_module_139);
+auto _x_main_module_690 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_689);
+auto _x_main_module_691 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_690, _x_main_module_138);
+auto _x_main_module_692 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_691, _x_main_module_137, _x_main_module_136, _x_main_module_135, _x_main_module_134);
+auto _x_main_module_693 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_692);
+auto _x_main_module_694 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_693, _x_main_module_133);
+auto _x_main_module_695 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_694, _x_main_module_132, _x_main_module_131, _x_main_module_130, _x_main_module_129);
+auto _x_main_module_696 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_695);
+auto _x_main_module_697 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_669);
+auto _x_main_module_698 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_697, _x_main_module_128);
+auto _x_main_module_699 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_698, _x_main_module_127, _x_main_module_126, _x_main_module_125, _x_main_module_124);
+auto _x_main_module_700 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_699);
+auto _x_main_module_701 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_672, _x_main_module_681, _x_main_module_696, _x_main_module_700);
+auto _x_main_module_702 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_701, _x_main_module_123);
+auto _x_main_module_703 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_702, _x_main_module_122, _x_main_module_121, _x_main_module_120, _x_main_module_119);
+auto _x_main_module_704 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_703);
+auto _x_main_module_705 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_704, _x_main_module_118);
+auto _x_main_module_706 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_705, _x_main_module_117, _x_main_module_116, _x_main_module_115, _x_main_module_114);
+auto _x_main_module_707 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_706);
+auto _x_main_module_708 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_701, _x_main_module_113);
+auto _x_main_module_709 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_708, _x_main_module_112, _x_main_module_111, _x_main_module_110, _x_main_module_109);
+auto _x_main_module_710 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_709);
+auto _x_main_module_711 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_710, _x_main_module_108);
+auto _x_main_module_712 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_711, _x_main_module_107, _x_main_module_106, _x_main_module_105, _x_main_module_104);
+auto _x_main_module_713 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_712);
+auto _x_main_module_714 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_713, _x_main_module_103);
+auto _x_main_module_715 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_714, _x_main_module_102, _x_main_module_101, _x_main_module_100, _x_main_module_99);
+auto _x_main_module_716 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_715);
+auto _x_main_module_717 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_716, _x_main_module_98);
+auto _x_main_module_718 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_717, _x_main_module_97, _x_main_module_96, _x_main_module_95, _x_main_module_94);
+auto _x_main_module_719 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_718);
+auto _x_main_module_720 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), _x_main_module_701);
+auto _x_main_module_721 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_707, _x_main_module_719, _x_main_module_720);
+auto _x_main_module_722 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_721, _x_main_module_93);
+auto _x_main_module_723 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_722, _x_main_module_92, _x_main_module_91, _x_main_module_90, _x_main_module_89);
+auto _x_main_module_724 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_723);
+auto _x_main_module_725 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_721, _x_main_module_88);
+auto _x_main_module_726 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_725, _x_main_module_87, _x_main_module_86, _x_main_module_85, _x_main_module_84);
+auto _x_main_module_727 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_726);
+auto _x_main_module_728 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_727, _x_main_module_83);
+auto _x_main_module_729 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_728, _x_main_module_82, _x_main_module_81, _x_main_module_80, _x_main_module_79);
+auto _x_main_module_730 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_729);
+auto _x_main_module_731 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_727, _x_main_module_78);
+auto _x_main_module_732 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_731, _x_main_module_77, _x_main_module_76, _x_main_module_75, _x_main_module_74);
+auto _x_main_module_733 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_732);
+auto _x_main_module_734 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_730, _x_main_module_733);
+auto _x_main_module_735 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_721, _x_main_module_73);
+auto _x_main_module_736 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_735, _x_main_module_72, _x_main_module_71, _x_main_module_70, _x_main_module_69);
+auto _x_main_module_737 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_736);
+auto _x_main_module_738 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_737, _x_main_module_68);
+auto _x_main_module_739 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_738, _x_main_module_67, _x_main_module_66, _x_main_module_65, _x_main_module_64);
+auto _x_main_module_740 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_739);
+auto _x_main_module_741 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_740, _x_main_module_63);
+auto _x_main_module_742 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_741, _x_main_module_62, _x_main_module_61, _x_main_module_60, _x_main_module_59);
+auto _x_main_module_743 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_742);
+auto _x_main_module_744 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_740, _x_main_module_58);
+auto _x_main_module_745 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_744, _x_main_module_57, _x_main_module_56, _x_main_module_55, _x_main_module_54);
+auto _x_main_module_746 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_745);
+auto _x_main_module_747 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_743, _x_main_module_746);
+auto _x_main_module_748 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_721);
+auto _x_main_module_749 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_748, _x_main_module_53);
+auto _x_main_module_750 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_749, _x_main_module_52, _x_main_module_51, _x_main_module_50, _x_main_module_49);
+auto _x_main_module_751 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_750);
+auto _x_main_module_752 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_724, _x_main_module_734, _x_main_module_747, _x_main_module_751);
+auto _x_main_module_753 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_752, _x_main_module_48);
+auto _x_main_module_754 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_753, _x_main_module_47, _x_main_module_46, _x_main_module_45, _x_main_module_44);
+auto _x_main_module_755 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_754);
+auto _x_main_module_756 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_752, _x_main_module_43);
+auto _x_main_module_757 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_756, _x_main_module_42, _x_main_module_41, _x_main_module_40, _x_main_module_39);
+auto _x_main_module_758 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_757);
+auto _x_main_module_759 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_758, _x_main_module_38);
+auto _x_main_module_760 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_759, _x_main_module_37, _x_main_module_36, _x_main_module_35, _x_main_module_34);
+auto _x_main_module_761 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_760);
+auto _x_main_module_762 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_758, _x_main_module_33);
+auto _x_main_module_763 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_762, _x_main_module_32, _x_main_module_31, _x_main_module_30, _x_main_module_29);
+auto _x_main_module_764 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_763);
+auto _x_main_module_765 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_761, _x_main_module_764);
+auto _x_main_module_766 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_752, _x_main_module_28);
+auto _x_main_module_767 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_766, _x_main_module_27, _x_main_module_26, _x_main_module_25, _x_main_module_24);
+auto _x_main_module_768 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_767);
+auto _x_main_module_769 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_768, _x_main_module_23);
+auto _x_main_module_770 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_769, _x_main_module_22, _x_main_module_21, _x_main_module_20, _x_main_module_19);
+auto _x_main_module_771 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_770);
+auto _x_main_module_772 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_771, _x_main_module_18);
+auto _x_main_module_773 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_772, _x_main_module_17, _x_main_module_16, _x_main_module_15, _x_main_module_14);
+auto _x_main_module_774 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_773);
+auto _x_main_module_775 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_771, _x_main_module_13);
+auto _x_main_module_776 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_775, _x_main_module_12, _x_main_module_11, _x_main_module_10, _x_main_module_9);
+auto _x_main_module_777 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_776);
+auto _x_main_module_778 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_774, _x_main_module_777);
+auto _x_main_module_779 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), _x_main_module_752);
+auto _x_main_module_780 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_779, _x_main_module_8);
+auto _x_main_module_781 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), _x_main_module_780, _x_main_module_7, _x_main_module_6, _x_main_module_5, _x_main_module_4);
+auto _x_main_module_782 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_781);
+auto _x_main_module_783 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_755, _x_main_module_765, _x_main_module_778, _x_main_module_782);
+auto _x_main_module_784 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[8,8],\"lp_order\":2,\"mode\":0,\"padding\":[0,0,0,0],\"stride\":[8,8]}")), _x_main_module_783);
+auto _x_main_module_785 = mmain->add_instruction(migraphx::make_op("identity"), _x_main_module_784);
+auto _x_main_module_786 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_785);
+auto _x_main_module_787 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), _x_main_module_3);
+auto _x_main_module_788 = mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_786, _x_main_module_787);
+auto _x_main_module_789 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), _x_main_module_2);
+auto _x_main_module_790 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), _x_main_module_0);
+auto _x_main_module_791 = mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_789, _x_main_module_790);
+auto _x_main_module_792 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_788, _x_main_module_791);
+mmain->add_return({_x_main_module_792});
+
 
     return p;
 }

--- a/src/driver/inceptionv3.cpp
+++ b/src/driver/inceptionv3.cpp
@@ -32,802 +32,2607 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program inceptionv3(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-migraphx::module_ref mmain = p.get_main_module();
-auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 299, 299}});
-auto x_main_module_2 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
-auto x_main_module_3 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
-auto x_main_module_4 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 3)));
-auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 4));
-auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 5));
-auto x_main_module_7 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 6)));
-auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 2048, 1, 1}}, 7));
-auto x_main_module_9 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 8)));
-auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 9));
-auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 10));
-auto x_main_module_12 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 11)));
-auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 12));
-auto x_main_module_14 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13)));
-auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 14));
-auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 15));
-auto x_main_module_17 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 16)));
-auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 17));
-auto x_main_module_19 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 18)));
-auto x_main_module_20 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 19));
-auto x_main_module_21 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 20));
-auto x_main_module_22 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 21)));
-auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 22));
-auto x_main_module_24 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 23)));
-auto x_main_module_25 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 24));
-auto x_main_module_26 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 25));
-auto x_main_module_27 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 26)));
-auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448, 2048, 1, 1}}, 27));
-auto x_main_module_29 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 28)));
-auto x_main_module_30 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 29)));
-auto x_main_module_31 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 30));
-auto x_main_module_32 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 31)));
-auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 32));
-auto x_main_module_34 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 33)));
-auto x_main_module_35 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 34)));
-auto x_main_module_36 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 35));
-auto x_main_module_37 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 36)));
-auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 37));
-auto x_main_module_39 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 38)));
-auto x_main_module_40 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 39));
-auto x_main_module_41 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 40));
-auto x_main_module_42 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 41)));
-auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 2048, 1, 1}}, 42));
-auto x_main_module_44 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 43)));
-auto x_main_module_45 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 44));
-auto x_main_module_46 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 45));
-auto x_main_module_47 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 46)));
-auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 2048, 1, 1}}, 47));
-auto x_main_module_49 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 48)));
-auto x_main_module_50 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 49));
-auto x_main_module_51 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 50));
-auto x_main_module_52 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 51)));
-auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 1280, 1, 1}}, 52));
-auto x_main_module_54 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 53)));
-auto x_main_module_55 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 54));
-auto x_main_module_56 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 55));
-auto x_main_module_57 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 56)));
-auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 57));
-auto x_main_module_59 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 58)));
-auto x_main_module_60 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 59));
-auto x_main_module_61 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 60));
-auto x_main_module_62 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 61)));
-auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 62));
-auto x_main_module_64 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 63)));
-auto x_main_module_65 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 64));
-auto x_main_module_66 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 65));
-auto x_main_module_67 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 66)));
-auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 67));
-auto x_main_module_69 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 68)));
-auto x_main_module_70 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 69));
-auto x_main_module_71 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 70));
-auto x_main_module_72 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 71)));
-auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448, 1280, 1, 1}}, 72));
-auto x_main_module_74 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 73)));
-auto x_main_module_75 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 74));
-auto x_main_module_76 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 75));
-auto x_main_module_77 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 76)));
-auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 77));
-auto x_main_module_79 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 78)));
-auto x_main_module_80 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 79));
-auto x_main_module_81 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 80));
-auto x_main_module_82 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 81)));
-auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 82));
-auto x_main_module_84 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 83)));
-auto x_main_module_85 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 84));
-auto x_main_module_86 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 85));
-auto x_main_module_87 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 86)));
-auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 1280, 1, 1}}, 87));
-auto x_main_module_89 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 88)));
-auto x_main_module_90 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 89));
-auto x_main_module_91 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 90));
-auto x_main_module_92 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 91)));
-auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 1280, 1, 1}}, 92));
-auto x_main_module_94 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 93)));
-auto x_main_module_95 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 94));
-auto x_main_module_96 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 95));
-auto x_main_module_97 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 96)));
-auto x_main_module_98 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 3, 3}}, 97));
-auto x_main_module_99 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 98)));
-auto x_main_module_100 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 99));
-auto x_main_module_101 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 100));
-auto x_main_module_102 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 101)));
-auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 102));
-auto x_main_module_104 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 103)));
-auto x_main_module_105 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 104));
-auto x_main_module_106 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 105));
-auto x_main_module_107 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 106)));
-auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 107));
-auto x_main_module_109 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 108)));
-auto x_main_module_110 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 109));
-auto x_main_module_111 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 110));
-auto x_main_module_112 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 111)));
-auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 112));
-auto x_main_module_114 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 113)));
-auto x_main_module_115 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 114));
-auto x_main_module_116 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 115));
-auto x_main_module_117 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 116)));
-auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 192, 3, 3}}, 117));
-auto x_main_module_119 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 118)));
-auto x_main_module_120 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 119));
-auto x_main_module_121 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 120));
-auto x_main_module_122 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 121)));
-auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 122));
-auto x_main_module_124 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 123)));
-auto x_main_module_125 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 124));
-auto x_main_module_126 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 125));
-auto x_main_module_127 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 126)));
-auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 127));
-auto x_main_module_129 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 128)));
-auto x_main_module_130 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 129));
-auto x_main_module_131 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 130));
-auto x_main_module_132 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 131)));
-auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 132));
-auto x_main_module_134 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 133)));
-auto x_main_module_135 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 134));
-auto x_main_module_136 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 135));
-auto x_main_module_137 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 136)));
-auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 137));
-auto x_main_module_139 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 138)));
-auto x_main_module_140 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 139));
-auto x_main_module_141 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 140));
-auto x_main_module_142 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 141)));
-auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 142));
-auto x_main_module_144 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 143)));
-auto x_main_module_145 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 144));
-auto x_main_module_146 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 145));
-auto x_main_module_147 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 146)));
-auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 147));
-auto x_main_module_149 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 148)));
-auto x_main_module_150 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 149));
-auto x_main_module_151 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 150));
-auto x_main_module_152 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 151)));
-auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 152));
-auto x_main_module_154 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 153)));
-auto x_main_module_155 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 154));
-auto x_main_module_156 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 155));
-auto x_main_module_157 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 156)));
-auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 157));
-auto x_main_module_159 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 158)));
-auto x_main_module_160 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 159));
-auto x_main_module_161 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 160));
-auto x_main_module_162 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 161)));
-auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 162));
-auto x_main_module_164 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 163)));
-auto x_main_module_165 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 164));
-auto x_main_module_166 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 165));
-auto x_main_module_167 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 166)));
-auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 167));
-auto x_main_module_169 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 168)));
-auto x_main_module_170 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 169));
-auto x_main_module_171 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 170));
-auto x_main_module_172 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 171)));
-auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 172));
-auto x_main_module_174 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 173)));
-auto x_main_module_175 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 174));
-auto x_main_module_176 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 175));
-auto x_main_module_177 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 176)));
-auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 177));
-auto x_main_module_179 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 178)));
-auto x_main_module_180 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 179));
-auto x_main_module_181 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 180));
-auto x_main_module_182 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 181)));
-auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 182));
-auto x_main_module_184 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 183)));
-auto x_main_module_185 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 184));
-auto x_main_module_186 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 185));
-auto x_main_module_187 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 186)));
-auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 187));
-auto x_main_module_189 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 188)));
-auto x_main_module_190 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 189));
-auto x_main_module_191 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 190));
-auto x_main_module_192 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 191)));
-auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 192));
-auto x_main_module_194 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 193)));
-auto x_main_module_195 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 194));
-auto x_main_module_196 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 195));
-auto x_main_module_197 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 196)));
-auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 197));
-auto x_main_module_199 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 198)));
-auto x_main_module_200 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 199));
-auto x_main_module_201 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 200));
-auto x_main_module_202 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 201)));
-auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 202));
-auto x_main_module_204 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 203)));
-auto x_main_module_205 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 204));
-auto x_main_module_206 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 205));
-auto x_main_module_207 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 206)));
-auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 207));
-auto x_main_module_209 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 208)));
-auto x_main_module_210 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 209));
-auto x_main_module_211 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 210));
-auto x_main_module_212 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 211)));
-auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 212));
-auto x_main_module_214 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 213)));
-auto x_main_module_215 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 214));
-auto x_main_module_216 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 215));
-auto x_main_module_217 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 216)));
-auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 217));
-auto x_main_module_219 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 218)));
-auto x_main_module_220 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 219));
-auto x_main_module_221 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 220));
-auto x_main_module_222 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 221)));
-auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 222));
-auto x_main_module_224 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 223)));
-auto x_main_module_225 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 224));
-auto x_main_module_226 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 225));
-auto x_main_module_227 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 226)));
-auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 227));
-auto x_main_module_229 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 228)));
-auto x_main_module_230 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 229));
-auto x_main_module_231 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 230));
-auto x_main_module_232 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 231)));
-auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 232));
-auto x_main_module_234 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 233)));
-auto x_main_module_235 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 234));
-auto x_main_module_236 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 235));
-auto x_main_module_237 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 236)));
-auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 237));
-auto x_main_module_239 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 238)));
-auto x_main_module_240 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 239));
-auto x_main_module_241 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 240));
-auto x_main_module_242 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 241)));
-auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 242));
-auto x_main_module_244 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 243)));
-auto x_main_module_245 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 244));
-auto x_main_module_246 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 245));
-auto x_main_module_247 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 246)));
-auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 247));
-auto x_main_module_249 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 248)));
-auto x_main_module_250 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 249));
-auto x_main_module_251 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 250));
-auto x_main_module_252 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 251)));
-auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 252));
-auto x_main_module_254 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 253)));
-auto x_main_module_255 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 254));
-auto x_main_module_256 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 255));
-auto x_main_module_257 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 256)));
-auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 257));
-auto x_main_module_259 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 258)));
-auto x_main_module_260 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 259));
-auto x_main_module_261 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 260));
-auto x_main_module_262 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 261)));
-auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 262));
-auto x_main_module_264 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 263)));
-auto x_main_module_265 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 264));
-auto x_main_module_266 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 265));
-auto x_main_module_267 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 266)));
-auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 267));
-auto x_main_module_269 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 268)));
-auto x_main_module_270 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 269));
-auto x_main_module_271 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 270));
-auto x_main_module_272 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 271)));
-auto x_main_module_273 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 272));
-auto x_main_module_274 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 273)));
-auto x_main_module_275 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 274));
-auto x_main_module_276 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 275));
-auto x_main_module_277 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 276)));
-auto x_main_module_278 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 277));
-auto x_main_module_279 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 278)));
-auto x_main_module_280 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 279));
-auto x_main_module_281 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 280));
-auto x_main_module_282 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 281)));
-auto x_main_module_283 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 128, 1, 7}}, 282));
-auto x_main_module_284 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 283)));
-auto x_main_module_285 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 284));
-auto x_main_module_286 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 285));
-auto x_main_module_287 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 286)));
-auto x_main_module_288 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 287));
-auto x_main_module_289 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 288)));
-auto x_main_module_290 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 289));
-auto x_main_module_291 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 290));
-auto x_main_module_292 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 291)));
-auto x_main_module_293 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 292));
-auto x_main_module_294 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 293)));
-auto x_main_module_295 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 294));
-auto x_main_module_296 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 295));
-auto x_main_module_297 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 296)));
-auto x_main_module_298 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 297));
-auto x_main_module_299 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 298)));
-auto x_main_module_300 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 299));
-auto x_main_module_301 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 300));
-auto x_main_module_302 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 301)));
-auto x_main_module_303 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 302));
-auto x_main_module_304 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 303)));
-auto x_main_module_305 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 304));
-auto x_main_module_306 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 305));
-auto x_main_module_307 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 306)));
-auto x_main_module_308 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 128, 7, 1}}, 307));
-auto x_main_module_309 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 308)));
-auto x_main_module_310 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 309));
-auto x_main_module_311 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 310));
-auto x_main_module_312 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 311)));
-auto x_main_module_313 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 312));
-auto x_main_module_314 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 313)));
-auto x_main_module_315 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 314));
-auto x_main_module_316 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 315));
-auto x_main_module_317 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 316)));
-auto x_main_module_318 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 317));
-auto x_main_module_319 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 318)));
-auto x_main_module_320 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 319));
-auto x_main_module_321 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 320));
-auto x_main_module_322 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 321)));
-auto x_main_module_323 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 322));
-auto x_main_module_324 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 323)));
-auto x_main_module_325 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 324));
-auto x_main_module_326 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 325));
-auto x_main_module_327 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 326)));
-auto x_main_module_328 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 327));
-auto x_main_module_329 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 328)));
-auto x_main_module_330 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 329));
-auto x_main_module_331 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 330));
-auto x_main_module_332 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 331)));
-auto x_main_module_333 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 332));
-auto x_main_module_334 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 333)));
-auto x_main_module_335 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 334));
-auto x_main_module_336 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 335));
-auto x_main_module_337 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 336)));
-auto x_main_module_338 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 337));
-auto x_main_module_339 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 338)));
-auto x_main_module_340 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 339));
-auto x_main_module_341 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 340));
-auto x_main_module_342 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 341)));
-auto x_main_module_343 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 288, 3, 3}}, 342));
-auto x_main_module_344 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 343)));
-auto x_main_module_345 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 344));
-auto x_main_module_346 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 345));
-auto x_main_module_347 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 346)));
-auto x_main_module_348 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 347));
-auto x_main_module_349 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 348)));
-auto x_main_module_350 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 349));
-auto x_main_module_351 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 350));
-auto x_main_module_352 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 351)));
-auto x_main_module_353 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 352));
-auto x_main_module_354 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 353)));
-auto x_main_module_355 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 354));
-auto x_main_module_356 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 355));
-auto x_main_module_357 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 356)));
-auto x_main_module_358 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 357));
-auto x_main_module_359 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 358)));
-auto x_main_module_360 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 359));
-auto x_main_module_361 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 360));
-auto x_main_module_362 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 361)));
-auto x_main_module_363 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 362));
-auto x_main_module_364 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 363)));
-auto x_main_module_365 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 364));
-auto x_main_module_366 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 365));
-auto x_main_module_367 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 366)));
-auto x_main_module_368 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 367));
-auto x_main_module_369 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 368)));
-auto x_main_module_370 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 369));
-auto x_main_module_371 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 370));
-auto x_main_module_372 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 371)));
-auto x_main_module_373 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 288, 1, 1}}, 372));
-auto x_main_module_374 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 373)));
-auto x_main_module_375 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 374));
-auto x_main_module_376 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 375));
-auto x_main_module_377 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 376)));
-auto x_main_module_378 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 377));
-auto x_main_module_379 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 378)));
-auto x_main_module_380 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 379));
-auto x_main_module_381 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 380));
-auto x_main_module_382 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 381)));
-auto x_main_module_383 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 382));
-auto x_main_module_384 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 383)));
-auto x_main_module_385 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 384));
-auto x_main_module_386 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 385));
-auto x_main_module_387 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 386)));
-auto x_main_module_388 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 387));
-auto x_main_module_389 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 388)));
-auto x_main_module_390 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 389));
-auto x_main_module_391 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 390));
-auto x_main_module_392 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 391)));
-auto x_main_module_393 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 392));
-auto x_main_module_394 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 393)));
-auto x_main_module_395 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 394));
-auto x_main_module_396 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 395));
-auto x_main_module_397 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 396)));
-auto x_main_module_398 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 397));
-auto x_main_module_399 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 398)));
-auto x_main_module_400 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 399));
-auto x_main_module_401 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 400));
-auto x_main_module_402 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 401)));
-auto x_main_module_403 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 402));
-auto x_main_module_404 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 403)));
-auto x_main_module_405 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 404));
-auto x_main_module_406 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 405));
-auto x_main_module_407 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 406)));
-auto x_main_module_408 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 256, 1, 1}}, 407));
-auto x_main_module_409 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 408)));
-auto x_main_module_410 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 409));
-auto x_main_module_411 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 410));
-auto x_main_module_412 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 411)));
-auto x_main_module_413 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 412));
-auto x_main_module_414 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 413)));
-auto x_main_module_415 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 414));
-auto x_main_module_416 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 415));
-auto x_main_module_417 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 416)));
-auto x_main_module_418 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 192, 1, 1}}, 417));
-auto x_main_module_419 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 418)));
-auto x_main_module_420 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 419));
-auto x_main_module_421 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 420));
-auto x_main_module_422 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 421)));
-auto x_main_module_423 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 422));
-auto x_main_module_424 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 423)));
-auto x_main_module_425 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 424));
-auto x_main_module_426 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 425));
-auto x_main_module_427 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 426)));
-auto x_main_module_428 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 427));
-auto x_main_module_429 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 428)));
-auto x_main_module_430 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 429));
-auto x_main_module_431 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 430));
-auto x_main_module_432 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 431)));
-auto x_main_module_433 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 432));
-auto x_main_module_434 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 433)));
-auto x_main_module_435 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 434));
-auto x_main_module_436 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 435));
-auto x_main_module_437 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 436)));
-auto x_main_module_438 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 437));
-auto x_main_module_439 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 438)));
-auto x_main_module_440 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 439));
-auto x_main_module_441 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 440));
-auto x_main_module_442 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 441)));
-auto x_main_module_443 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 192, 1, 1}}, 442));
-auto x_main_module_444 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 443)));
-auto x_main_module_445 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 444));
-auto x_main_module_446 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 445));
-auto x_main_module_447 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 446)));
-auto x_main_module_448 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 447));
-auto x_main_module_449 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 448)));
-auto x_main_module_450 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 449));
-auto x_main_module_451 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 450));
-auto x_main_module_452 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 451)));
-auto x_main_module_453 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 80, 3, 3}}, 452));
-auto x_main_module_454 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 453)));
-auto x_main_module_455 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 454));
-auto x_main_module_456 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 455));
-auto x_main_module_457 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 456)));
-auto x_main_module_458 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80, 64, 1, 1}}, 457));
-auto x_main_module_459 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 458)));
-auto x_main_module_460 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 459));
-auto x_main_module_461 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 460));
-auto x_main_module_462 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 461)));
-auto x_main_module_463 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 32, 3, 3}}, 462));
-auto x_main_module_464 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 463)));
-auto x_main_module_465 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 464));
-auto x_main_module_466 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 465));
-auto x_main_module_467 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 466)));
-auto x_main_module_468 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 32, 3, 3}}, 467));
-auto x_main_module_469 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 468)));
-auto x_main_module_470 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 469));
-auto x_main_module_471 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 470));
-auto x_main_module_472 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 471)));
-auto x_main_module_473 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 3, 3, 3}}, 472));
-auto x_main_module_474 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_0, x_main_module_473);
-auto x_main_module_475 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_474, x_main_module_472, x_main_module_471, x_main_module_470, x_main_module_469);
-auto x_main_module_476 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_475);
-auto x_main_module_477 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_476, x_main_module_468);
-auto x_main_module_478 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_477, x_main_module_467, x_main_module_466, x_main_module_465, x_main_module_464);
-auto x_main_module_479 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_478);
-auto x_main_module_480 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_479, x_main_module_463);
-auto x_main_module_481 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_480, x_main_module_462, x_main_module_461, x_main_module_460, x_main_module_459);
-auto x_main_module_482 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_481);
-auto x_main_module_483 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"), x_main_module_482);
-auto x_main_module_484 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_483, x_main_module_458);
-auto x_main_module_485 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_484, x_main_module_457, x_main_module_456, x_main_module_455, x_main_module_454);
-auto x_main_module_486 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_485);
-auto x_main_module_487 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_486, x_main_module_453);
-auto x_main_module_488 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_487, x_main_module_452, x_main_module_451, x_main_module_450, x_main_module_449);
-auto x_main_module_489 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_488);
-auto x_main_module_490 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"), x_main_module_489);
-auto x_main_module_491 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_490, x_main_module_448);
-auto x_main_module_492 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_491, x_main_module_447, x_main_module_446, x_main_module_445, x_main_module_444);
-auto x_main_module_493 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_492);
-auto x_main_module_494 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_490, x_main_module_443);
-auto x_main_module_495 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_494, x_main_module_442, x_main_module_441, x_main_module_440, x_main_module_439);
-auto x_main_module_496 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_495);
-auto x_main_module_497 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_496, x_main_module_438);
-auto x_main_module_498 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_497, x_main_module_437, x_main_module_436, x_main_module_435, x_main_module_434);
-auto x_main_module_499 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_498);
-auto x_main_module_500 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_490, x_main_module_433);
-auto x_main_module_501 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_500, x_main_module_432, x_main_module_431, x_main_module_430, x_main_module_429);
-auto x_main_module_502 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_501);
-auto x_main_module_503 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_502, x_main_module_428);
-auto x_main_module_504 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_503, x_main_module_427, x_main_module_426, x_main_module_425, x_main_module_424);
-auto x_main_module_505 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_504);
-auto x_main_module_506 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_505, x_main_module_423);
-auto x_main_module_507 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_506, x_main_module_422, x_main_module_421, x_main_module_420, x_main_module_419);
-auto x_main_module_508 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_507);
-auto x_main_module_509 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_490);
-auto x_main_module_510 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_509, x_main_module_418);
-auto x_main_module_511 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_510, x_main_module_417, x_main_module_416, x_main_module_415, x_main_module_414);
-auto x_main_module_512 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_511);
-auto x_main_module_513 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_493, x_main_module_499, x_main_module_508, x_main_module_512);
-auto x_main_module_514 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_513, x_main_module_413);
-auto x_main_module_515 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_514, x_main_module_412, x_main_module_411, x_main_module_410, x_main_module_409);
-auto x_main_module_516 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_515);
-auto x_main_module_517 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_513, x_main_module_408);
-auto x_main_module_518 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_517, x_main_module_407, x_main_module_406, x_main_module_405, x_main_module_404);
-auto x_main_module_519 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_518);
-auto x_main_module_520 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_519, x_main_module_403);
-auto x_main_module_521 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_520, x_main_module_402, x_main_module_401, x_main_module_400, x_main_module_399);
-auto x_main_module_522 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_521);
-auto x_main_module_523 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_513, x_main_module_398);
-auto x_main_module_524 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_523, x_main_module_397, x_main_module_396, x_main_module_395, x_main_module_394);
-auto x_main_module_525 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_524);
-auto x_main_module_526 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_525, x_main_module_393);
-auto x_main_module_527 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_526, x_main_module_392, x_main_module_391, x_main_module_390, x_main_module_389);
-auto x_main_module_528 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_527);
-auto x_main_module_529 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_528, x_main_module_388);
-auto x_main_module_530 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_529, x_main_module_387, x_main_module_386, x_main_module_385, x_main_module_384);
-auto x_main_module_531 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_530);
-auto x_main_module_532 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_513);
-auto x_main_module_533 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_532, x_main_module_383);
-auto x_main_module_534 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_533, x_main_module_382, x_main_module_381, x_main_module_380, x_main_module_379);
-auto x_main_module_535 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_534);
-auto x_main_module_536 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_516, x_main_module_522, x_main_module_531, x_main_module_535);
-auto x_main_module_537 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_536, x_main_module_378);
-auto x_main_module_538 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_537, x_main_module_377, x_main_module_376, x_main_module_375, x_main_module_374);
-auto x_main_module_539 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_538);
-auto x_main_module_540 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_536, x_main_module_373);
-auto x_main_module_541 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_540, x_main_module_372, x_main_module_371, x_main_module_370, x_main_module_369);
-auto x_main_module_542 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_541);
-auto x_main_module_543 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_542, x_main_module_368);
-auto x_main_module_544 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_543, x_main_module_367, x_main_module_366, x_main_module_365, x_main_module_364);
-auto x_main_module_545 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_544);
-auto x_main_module_546 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_536, x_main_module_363);
-auto x_main_module_547 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_546, x_main_module_362, x_main_module_361, x_main_module_360, x_main_module_359);
-auto x_main_module_548 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_547);
-auto x_main_module_549 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_548, x_main_module_358);
-auto x_main_module_550 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_549, x_main_module_357, x_main_module_356, x_main_module_355, x_main_module_354);
-auto x_main_module_551 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_550);
-auto x_main_module_552 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_551, x_main_module_353);
-auto x_main_module_553 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_552, x_main_module_352, x_main_module_351, x_main_module_350, x_main_module_349);
-auto x_main_module_554 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_553);
-auto x_main_module_555 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_536);
-auto x_main_module_556 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_555, x_main_module_348);
-auto x_main_module_557 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_556, x_main_module_347, x_main_module_346, x_main_module_345, x_main_module_344);
-auto x_main_module_558 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_557);
-auto x_main_module_559 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_539, x_main_module_545, x_main_module_554, x_main_module_558);
-auto x_main_module_560 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_559, x_main_module_343);
-auto x_main_module_561 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_560, x_main_module_342, x_main_module_341, x_main_module_340, x_main_module_339);
-auto x_main_module_562 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_561);
-auto x_main_module_563 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_559, x_main_module_338);
-auto x_main_module_564 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_563, x_main_module_337, x_main_module_336, x_main_module_335, x_main_module_334);
-auto x_main_module_565 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_564);
-auto x_main_module_566 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_565, x_main_module_333);
-auto x_main_module_567 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_566, x_main_module_332, x_main_module_331, x_main_module_330, x_main_module_329);
-auto x_main_module_568 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_567);
-auto x_main_module_569 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_568, x_main_module_328);
-auto x_main_module_570 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_569, x_main_module_327, x_main_module_326, x_main_module_325, x_main_module_324);
-auto x_main_module_571 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_570);
-auto x_main_module_572 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"), x_main_module_559);
-auto x_main_module_573 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_562, x_main_module_571, x_main_module_572);
-auto x_main_module_574 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_573, x_main_module_323);
-auto x_main_module_575 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_574, x_main_module_322, x_main_module_321, x_main_module_320, x_main_module_319);
-auto x_main_module_576 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_575);
-auto x_main_module_577 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_573, x_main_module_318);
-auto x_main_module_578 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_577, x_main_module_317, x_main_module_316, x_main_module_315, x_main_module_314);
-auto x_main_module_579 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_578);
-auto x_main_module_580 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_579, x_main_module_313);
-auto x_main_module_581 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_580, x_main_module_312, x_main_module_311, x_main_module_310, x_main_module_309);
-auto x_main_module_582 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_581);
-auto x_main_module_583 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_582, x_main_module_308);
-auto x_main_module_584 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_583, x_main_module_307, x_main_module_306, x_main_module_305, x_main_module_304);
-auto x_main_module_585 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_584);
-auto x_main_module_586 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_573, x_main_module_303);
-auto x_main_module_587 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_586, x_main_module_302, x_main_module_301, x_main_module_300, x_main_module_299);
-auto x_main_module_588 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_587);
-auto x_main_module_589 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_588, x_main_module_298);
-auto x_main_module_590 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_589, x_main_module_297, x_main_module_296, x_main_module_295, x_main_module_294);
-auto x_main_module_591 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_590);
-auto x_main_module_592 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_591, x_main_module_293);
-auto x_main_module_593 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_592, x_main_module_292, x_main_module_291, x_main_module_290, x_main_module_289);
-auto x_main_module_594 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_593);
-auto x_main_module_595 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_594, x_main_module_288);
-auto x_main_module_596 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_595, x_main_module_287, x_main_module_286, x_main_module_285, x_main_module_284);
-auto x_main_module_597 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_596);
-auto x_main_module_598 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_597, x_main_module_283);
-auto x_main_module_599 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_598, x_main_module_282, x_main_module_281, x_main_module_280, x_main_module_279);
-auto x_main_module_600 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_599);
-auto x_main_module_601 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_573);
-auto x_main_module_602 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_601, x_main_module_278);
-auto x_main_module_603 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_602, x_main_module_277, x_main_module_276, x_main_module_275, x_main_module_274);
-auto x_main_module_604 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_603);
-auto x_main_module_605 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_576, x_main_module_585, x_main_module_600, x_main_module_604);
-auto x_main_module_606 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_605, x_main_module_273);
-auto x_main_module_607 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_606, x_main_module_272, x_main_module_271, x_main_module_270, x_main_module_269);
-auto x_main_module_608 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_607);
-auto x_main_module_609 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_605, x_main_module_268);
-auto x_main_module_610 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_609, x_main_module_267, x_main_module_266, x_main_module_265, x_main_module_264);
-auto x_main_module_611 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_610);
-auto x_main_module_612 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_611, x_main_module_263);
-auto x_main_module_613 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_612, x_main_module_262, x_main_module_261, x_main_module_260, x_main_module_259);
-auto x_main_module_614 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_613);
-auto x_main_module_615 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_614, x_main_module_258);
-auto x_main_module_616 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_615, x_main_module_257, x_main_module_256, x_main_module_255, x_main_module_254);
-auto x_main_module_617 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_616);
-auto x_main_module_618 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_605, x_main_module_253);
-auto x_main_module_619 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_618, x_main_module_252, x_main_module_251, x_main_module_250, x_main_module_249);
-auto x_main_module_620 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_619);
-auto x_main_module_621 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_620, x_main_module_248);
-auto x_main_module_622 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_621, x_main_module_247, x_main_module_246, x_main_module_245, x_main_module_244);
-auto x_main_module_623 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_622);
-auto x_main_module_624 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_623, x_main_module_243);
-auto x_main_module_625 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_624, x_main_module_242, x_main_module_241, x_main_module_240, x_main_module_239);
-auto x_main_module_626 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_625);
-auto x_main_module_627 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_626, x_main_module_238);
-auto x_main_module_628 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_627, x_main_module_237, x_main_module_236, x_main_module_235, x_main_module_234);
-auto x_main_module_629 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_628);
-auto x_main_module_630 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_629, x_main_module_233);
-auto x_main_module_631 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_630, x_main_module_232, x_main_module_231, x_main_module_230, x_main_module_229);
-auto x_main_module_632 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_631);
-auto x_main_module_633 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_605);
-auto x_main_module_634 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_633, x_main_module_228);
-auto x_main_module_635 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_634, x_main_module_227, x_main_module_226, x_main_module_225, x_main_module_224);
-auto x_main_module_636 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_635);
-auto x_main_module_637 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_608, x_main_module_617, x_main_module_632, x_main_module_636);
-auto x_main_module_638 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_637, x_main_module_223);
-auto x_main_module_639 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_638, x_main_module_222, x_main_module_221, x_main_module_220, x_main_module_219);
-auto x_main_module_640 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_639);
-auto x_main_module_641 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_637, x_main_module_218);
-auto x_main_module_642 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_641, x_main_module_217, x_main_module_216, x_main_module_215, x_main_module_214);
-auto x_main_module_643 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_642);
-auto x_main_module_644 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_643, x_main_module_213);
-auto x_main_module_645 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_644, x_main_module_212, x_main_module_211, x_main_module_210, x_main_module_209);
-auto x_main_module_646 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_645);
-auto x_main_module_647 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_646, x_main_module_208);
-auto x_main_module_648 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_647, x_main_module_207, x_main_module_206, x_main_module_205, x_main_module_204);
-auto x_main_module_649 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_648);
-auto x_main_module_650 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_637, x_main_module_203);
-auto x_main_module_651 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_650, x_main_module_202, x_main_module_201, x_main_module_200, x_main_module_199);
-auto x_main_module_652 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_651);
-auto x_main_module_653 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_652, x_main_module_198);
-auto x_main_module_654 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_653, x_main_module_197, x_main_module_196, x_main_module_195, x_main_module_194);
-auto x_main_module_655 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_654);
-auto x_main_module_656 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_655, x_main_module_193);
-auto x_main_module_657 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_656, x_main_module_192, x_main_module_191, x_main_module_190, x_main_module_189);
-auto x_main_module_658 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_657);
-auto x_main_module_659 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_658, x_main_module_188);
-auto x_main_module_660 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_659, x_main_module_187, x_main_module_186, x_main_module_185, x_main_module_184);
-auto x_main_module_661 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_660);
-auto x_main_module_662 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_661, x_main_module_183);
-auto x_main_module_663 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_662, x_main_module_182, x_main_module_181, x_main_module_180, x_main_module_179);
-auto x_main_module_664 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_663);
-auto x_main_module_665 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_637);
-auto x_main_module_666 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_665, x_main_module_178);
-auto x_main_module_667 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_666, x_main_module_177, x_main_module_176, x_main_module_175, x_main_module_174);
-auto x_main_module_668 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_667);
-auto x_main_module_669 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_640, x_main_module_649, x_main_module_664, x_main_module_668);
-auto x_main_module_670 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_669, x_main_module_173);
-auto x_main_module_671 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_670, x_main_module_172, x_main_module_171, x_main_module_170, x_main_module_169);
-auto x_main_module_672 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_671);
-auto x_main_module_673 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_669, x_main_module_168);
-auto x_main_module_674 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_673, x_main_module_167, x_main_module_166, x_main_module_165, x_main_module_164);
-auto x_main_module_675 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_674);
-auto x_main_module_676 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_675, x_main_module_163);
-auto x_main_module_677 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_676, x_main_module_162, x_main_module_161, x_main_module_160, x_main_module_159);
-auto x_main_module_678 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_677);
-auto x_main_module_679 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_678, x_main_module_158);
-auto x_main_module_680 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_679, x_main_module_157, x_main_module_156, x_main_module_155, x_main_module_154);
-auto x_main_module_681 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_680);
-auto x_main_module_682 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_669, x_main_module_153);
-auto x_main_module_683 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_682, x_main_module_152, x_main_module_151, x_main_module_150, x_main_module_149);
-auto x_main_module_684 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_683);
-auto x_main_module_685 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_684, x_main_module_148);
-auto x_main_module_686 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_685, x_main_module_147, x_main_module_146, x_main_module_145, x_main_module_144);
-auto x_main_module_687 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_686);
-auto x_main_module_688 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_687, x_main_module_143);
-auto x_main_module_689 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_688, x_main_module_142, x_main_module_141, x_main_module_140, x_main_module_139);
-auto x_main_module_690 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_689);
-auto x_main_module_691 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_690, x_main_module_138);
-auto x_main_module_692 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_691, x_main_module_137, x_main_module_136, x_main_module_135, x_main_module_134);
-auto x_main_module_693 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_692);
-auto x_main_module_694 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_693, x_main_module_133);
-auto x_main_module_695 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_694, x_main_module_132, x_main_module_131, x_main_module_130, x_main_module_129);
-auto x_main_module_696 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_695);
-auto x_main_module_697 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_669);
-auto x_main_module_698 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_697, x_main_module_128);
-auto x_main_module_699 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_698, x_main_module_127, x_main_module_126, x_main_module_125, x_main_module_124);
-auto x_main_module_700 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_699);
-auto x_main_module_701 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_672, x_main_module_681, x_main_module_696, x_main_module_700);
-auto x_main_module_702 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_701, x_main_module_123);
-auto x_main_module_703 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_702, x_main_module_122, x_main_module_121, x_main_module_120, x_main_module_119);
-auto x_main_module_704 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_703);
-auto x_main_module_705 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_704, x_main_module_118);
-auto x_main_module_706 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_705, x_main_module_117, x_main_module_116, x_main_module_115, x_main_module_114);
-auto x_main_module_707 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_706);
-auto x_main_module_708 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_701, x_main_module_113);
-auto x_main_module_709 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_708, x_main_module_112, x_main_module_111, x_main_module_110, x_main_module_109);
-auto x_main_module_710 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_709);
-auto x_main_module_711 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_710, x_main_module_108);
-auto x_main_module_712 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_711, x_main_module_107, x_main_module_106, x_main_module_105, x_main_module_104);
-auto x_main_module_713 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_712);
-auto x_main_module_714 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_713, x_main_module_103);
-auto x_main_module_715 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_714, x_main_module_102, x_main_module_101, x_main_module_100, x_main_module_99);
-auto x_main_module_716 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_715);
-auto x_main_module_717 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_716, x_main_module_98);
-auto x_main_module_718 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_717, x_main_module_97, x_main_module_96, x_main_module_95, x_main_module_94);
-auto x_main_module_719 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_718);
-auto x_main_module_720 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"), x_main_module_701);
-auto x_main_module_721 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_707, x_main_module_719, x_main_module_720);
-auto x_main_module_722 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_721, x_main_module_93);
-auto x_main_module_723 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_722, x_main_module_92, x_main_module_91, x_main_module_90, x_main_module_89);
-auto x_main_module_724 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_723);
-auto x_main_module_725 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_721, x_main_module_88);
-auto x_main_module_726 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_725, x_main_module_87, x_main_module_86, x_main_module_85, x_main_module_84);
-auto x_main_module_727 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_726);
-auto x_main_module_728 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,1,0,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_727, x_main_module_83);
-auto x_main_module_729 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_728, x_main_module_82, x_main_module_81, x_main_module_80, x_main_module_79);
-auto x_main_module_730 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_729);
-auto x_main_module_731 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,0,1,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_727, x_main_module_78);
-auto x_main_module_732 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_731, x_main_module_77, x_main_module_76, x_main_module_75, x_main_module_74);
-auto x_main_module_733 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_732);
-auto x_main_module_734 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_730, x_main_module_733);
-auto x_main_module_735 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_721, x_main_module_73);
-auto x_main_module_736 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_735, x_main_module_72, x_main_module_71, x_main_module_70, x_main_module_69);
-auto x_main_module_737 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_736);
-auto x_main_module_738 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_737, x_main_module_68);
-auto x_main_module_739 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_738, x_main_module_67, x_main_module_66, x_main_module_65, x_main_module_64);
-auto x_main_module_740 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_739);
-auto x_main_module_741 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,1,0,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_740, x_main_module_63);
-auto x_main_module_742 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_741, x_main_module_62, x_main_module_61, x_main_module_60, x_main_module_59);
-auto x_main_module_743 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_742);
-auto x_main_module_744 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,0,1,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_740, x_main_module_58);
-auto x_main_module_745 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_744, x_main_module_57, x_main_module_56, x_main_module_55, x_main_module_54);
-auto x_main_module_746 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_745);
-auto x_main_module_747 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_743, x_main_module_746);
-auto x_main_module_748 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_721);
-auto x_main_module_749 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_748, x_main_module_53);
-auto x_main_module_750 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_749, x_main_module_52, x_main_module_51, x_main_module_50, x_main_module_49);
-auto x_main_module_751 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_750);
-auto x_main_module_752 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_724, x_main_module_734, x_main_module_747, x_main_module_751);
-auto x_main_module_753 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_752, x_main_module_48);
-auto x_main_module_754 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_753, x_main_module_47, x_main_module_46, x_main_module_45, x_main_module_44);
-auto x_main_module_755 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_754);
-auto x_main_module_756 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_752, x_main_module_43);
-auto x_main_module_757 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_756, x_main_module_42, x_main_module_41, x_main_module_40, x_main_module_39);
-auto x_main_module_758 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_757);
-auto x_main_module_759 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,1,0,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_758, x_main_module_38);
-auto x_main_module_760 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_759, x_main_module_37, x_main_module_36, x_main_module_35, x_main_module_34);
-auto x_main_module_761 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_760);
-auto x_main_module_762 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,0,1,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_758, x_main_module_33);
-auto x_main_module_763 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_762, x_main_module_32, x_main_module_31, x_main_module_30, x_main_module_29);
-auto x_main_module_764 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_763);
-auto x_main_module_765 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_761, x_main_module_764);
-auto x_main_module_766 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_752, x_main_module_28);
-auto x_main_module_767 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_766, x_main_module_27, x_main_module_26, x_main_module_25, x_main_module_24);
-auto x_main_module_768 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_767);
-auto x_main_module_769 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_768, x_main_module_23);
-auto x_main_module_770 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_769, x_main_module_22, x_main_module_21, x_main_module_20, x_main_module_19);
-auto x_main_module_771 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_770);
-auto x_main_module_772 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,1,0,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_771, x_main_module_18);
-auto x_main_module_773 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_772, x_main_module_17, x_main_module_16, x_main_module_15, x_main_module_14);
-auto x_main_module_774 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_773);
-auto x_main_module_775 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,0,1,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_771, x_main_module_13);
-auto x_main_module_776 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_775, x_main_module_12, x_main_module_11, x_main_module_10, x_main_module_9);
-auto x_main_module_777 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_776);
-auto x_main_module_778 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_774, x_main_module_777);
-auto x_main_module_779 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"), x_main_module_752);
-auto x_main_module_780 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_779, x_main_module_8);
-auto x_main_module_781 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"), x_main_module_780, x_main_module_7, x_main_module_6, x_main_module_5, x_main_module_4);
-auto x_main_module_782 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_781);
-auto x_main_module_783 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"), x_main_module_755, x_main_module_765, x_main_module_778, x_main_module_782);
-auto x_main_module_784 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[8,8],lp_order:2,mode:0,padding:[0,0,0,0],stride:[8,8]}"), x_main_module_783);
-auto x_main_module_785 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_784);
-auto x_main_module_786 = mmain->add_instruction(migraphx::make_json_op("flatten", "{axis:1}"), x_main_module_785);
-auto x_main_module_787 = mmain->add_instruction(migraphx::make_json_op("transpose", "{permutation:[1,0]}"), x_main_module_3);
-auto x_main_module_788 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_786, x_main_module_787);
-auto x_main_module_789 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_2);
-auto x_main_module_790 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_0);
-auto x_main_module_791 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_789, x_main_module_790);
-auto x_main_module_792 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_788, x_main_module_791);
-mmain->add_return({x_main_module_792});
-
+    migraphx::module_ref mmain = p.get_main_module();
+    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+    auto x_0                   = mmain->add_parameter(
+        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 299, 299}});
+    auto x_main_module_2 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
+    auto x_main_module_3 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
+    auto x_main_module_4 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 3)));
+    auto x_main_module_5 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 4));
+    auto x_main_module_6 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 5));
+    auto x_main_module_7  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 6)));
+    auto x_main_module_8  = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 2048, 1, 1}}, 7));
+    auto x_main_module_9  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 8)));
+    auto x_main_module_10 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 9));
+    auto x_main_module_11 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 10));
+    auto x_main_module_12 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 11)));
+    auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 12));
+    auto x_main_module_14 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13)));
+    auto x_main_module_15 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 14));
+    auto x_main_module_16 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 15));
+    auto x_main_module_17 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 16)));
+    auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 17));
+    auto x_main_module_19 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 18)));
+    auto x_main_module_20 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 19));
+    auto x_main_module_21 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 20));
+    auto x_main_module_22 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 21)));
+    auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 22));
+    auto x_main_module_24 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 23)));
+    auto x_main_module_25 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 24));
+    auto x_main_module_26 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 25));
+    auto x_main_module_27 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 26)));
+    auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {448, 2048, 1, 1}}, 27));
+    auto x_main_module_29 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 28)));
+    auto x_main_module_30 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 29)));
+    auto x_main_module_31 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 30));
+    auto x_main_module_32 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 31)));
+    auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 32));
+    auto x_main_module_34 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 33)));
+    auto x_main_module_35 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 34)));
+    auto x_main_module_36 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 35));
+    auto x_main_module_37 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 36)));
+    auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 37));
+    auto x_main_module_39 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 38)));
+    auto x_main_module_40 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 39));
+    auto x_main_module_41 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 40));
+    auto x_main_module_42 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 41)));
+    auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 2048, 1, 1}}, 42));
+    auto x_main_module_44 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 43)));
+    auto x_main_module_45 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 44));
+    auto x_main_module_46 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 45));
+    auto x_main_module_47 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 46)));
+    auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {320, 2048, 1, 1}}, 47));
+    auto x_main_module_49 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 48)));
+    auto x_main_module_50 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 49));
+    auto x_main_module_51 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 50));
+    auto x_main_module_52 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 51)));
+    auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 1280, 1, 1}}, 52));
+    auto x_main_module_54 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 53)));
+    auto x_main_module_55 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 54));
+    auto x_main_module_56 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 55));
+    auto x_main_module_57 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 56)));
+    auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 57));
+    auto x_main_module_59 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 58)));
+    auto x_main_module_60 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 59));
+    auto x_main_module_61 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 60));
+    auto x_main_module_62 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 61)));
+    auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 62));
+    auto x_main_module_64 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 63)));
+    auto x_main_module_65 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 64));
+    auto x_main_module_66 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 65));
+    auto x_main_module_67 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 66)));
+    auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 67));
+    auto x_main_module_69 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 68)));
+    auto x_main_module_70 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 69));
+    auto x_main_module_71 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 70));
+    auto x_main_module_72 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 71)));
+    auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {448, 1280, 1, 1}}, 72));
+    auto x_main_module_74 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 73)));
+    auto x_main_module_75 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 74));
+    auto x_main_module_76 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 75));
+    auto x_main_module_77 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 76)));
+    auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 77));
+    auto x_main_module_79 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 78)));
+    auto x_main_module_80 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 79));
+    auto x_main_module_81 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 80));
+    auto x_main_module_82 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 81)));
+    auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 82));
+    auto x_main_module_84 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 83)));
+    auto x_main_module_85 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 84));
+    auto x_main_module_86 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 85));
+    auto x_main_module_87 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 86)));
+    auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 1280, 1, 1}}, 87));
+    auto x_main_module_89 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 88)));
+    auto x_main_module_90 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 89));
+    auto x_main_module_91 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 90));
+    auto x_main_module_92 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 91)));
+    auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {320, 1280, 1, 1}}, 92));
+    auto x_main_module_94 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 93)));
+    auto x_main_module_95 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 94));
+    auto x_main_module_96 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 95));
+    auto x_main_module_97  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 96)));
+    auto x_main_module_98  = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 3, 3}}, 97));
+    auto x_main_module_99  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 98)));
+    auto x_main_module_100 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 99));
+    auto x_main_module_101 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 100));
+    auto x_main_module_102 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 101)));
+    auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 102));
+    auto x_main_module_104 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 103)));
+    auto x_main_module_105 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 104));
+    auto x_main_module_106 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 105));
+    auto x_main_module_107 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 106)));
+    auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 107));
+    auto x_main_module_109 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 108)));
+    auto x_main_module_110 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 109));
+    auto x_main_module_111 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 110));
+    auto x_main_module_112 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 111)));
+    auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 112));
+    auto x_main_module_114 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 113)));
+    auto x_main_module_115 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 114));
+    auto x_main_module_116 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 115));
+    auto x_main_module_117 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 116)));
+    auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {320, 192, 3, 3}}, 117));
+    auto x_main_module_119 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 118)));
+    auto x_main_module_120 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 119));
+    auto x_main_module_121 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 120));
+    auto x_main_module_122 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 121)));
+    auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 122));
+    auto x_main_module_124 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 123)));
+    auto x_main_module_125 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 124));
+    auto x_main_module_126 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 125));
+    auto x_main_module_127 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 126)));
+    auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 127));
+    auto x_main_module_129 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 128)));
+    auto x_main_module_130 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 129));
+    auto x_main_module_131 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 130));
+    auto x_main_module_132 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 131)));
+    auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 132));
+    auto x_main_module_134 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 133)));
+    auto x_main_module_135 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 134));
+    auto x_main_module_136 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 135));
+    auto x_main_module_137 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 136)));
+    auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 137));
+    auto x_main_module_139 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 138)));
+    auto x_main_module_140 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 139));
+    auto x_main_module_141 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 140));
+    auto x_main_module_142 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 141)));
+    auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 142));
+    auto x_main_module_144 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 143)));
+    auto x_main_module_145 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 144));
+    auto x_main_module_146 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 145));
+    auto x_main_module_147 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 146)));
+    auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 147));
+    auto x_main_module_149 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 148)));
+    auto x_main_module_150 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 149));
+    auto x_main_module_151 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 150));
+    auto x_main_module_152 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 151)));
+    auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 152));
+    auto x_main_module_154 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 153)));
+    auto x_main_module_155 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 154));
+    auto x_main_module_156 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 155));
+    auto x_main_module_157 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 156)));
+    auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 157));
+    auto x_main_module_159 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 158)));
+    auto x_main_module_160 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 159));
+    auto x_main_module_161 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 160));
+    auto x_main_module_162 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 161)));
+    auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 162));
+    auto x_main_module_164 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 163)));
+    auto x_main_module_165 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 164));
+    auto x_main_module_166 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 165));
+    auto x_main_module_167 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 166)));
+    auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 167));
+    auto x_main_module_169 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 168)));
+    auto x_main_module_170 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 169));
+    auto x_main_module_171 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 170));
+    auto x_main_module_172 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 171)));
+    auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 172));
+    auto x_main_module_174 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 173)));
+    auto x_main_module_175 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 174));
+    auto x_main_module_176 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 175));
+    auto x_main_module_177 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 176)));
+    auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 177));
+    auto x_main_module_179 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 178)));
+    auto x_main_module_180 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 179));
+    auto x_main_module_181 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 180));
+    auto x_main_module_182 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 181)));
+    auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 182));
+    auto x_main_module_184 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 183)));
+    auto x_main_module_185 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 184));
+    auto x_main_module_186 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 185));
+    auto x_main_module_187 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 186)));
+    auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 187));
+    auto x_main_module_189 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 188)));
+    auto x_main_module_190 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 189));
+    auto x_main_module_191 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 190));
+    auto x_main_module_192 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 191)));
+    auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 192));
+    auto x_main_module_194 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 193)));
+    auto x_main_module_195 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 194));
+    auto x_main_module_196 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 195));
+    auto x_main_module_197 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 196)));
+    auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 197));
+    auto x_main_module_199 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 198)));
+    auto x_main_module_200 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 199));
+    auto x_main_module_201 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 200));
+    auto x_main_module_202 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 201)));
+    auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 202));
+    auto x_main_module_204 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 203)));
+    auto x_main_module_205 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 204));
+    auto x_main_module_206 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 205));
+    auto x_main_module_207 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 206)));
+    auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 207));
+    auto x_main_module_209 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 208)));
+    auto x_main_module_210 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 209));
+    auto x_main_module_211 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 210));
+    auto x_main_module_212 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 211)));
+    auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 212));
+    auto x_main_module_214 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 213)));
+    auto x_main_module_215 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 214));
+    auto x_main_module_216 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 215));
+    auto x_main_module_217 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 216)));
+    auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 217));
+    auto x_main_module_219 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 218)));
+    auto x_main_module_220 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 219));
+    auto x_main_module_221 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 220));
+    auto x_main_module_222 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 221)));
+    auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 222));
+    auto x_main_module_224 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 223)));
+    auto x_main_module_225 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 224));
+    auto x_main_module_226 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 225));
+    auto x_main_module_227 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 226)));
+    auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 227));
+    auto x_main_module_229 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 228)));
+    auto x_main_module_230 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 229));
+    auto x_main_module_231 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 230));
+    auto x_main_module_232 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 231)));
+    auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 232));
+    auto x_main_module_234 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 233)));
+    auto x_main_module_235 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 234));
+    auto x_main_module_236 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 235));
+    auto x_main_module_237 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 236)));
+    auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 237));
+    auto x_main_module_239 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 238)));
+    auto x_main_module_240 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 239));
+    auto x_main_module_241 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 240));
+    auto x_main_module_242 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 241)));
+    auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 242));
+    auto x_main_module_244 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 243)));
+    auto x_main_module_245 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 244));
+    auto x_main_module_246 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 245));
+    auto x_main_module_247 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 246)));
+    auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 247));
+    auto x_main_module_249 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 248)));
+    auto x_main_module_250 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 249));
+    auto x_main_module_251 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 250));
+    auto x_main_module_252 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 251)));
+    auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 252));
+    auto x_main_module_254 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 253)));
+    auto x_main_module_255 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 254));
+    auto x_main_module_256 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 255));
+    auto x_main_module_257 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 256)));
+    auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 257));
+    auto x_main_module_259 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 258)));
+    auto x_main_module_260 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 259));
+    auto x_main_module_261 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 260));
+    auto x_main_module_262 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 261)));
+    auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 262));
+    auto x_main_module_264 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 263)));
+    auto x_main_module_265 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 264));
+    auto x_main_module_266 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 265));
+    auto x_main_module_267 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 266)));
+    auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 267));
+    auto x_main_module_269 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 268)));
+    auto x_main_module_270 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 269));
+    auto x_main_module_271 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 270));
+    auto x_main_module_272 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 271)));
+    auto x_main_module_273 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 272));
+    auto x_main_module_274 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 273)));
+    auto x_main_module_275 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 274));
+    auto x_main_module_276 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 275));
+    auto x_main_module_277 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 276)));
+    auto x_main_module_278 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 277));
+    auto x_main_module_279 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 278)));
+    auto x_main_module_280 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 279));
+    auto x_main_module_281 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 280));
+    auto x_main_module_282 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 281)));
+    auto x_main_module_283 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 128, 1, 7}}, 282));
+    auto x_main_module_284 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 283)));
+    auto x_main_module_285 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 284));
+    auto x_main_module_286 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 285));
+    auto x_main_module_287 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 286)));
+    auto x_main_module_288 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 287));
+    auto x_main_module_289 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 288)));
+    auto x_main_module_290 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 289));
+    auto x_main_module_291 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 290));
+    auto x_main_module_292 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 291)));
+    auto x_main_module_293 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 292));
+    auto x_main_module_294 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 293)));
+    auto x_main_module_295 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 294));
+    auto x_main_module_296 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 295));
+    auto x_main_module_297 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 296)));
+    auto x_main_module_298 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 297));
+    auto x_main_module_299 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 298)));
+    auto x_main_module_300 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 299));
+    auto x_main_module_301 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 300));
+    auto x_main_module_302 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 301)));
+    auto x_main_module_303 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 302));
+    auto x_main_module_304 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 303)));
+    auto x_main_module_305 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 304));
+    auto x_main_module_306 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 305));
+    auto x_main_module_307 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 306)));
+    auto x_main_module_308 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 128, 7, 1}}, 307));
+    auto x_main_module_309 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 308)));
+    auto x_main_module_310 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 309));
+    auto x_main_module_311 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 310));
+    auto x_main_module_312 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 311)));
+    auto x_main_module_313 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 312));
+    auto x_main_module_314 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 313)));
+    auto x_main_module_315 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 314));
+    auto x_main_module_316 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 315));
+    auto x_main_module_317 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 316)));
+    auto x_main_module_318 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 317));
+    auto x_main_module_319 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 318)));
+    auto x_main_module_320 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 319));
+    auto x_main_module_321 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 320));
+    auto x_main_module_322 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 321)));
+    auto x_main_module_323 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 322));
+    auto x_main_module_324 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 323)));
+    auto x_main_module_325 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 324));
+    auto x_main_module_326 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 325));
+    auto x_main_module_327 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 326)));
+    auto x_main_module_328 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 327));
+    auto x_main_module_329 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 328)));
+    auto x_main_module_330 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 329));
+    auto x_main_module_331 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 330));
+    auto x_main_module_332 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 331)));
+    auto x_main_module_333 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 332));
+    auto x_main_module_334 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 333)));
+    auto x_main_module_335 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 334));
+    auto x_main_module_336 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 335));
+    auto x_main_module_337 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 336)));
+    auto x_main_module_338 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 337));
+    auto x_main_module_339 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 338)));
+    auto x_main_module_340 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 339));
+    auto x_main_module_341 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 340));
+    auto x_main_module_342 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 341)));
+    auto x_main_module_343 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 288, 3, 3}}, 342));
+    auto x_main_module_344 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 343)));
+    auto x_main_module_345 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 344));
+    auto x_main_module_346 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 345));
+    auto x_main_module_347 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 346)));
+    auto x_main_module_348 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 347));
+    auto x_main_module_349 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 348)));
+    auto x_main_module_350 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 349));
+    auto x_main_module_351 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 350));
+    auto x_main_module_352 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 351)));
+    auto x_main_module_353 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 352));
+    auto x_main_module_354 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 353)));
+    auto x_main_module_355 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 354));
+    auto x_main_module_356 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 355));
+    auto x_main_module_357 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 356)));
+    auto x_main_module_358 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 357));
+    auto x_main_module_359 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 358)));
+    auto x_main_module_360 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 359));
+    auto x_main_module_361 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 360));
+    auto x_main_module_362 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 361)));
+    auto x_main_module_363 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 362));
+    auto x_main_module_364 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 363)));
+    auto x_main_module_365 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 364));
+    auto x_main_module_366 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 365));
+    auto x_main_module_367 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 366)));
+    auto x_main_module_368 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 367));
+    auto x_main_module_369 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 368)));
+    auto x_main_module_370 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 369));
+    auto x_main_module_371 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 370));
+    auto x_main_module_372 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 371)));
+    auto x_main_module_373 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {48, 288, 1, 1}}, 372));
+    auto x_main_module_374 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 373)));
+    auto x_main_module_375 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 374));
+    auto x_main_module_376 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 375));
+    auto x_main_module_377 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 376)));
+    auto x_main_module_378 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 377));
+    auto x_main_module_379 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 378)));
+    auto x_main_module_380 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 379));
+    auto x_main_module_381 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 380));
+    auto x_main_module_382 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 381)));
+    auto x_main_module_383 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 382));
+    auto x_main_module_384 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 383)));
+    auto x_main_module_385 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 384));
+    auto x_main_module_386 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 385));
+    auto x_main_module_387 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 386)));
+    auto x_main_module_388 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 387));
+    auto x_main_module_389 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 388)));
+    auto x_main_module_390 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 389));
+    auto x_main_module_391 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 390));
+    auto x_main_module_392 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 391)));
+    auto x_main_module_393 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 392));
+    auto x_main_module_394 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 393)));
+    auto x_main_module_395 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 394));
+    auto x_main_module_396 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 395));
+    auto x_main_module_397 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 396)));
+    auto x_main_module_398 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 397));
+    auto x_main_module_399 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 398)));
+    auto x_main_module_400 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 399));
+    auto x_main_module_401 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 400));
+    auto x_main_module_402 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 401)));
+    auto x_main_module_403 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 402));
+    auto x_main_module_404 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 403)));
+    auto x_main_module_405 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 404));
+    auto x_main_module_406 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 405));
+    auto x_main_module_407 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 406)));
+    auto x_main_module_408 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {48, 256, 1, 1}}, 407));
+    auto x_main_module_409 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 408)));
+    auto x_main_module_410 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 409));
+    auto x_main_module_411 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 410));
+    auto x_main_module_412 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 411)));
+    auto x_main_module_413 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 412));
+    auto x_main_module_414 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 413)));
+    auto x_main_module_415 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 414));
+    auto x_main_module_416 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 415));
+    auto x_main_module_417 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 416)));
+    auto x_main_module_418 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {32, 192, 1, 1}}, 417));
+    auto x_main_module_419 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 418)));
+    auto x_main_module_420 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 419));
+    auto x_main_module_421 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 420));
+    auto x_main_module_422 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 421)));
+    auto x_main_module_423 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 422));
+    auto x_main_module_424 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 423)));
+    auto x_main_module_425 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 424));
+    auto x_main_module_426 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 425));
+    auto x_main_module_427 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 426)));
+    auto x_main_module_428 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 427));
+    auto x_main_module_429 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 428)));
+    auto x_main_module_430 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 429));
+    auto x_main_module_431 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 430));
+    auto x_main_module_432 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 431)));
+    auto x_main_module_433 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 432));
+    auto x_main_module_434 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 433)));
+    auto x_main_module_435 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 434));
+    auto x_main_module_436 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 435));
+    auto x_main_module_437 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 436)));
+    auto x_main_module_438 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 437));
+    auto x_main_module_439 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 438)));
+    auto x_main_module_440 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 439));
+    auto x_main_module_441 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 440));
+    auto x_main_module_442 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 441)));
+    auto x_main_module_443 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {48, 192, 1, 1}}, 442));
+    auto x_main_module_444 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 443)));
+    auto x_main_module_445 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 444));
+    auto x_main_module_446 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 445));
+    auto x_main_module_447 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 446)));
+    auto x_main_module_448 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 447));
+    auto x_main_module_449 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 448)));
+    auto x_main_module_450 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 449));
+    auto x_main_module_451 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 450));
+    auto x_main_module_452 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 451)));
+    auto x_main_module_453 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 80, 3, 3}}, 452));
+    auto x_main_module_454 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 453)));
+    auto x_main_module_455 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 454));
+    auto x_main_module_456 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 455));
+    auto x_main_module_457 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 456)));
+    auto x_main_module_458 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {80, 64, 1, 1}}, 457));
+    auto x_main_module_459 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 458)));
+    auto x_main_module_460 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 459));
+    auto x_main_module_461 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 460));
+    auto x_main_module_462 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 461)));
+    auto x_main_module_463 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 32, 3, 3}}, 462));
+    auto x_main_module_464 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 463)));
+    auto x_main_module_465 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 464));
+    auto x_main_module_466 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 465));
+    auto x_main_module_467 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 466)));
+    auto x_main_module_468 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {32, 32, 3, 3}}, 467));
+    auto x_main_module_469 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 468)));
+    auto x_main_module_470 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 469));
+    auto x_main_module_471 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 470));
+    auto x_main_module_472 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 471)));
+    auto x_main_module_473 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {32, 3, 3, 3}}, 472));
+    auto x_main_module_474 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,"
+                               "2],use_dynamic_same_auto_pad:0}"),
+        x_0,
+        x_main_module_473);
+    auto x_main_module_475 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_474,
+        x_main_module_472,
+        x_main_module_471,
+        x_main_module_470,
+        x_main_module_469);
+    auto x_main_module_476 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_475);
+    auto x_main_module_477 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_476,
+        x_main_module_468);
+    auto x_main_module_478 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_477,
+        x_main_module_467,
+        x_main_module_466,
+        x_main_module_465,
+        x_main_module_464);
+    auto x_main_module_479 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_478);
+    auto x_main_module_480 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_479,
+        x_main_module_463);
+    auto x_main_module_481 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_480,
+        x_main_module_462,
+        x_main_module_461,
+        x_main_module_460,
+        x_main_module_459);
+    auto x_main_module_482 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_481);
+    auto x_main_module_483 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"),
+        x_main_module_482);
+    auto x_main_module_484 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_483,
+        x_main_module_458);
+    auto x_main_module_485 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_484,
+        x_main_module_457,
+        x_main_module_456,
+        x_main_module_455,
+        x_main_module_454);
+    auto x_main_module_486 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_485);
+    auto x_main_module_487 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_486,
+        x_main_module_453);
+    auto x_main_module_488 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_487,
+        x_main_module_452,
+        x_main_module_451,
+        x_main_module_450,
+        x_main_module_449);
+    auto x_main_module_489 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_488);
+    auto x_main_module_490 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"),
+        x_main_module_489);
+    auto x_main_module_491 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_490,
+        x_main_module_448);
+    auto x_main_module_492 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_491,
+        x_main_module_447,
+        x_main_module_446,
+        x_main_module_445,
+        x_main_module_444);
+    auto x_main_module_493 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_492);
+    auto x_main_module_494 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_490,
+        x_main_module_443);
+    auto x_main_module_495 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_494,
+        x_main_module_442,
+        x_main_module_441,
+        x_main_module_440,
+        x_main_module_439);
+    auto x_main_module_496 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_495);
+    auto x_main_module_497 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_496,
+        x_main_module_438);
+    auto x_main_module_498 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_497,
+        x_main_module_437,
+        x_main_module_436,
+        x_main_module_435,
+        x_main_module_434);
+    auto x_main_module_499 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_498);
+    auto x_main_module_500 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_490,
+        x_main_module_433);
+    auto x_main_module_501 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_500,
+        x_main_module_432,
+        x_main_module_431,
+        x_main_module_430,
+        x_main_module_429);
+    auto x_main_module_502 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_501);
+    auto x_main_module_503 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_502,
+        x_main_module_428);
+    auto x_main_module_504 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_503,
+        x_main_module_427,
+        x_main_module_426,
+        x_main_module_425,
+        x_main_module_424);
+    auto x_main_module_505 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_504);
+    auto x_main_module_506 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_505,
+        x_main_module_423);
+    auto x_main_module_507 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_506,
+        x_main_module_422,
+        x_main_module_421,
+        x_main_module_420,
+        x_main_module_419);
+    auto x_main_module_508 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_507);
+    auto x_main_module_509 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"),
+        x_main_module_490);
+    auto x_main_module_510 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_509,
+        x_main_module_418);
+    auto x_main_module_511 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_510,
+        x_main_module_417,
+        x_main_module_416,
+        x_main_module_415,
+        x_main_module_414);
+    auto x_main_module_512 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_511);
+    auto x_main_module_513 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"),
+                                                    x_main_module_493,
+                                                    x_main_module_499,
+                                                    x_main_module_508,
+                                                    x_main_module_512);
+    auto x_main_module_514 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_513,
+        x_main_module_413);
+    auto x_main_module_515 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_514,
+        x_main_module_412,
+        x_main_module_411,
+        x_main_module_410,
+        x_main_module_409);
+    auto x_main_module_516 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_515);
+    auto x_main_module_517 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_513,
+        x_main_module_408);
+    auto x_main_module_518 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_517,
+        x_main_module_407,
+        x_main_module_406,
+        x_main_module_405,
+        x_main_module_404);
+    auto x_main_module_519 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_518);
+    auto x_main_module_520 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_519,
+        x_main_module_403);
+    auto x_main_module_521 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_520,
+        x_main_module_402,
+        x_main_module_401,
+        x_main_module_400,
+        x_main_module_399);
+    auto x_main_module_522 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_521);
+    auto x_main_module_523 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_513,
+        x_main_module_398);
+    auto x_main_module_524 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_523,
+        x_main_module_397,
+        x_main_module_396,
+        x_main_module_395,
+        x_main_module_394);
+    auto x_main_module_525 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_524);
+    auto x_main_module_526 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_525,
+        x_main_module_393);
+    auto x_main_module_527 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_526,
+        x_main_module_392,
+        x_main_module_391,
+        x_main_module_390,
+        x_main_module_389);
+    auto x_main_module_528 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_527);
+    auto x_main_module_529 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_528,
+        x_main_module_388);
+    auto x_main_module_530 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_529,
+        x_main_module_387,
+        x_main_module_386,
+        x_main_module_385,
+        x_main_module_384);
+    auto x_main_module_531 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_530);
+    auto x_main_module_532 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"),
+        x_main_module_513);
+    auto x_main_module_533 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_532,
+        x_main_module_383);
+    auto x_main_module_534 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_533,
+        x_main_module_382,
+        x_main_module_381,
+        x_main_module_380,
+        x_main_module_379);
+    auto x_main_module_535 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_534);
+    auto x_main_module_536 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"),
+                                                    x_main_module_516,
+                                                    x_main_module_522,
+                                                    x_main_module_531,
+                                                    x_main_module_535);
+    auto x_main_module_537 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_536,
+        x_main_module_378);
+    auto x_main_module_538 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_537,
+        x_main_module_377,
+        x_main_module_376,
+        x_main_module_375,
+        x_main_module_374);
+    auto x_main_module_539 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_538);
+    auto x_main_module_540 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_536,
+        x_main_module_373);
+    auto x_main_module_541 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_540,
+        x_main_module_372,
+        x_main_module_371,
+        x_main_module_370,
+        x_main_module_369);
+    auto x_main_module_542 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_541);
+    auto x_main_module_543 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[2,2,2,2],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_542,
+        x_main_module_368);
+    auto x_main_module_544 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_543,
+        x_main_module_367,
+        x_main_module_366,
+        x_main_module_365,
+        x_main_module_364);
+    auto x_main_module_545 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_544);
+    auto x_main_module_546 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_536,
+        x_main_module_363);
+    auto x_main_module_547 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_546,
+        x_main_module_362,
+        x_main_module_361,
+        x_main_module_360,
+        x_main_module_359);
+    auto x_main_module_548 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_547);
+    auto x_main_module_549 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_548,
+        x_main_module_358);
+    auto x_main_module_550 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_549,
+        x_main_module_357,
+        x_main_module_356,
+        x_main_module_355,
+        x_main_module_354);
+    auto x_main_module_551 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_550);
+    auto x_main_module_552 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_551,
+        x_main_module_353);
+    auto x_main_module_553 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_552,
+        x_main_module_352,
+        x_main_module_351,
+        x_main_module_350,
+        x_main_module_349);
+    auto x_main_module_554 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_553);
+    auto x_main_module_555 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"),
+        x_main_module_536);
+    auto x_main_module_556 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_555,
+        x_main_module_348);
+    auto x_main_module_557 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_556,
+        x_main_module_347,
+        x_main_module_346,
+        x_main_module_345,
+        x_main_module_344);
+    auto x_main_module_558 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_557);
+    auto x_main_module_559 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"),
+                                                    x_main_module_539,
+                                                    x_main_module_545,
+                                                    x_main_module_554,
+                                                    x_main_module_558);
+    auto x_main_module_560 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,"
+                               "2],use_dynamic_same_auto_pad:0}"),
+        x_main_module_559,
+        x_main_module_343);
+    auto x_main_module_561 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_560,
+        x_main_module_342,
+        x_main_module_341,
+        x_main_module_340,
+        x_main_module_339);
+    auto x_main_module_562 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_561);
+    auto x_main_module_563 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_559,
+        x_main_module_338);
+    auto x_main_module_564 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_563,
+        x_main_module_337,
+        x_main_module_336,
+        x_main_module_335,
+        x_main_module_334);
+    auto x_main_module_565 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_564);
+    auto x_main_module_566 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_565,
+        x_main_module_333);
+    auto x_main_module_567 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_566,
+        x_main_module_332,
+        x_main_module_331,
+        x_main_module_330,
+        x_main_module_329);
+    auto x_main_module_568 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_567);
+    auto x_main_module_569 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,"
+                               "2],use_dynamic_same_auto_pad:0}"),
+        x_main_module_568,
+        x_main_module_328);
+    auto x_main_module_570 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_569,
+        x_main_module_327,
+        x_main_module_326,
+        x_main_module_325,
+        x_main_module_324);
+    auto x_main_module_571 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_570);
+    auto x_main_module_572 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"),
+        x_main_module_559);
+    auto x_main_module_573 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"),
+                                                    x_main_module_562,
+                                                    x_main_module_571,
+                                                    x_main_module_572);
+    auto x_main_module_574 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_573,
+        x_main_module_323);
+    auto x_main_module_575 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_574,
+        x_main_module_322,
+        x_main_module_321,
+        x_main_module_320,
+        x_main_module_319);
+    auto x_main_module_576 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_575);
+    auto x_main_module_577 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_573,
+        x_main_module_318);
+    auto x_main_module_578 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_577,
+        x_main_module_317,
+        x_main_module_316,
+        x_main_module_315,
+        x_main_module_314);
+    auto x_main_module_579 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_578);
+    auto x_main_module_580 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_579,
+        x_main_module_313);
+    auto x_main_module_581 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_580,
+        x_main_module_312,
+        x_main_module_311,
+        x_main_module_310,
+        x_main_module_309);
+    auto x_main_module_582 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_581);
+    auto x_main_module_583 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_582,
+        x_main_module_308);
+    auto x_main_module_584 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_583,
+        x_main_module_307,
+        x_main_module_306,
+        x_main_module_305,
+        x_main_module_304);
+    auto x_main_module_585 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_584);
+    auto x_main_module_586 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_573,
+        x_main_module_303);
+    auto x_main_module_587 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_586,
+        x_main_module_302,
+        x_main_module_301,
+        x_main_module_300,
+        x_main_module_299);
+    auto x_main_module_588 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_587);
+    auto x_main_module_589 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_588,
+        x_main_module_298);
+    auto x_main_module_590 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_589,
+        x_main_module_297,
+        x_main_module_296,
+        x_main_module_295,
+        x_main_module_294);
+    auto x_main_module_591 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_590);
+    auto x_main_module_592 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_591,
+        x_main_module_293);
+    auto x_main_module_593 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_592,
+        x_main_module_292,
+        x_main_module_291,
+        x_main_module_290,
+        x_main_module_289);
+    auto x_main_module_594 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_593);
+    auto x_main_module_595 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_594,
+        x_main_module_288);
+    auto x_main_module_596 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_595,
+        x_main_module_287,
+        x_main_module_286,
+        x_main_module_285,
+        x_main_module_284);
+    auto x_main_module_597 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_596);
+    auto x_main_module_598 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_597,
+        x_main_module_283);
+    auto x_main_module_599 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_598,
+        x_main_module_282,
+        x_main_module_281,
+        x_main_module_280,
+        x_main_module_279);
+    auto x_main_module_600 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_599);
+    auto x_main_module_601 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"),
+        x_main_module_573);
+    auto x_main_module_602 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_601,
+        x_main_module_278);
+    auto x_main_module_603 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_602,
+        x_main_module_277,
+        x_main_module_276,
+        x_main_module_275,
+        x_main_module_274);
+    auto x_main_module_604 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_603);
+    auto x_main_module_605 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"),
+                                                    x_main_module_576,
+                                                    x_main_module_585,
+                                                    x_main_module_600,
+                                                    x_main_module_604);
+    auto x_main_module_606 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_605,
+        x_main_module_273);
+    auto x_main_module_607 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_606,
+        x_main_module_272,
+        x_main_module_271,
+        x_main_module_270,
+        x_main_module_269);
+    auto x_main_module_608 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_607);
+    auto x_main_module_609 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_605,
+        x_main_module_268);
+    auto x_main_module_610 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_609,
+        x_main_module_267,
+        x_main_module_266,
+        x_main_module_265,
+        x_main_module_264);
+    auto x_main_module_611 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_610);
+    auto x_main_module_612 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_611,
+        x_main_module_263);
+    auto x_main_module_613 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_612,
+        x_main_module_262,
+        x_main_module_261,
+        x_main_module_260,
+        x_main_module_259);
+    auto x_main_module_614 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_613);
+    auto x_main_module_615 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_614,
+        x_main_module_258);
+    auto x_main_module_616 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_615,
+        x_main_module_257,
+        x_main_module_256,
+        x_main_module_255,
+        x_main_module_254);
+    auto x_main_module_617 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_616);
+    auto x_main_module_618 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_605,
+        x_main_module_253);
+    auto x_main_module_619 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_618,
+        x_main_module_252,
+        x_main_module_251,
+        x_main_module_250,
+        x_main_module_249);
+    auto x_main_module_620 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_619);
+    auto x_main_module_621 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_620,
+        x_main_module_248);
+    auto x_main_module_622 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_621,
+        x_main_module_247,
+        x_main_module_246,
+        x_main_module_245,
+        x_main_module_244);
+    auto x_main_module_623 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_622);
+    auto x_main_module_624 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_623,
+        x_main_module_243);
+    auto x_main_module_625 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_624,
+        x_main_module_242,
+        x_main_module_241,
+        x_main_module_240,
+        x_main_module_239);
+    auto x_main_module_626 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_625);
+    auto x_main_module_627 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_626,
+        x_main_module_238);
+    auto x_main_module_628 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_627,
+        x_main_module_237,
+        x_main_module_236,
+        x_main_module_235,
+        x_main_module_234);
+    auto x_main_module_629 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_628);
+    auto x_main_module_630 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_629,
+        x_main_module_233);
+    auto x_main_module_631 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_630,
+        x_main_module_232,
+        x_main_module_231,
+        x_main_module_230,
+        x_main_module_229);
+    auto x_main_module_632 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_631);
+    auto x_main_module_633 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"),
+        x_main_module_605);
+    auto x_main_module_634 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_633,
+        x_main_module_228);
+    auto x_main_module_635 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_634,
+        x_main_module_227,
+        x_main_module_226,
+        x_main_module_225,
+        x_main_module_224);
+    auto x_main_module_636 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_635);
+    auto x_main_module_637 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"),
+                                                    x_main_module_608,
+                                                    x_main_module_617,
+                                                    x_main_module_632,
+                                                    x_main_module_636);
+    auto x_main_module_638 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_637,
+        x_main_module_223);
+    auto x_main_module_639 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_638,
+        x_main_module_222,
+        x_main_module_221,
+        x_main_module_220,
+        x_main_module_219);
+    auto x_main_module_640 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_639);
+    auto x_main_module_641 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_637,
+        x_main_module_218);
+    auto x_main_module_642 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_641,
+        x_main_module_217,
+        x_main_module_216,
+        x_main_module_215,
+        x_main_module_214);
+    auto x_main_module_643 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_642);
+    auto x_main_module_644 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_643,
+        x_main_module_213);
+    auto x_main_module_645 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_644,
+        x_main_module_212,
+        x_main_module_211,
+        x_main_module_210,
+        x_main_module_209);
+    auto x_main_module_646 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_645);
+    auto x_main_module_647 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_646,
+        x_main_module_208);
+    auto x_main_module_648 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_647,
+        x_main_module_207,
+        x_main_module_206,
+        x_main_module_205,
+        x_main_module_204);
+    auto x_main_module_649 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_648);
+    auto x_main_module_650 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_637,
+        x_main_module_203);
+    auto x_main_module_651 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_650,
+        x_main_module_202,
+        x_main_module_201,
+        x_main_module_200,
+        x_main_module_199);
+    auto x_main_module_652 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_651);
+    auto x_main_module_653 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_652,
+        x_main_module_198);
+    auto x_main_module_654 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_653,
+        x_main_module_197,
+        x_main_module_196,
+        x_main_module_195,
+        x_main_module_194);
+    auto x_main_module_655 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_654);
+    auto x_main_module_656 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_655,
+        x_main_module_193);
+    auto x_main_module_657 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_656,
+        x_main_module_192,
+        x_main_module_191,
+        x_main_module_190,
+        x_main_module_189);
+    auto x_main_module_658 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_657);
+    auto x_main_module_659 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_658,
+        x_main_module_188);
+    auto x_main_module_660 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_659,
+        x_main_module_187,
+        x_main_module_186,
+        x_main_module_185,
+        x_main_module_184);
+    auto x_main_module_661 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_660);
+    auto x_main_module_662 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_661,
+        x_main_module_183);
+    auto x_main_module_663 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_662,
+        x_main_module_182,
+        x_main_module_181,
+        x_main_module_180,
+        x_main_module_179);
+    auto x_main_module_664 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_663);
+    auto x_main_module_665 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"),
+        x_main_module_637);
+    auto x_main_module_666 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_665,
+        x_main_module_178);
+    auto x_main_module_667 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_666,
+        x_main_module_177,
+        x_main_module_176,
+        x_main_module_175,
+        x_main_module_174);
+    auto x_main_module_668 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_667);
+    auto x_main_module_669 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"),
+                                                    x_main_module_640,
+                                                    x_main_module_649,
+                                                    x_main_module_664,
+                                                    x_main_module_668);
+    auto x_main_module_670 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_669,
+        x_main_module_173);
+    auto x_main_module_671 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_670,
+        x_main_module_172,
+        x_main_module_171,
+        x_main_module_170,
+        x_main_module_169);
+    auto x_main_module_672 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_671);
+    auto x_main_module_673 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_669,
+        x_main_module_168);
+    auto x_main_module_674 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_673,
+        x_main_module_167,
+        x_main_module_166,
+        x_main_module_165,
+        x_main_module_164);
+    auto x_main_module_675 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_674);
+    auto x_main_module_676 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_675,
+        x_main_module_163);
+    auto x_main_module_677 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_676,
+        x_main_module_162,
+        x_main_module_161,
+        x_main_module_160,
+        x_main_module_159);
+    auto x_main_module_678 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_677);
+    auto x_main_module_679 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_678,
+        x_main_module_158);
+    auto x_main_module_680 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_679,
+        x_main_module_157,
+        x_main_module_156,
+        x_main_module_155,
+        x_main_module_154);
+    auto x_main_module_681 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_680);
+    auto x_main_module_682 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_669,
+        x_main_module_153);
+    auto x_main_module_683 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_682,
+        x_main_module_152,
+        x_main_module_151,
+        x_main_module_150,
+        x_main_module_149);
+    auto x_main_module_684 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_683);
+    auto x_main_module_685 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_684,
+        x_main_module_148);
+    auto x_main_module_686 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_685,
+        x_main_module_147,
+        x_main_module_146,
+        x_main_module_145,
+        x_main_module_144);
+    auto x_main_module_687 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_686);
+    auto x_main_module_688 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_687,
+        x_main_module_143);
+    auto x_main_module_689 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_688,
+        x_main_module_142,
+        x_main_module_141,
+        x_main_module_140,
+        x_main_module_139);
+    auto x_main_module_690 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_689);
+    auto x_main_module_691 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_690,
+        x_main_module_138);
+    auto x_main_module_692 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_691,
+        x_main_module_137,
+        x_main_module_136,
+        x_main_module_135,
+        x_main_module_134);
+    auto x_main_module_693 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_692);
+    auto x_main_module_694 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_693,
+        x_main_module_133);
+    auto x_main_module_695 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_694,
+        x_main_module_132,
+        x_main_module_131,
+        x_main_module_130,
+        x_main_module_129);
+    auto x_main_module_696 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_695);
+    auto x_main_module_697 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"),
+        x_main_module_669);
+    auto x_main_module_698 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_697,
+        x_main_module_128);
+    auto x_main_module_699 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_698,
+        x_main_module_127,
+        x_main_module_126,
+        x_main_module_125,
+        x_main_module_124);
+    auto x_main_module_700 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_699);
+    auto x_main_module_701 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"),
+                                                    x_main_module_672,
+                                                    x_main_module_681,
+                                                    x_main_module_696,
+                                                    x_main_module_700);
+    auto x_main_module_702 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_701,
+        x_main_module_123);
+    auto x_main_module_703 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_702,
+        x_main_module_122,
+        x_main_module_121,
+        x_main_module_120,
+        x_main_module_119);
+    auto x_main_module_704 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_703);
+    auto x_main_module_705 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,"
+                               "2],use_dynamic_same_auto_pad:0}"),
+        x_main_module_704,
+        x_main_module_118);
+    auto x_main_module_706 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_705,
+        x_main_module_117,
+        x_main_module_116,
+        x_main_module_115,
+        x_main_module_114);
+    auto x_main_module_707 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_706);
+    auto x_main_module_708 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_701,
+        x_main_module_113);
+    auto x_main_module_709 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_708,
+        x_main_module_112,
+        x_main_module_111,
+        x_main_module_110,
+        x_main_module_109);
+    auto x_main_module_710 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_709);
+    auto x_main_module_711 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,3,0,3],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_710,
+        x_main_module_108);
+    auto x_main_module_712 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_711,
+        x_main_module_107,
+        x_main_module_106,
+        x_main_module_105,
+        x_main_module_104);
+    auto x_main_module_713 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_712);
+    auto x_main_module_714 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[3,0,3,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_713,
+        x_main_module_103);
+    auto x_main_module_715 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_714,
+        x_main_module_102,
+        x_main_module_101,
+        x_main_module_100,
+        x_main_module_99);
+    auto x_main_module_716 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_715);
+    auto x_main_module_717 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,"
+                               "2],use_dynamic_same_auto_pad:0}"),
+        x_main_module_716,
+        x_main_module_98);
+    auto x_main_module_718 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_717,
+        x_main_module_97,
+        x_main_module_96,
+        x_main_module_95,
+        x_main_module_94);
+    auto x_main_module_719 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_718);
+    auto x_main_module_720 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[0,0,0,0],stride:[2,2]}"),
+        x_main_module_701);
+    auto x_main_module_721 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"),
+                                                    x_main_module_707,
+                                                    x_main_module_719,
+                                                    x_main_module_720);
+    auto x_main_module_722 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_721,
+        x_main_module_93);
+    auto x_main_module_723 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_722,
+        x_main_module_92,
+        x_main_module_91,
+        x_main_module_90,
+        x_main_module_89);
+    auto x_main_module_724 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_723);
+    auto x_main_module_725 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_721,
+        x_main_module_88);
+    auto x_main_module_726 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_725,
+        x_main_module_87,
+        x_main_module_86,
+        x_main_module_85,
+        x_main_module_84);
+    auto x_main_module_727 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_726);
+    auto x_main_module_728 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,1,0,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_727,
+        x_main_module_83);
+    auto x_main_module_729 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_728,
+        x_main_module_82,
+        x_main_module_81,
+        x_main_module_80,
+        x_main_module_79);
+    auto x_main_module_730 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_729);
+    auto x_main_module_731 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,0,1,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_727,
+        x_main_module_78);
+    auto x_main_module_732 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_731,
+        x_main_module_77,
+        x_main_module_76,
+        x_main_module_75,
+        x_main_module_74);
+    auto x_main_module_733 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_732);
+    auto x_main_module_734 = mmain->add_instruction(
+        migraphx::make_json_op("concat", "{axis:1}"), x_main_module_730, x_main_module_733);
+    auto x_main_module_735 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_721,
+        x_main_module_73);
+    auto x_main_module_736 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_735,
+        x_main_module_72,
+        x_main_module_71,
+        x_main_module_70,
+        x_main_module_69);
+    auto x_main_module_737 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_736);
+    auto x_main_module_738 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_737,
+        x_main_module_68);
+    auto x_main_module_739 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_738,
+        x_main_module_67,
+        x_main_module_66,
+        x_main_module_65,
+        x_main_module_64);
+    auto x_main_module_740 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_739);
+    auto x_main_module_741 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,1,0,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_740,
+        x_main_module_63);
+    auto x_main_module_742 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_741,
+        x_main_module_62,
+        x_main_module_61,
+        x_main_module_60,
+        x_main_module_59);
+    auto x_main_module_743 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_742);
+    auto x_main_module_744 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,0,1,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_740,
+        x_main_module_58);
+    auto x_main_module_745 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_744,
+        x_main_module_57,
+        x_main_module_56,
+        x_main_module_55,
+        x_main_module_54);
+    auto x_main_module_746 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_745);
+    auto x_main_module_747 = mmain->add_instruction(
+        migraphx::make_json_op("concat", "{axis:1}"), x_main_module_743, x_main_module_746);
+    auto x_main_module_748 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"),
+        x_main_module_721);
+    auto x_main_module_749 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_748,
+        x_main_module_53);
+    auto x_main_module_750 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_749,
+        x_main_module_52,
+        x_main_module_51,
+        x_main_module_50,
+        x_main_module_49);
+    auto x_main_module_751 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_750);
+    auto x_main_module_752 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"),
+                                                    x_main_module_724,
+                                                    x_main_module_734,
+                                                    x_main_module_747,
+                                                    x_main_module_751);
+    auto x_main_module_753 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_752,
+        x_main_module_48);
+    auto x_main_module_754 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_753,
+        x_main_module_47,
+        x_main_module_46,
+        x_main_module_45,
+        x_main_module_44);
+    auto x_main_module_755 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_754);
+    auto x_main_module_756 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_752,
+        x_main_module_43);
+    auto x_main_module_757 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_756,
+        x_main_module_42,
+        x_main_module_41,
+        x_main_module_40,
+        x_main_module_39);
+    auto x_main_module_758 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_757);
+    auto x_main_module_759 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,1,0,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_758,
+        x_main_module_38);
+    auto x_main_module_760 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_759,
+        x_main_module_37,
+        x_main_module_36,
+        x_main_module_35,
+        x_main_module_34);
+    auto x_main_module_761 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_760);
+    auto x_main_module_762 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,0,1,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_758,
+        x_main_module_33);
+    auto x_main_module_763 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_762,
+        x_main_module_32,
+        x_main_module_31,
+        x_main_module_30,
+        x_main_module_29);
+    auto x_main_module_764 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_763);
+    auto x_main_module_765 = mmain->add_instruction(
+        migraphx::make_json_op("concat", "{axis:1}"), x_main_module_761, x_main_module_764);
+    auto x_main_module_766 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_752,
+        x_main_module_28);
+    auto x_main_module_767 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_766,
+        x_main_module_27,
+        x_main_module_26,
+        x_main_module_25,
+        x_main_module_24);
+    auto x_main_module_768 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_767);
+    auto x_main_module_769 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_768,
+        x_main_module_23);
+    auto x_main_module_770 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_769,
+        x_main_module_22,
+        x_main_module_21,
+        x_main_module_20,
+        x_main_module_19);
+    auto x_main_module_771 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_770);
+    auto x_main_module_772 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,1,0,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_771,
+        x_main_module_18);
+    auto x_main_module_773 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_772,
+        x_main_module_17,
+        x_main_module_16,
+        x_main_module_15,
+        x_main_module_14);
+    auto x_main_module_774 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_773);
+    auto x_main_module_775 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,0,1,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_771,
+        x_main_module_13);
+    auto x_main_module_776 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_775,
+        x_main_module_12,
+        x_main_module_11,
+        x_main_module_10,
+        x_main_module_9);
+    auto x_main_module_777 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_776);
+    auto x_main_module_778 = mmain->add_instruction(
+        migraphx::make_json_op("concat", "{axis:1}"), x_main_module_774, x_main_module_777);
+    auto x_main_module_779 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:0,padding:[1,1,1,1],stride:[1,1]}"),
+        x_main_module_752);
+    auto x_main_module_780 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_779,
+        x_main_module_8);
+    auto x_main_module_781 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:0.0010000000474974513,momentum:0.8999999761581421}"),
+        x_main_module_780,
+        x_main_module_7,
+        x_main_module_6,
+        x_main_module_5,
+        x_main_module_4);
+    auto x_main_module_782 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_781);
+    auto x_main_module_783 = mmain->add_instruction(migraphx::make_json_op("concat", "{axis:1}"),
+                                                    x_main_module_755,
+                                                    x_main_module_765,
+                                                    x_main_module_778,
+                                                    x_main_module_782);
+    auto x_main_module_784 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[8,8],lp_order:2,mode:0,padding:[0,0,0,0],stride:[8,8]}"),
+        x_main_module_783);
+    auto x_main_module_785 =
+        mmain->add_instruction(migraphx::make_op("identity"), x_main_module_784);
+    auto x_main_module_786 =
+        mmain->add_instruction(migraphx::make_json_op("flatten", "{axis:1}"), x_main_module_785);
+    auto x_main_module_787 = mmain->add_instruction(
+        migraphx::make_json_op("transpose", "{permutation:[1,0]}"), x_main_module_3);
+    auto x_main_module_788 =
+        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_786, x_main_module_787);
+    auto x_main_module_789 = mmain->add_instruction(
+        migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_2);
+    auto x_main_module_790 = mmain->add_instruction(
+        migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_0);
+    auto x_main_module_791 =
+        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_789, x_main_module_790);
+    auto x_main_module_792 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_788, x_main_module_791);
+    mmain->add_return({x_main_module_792});
 
     return p;
 }

--- a/src/driver/inceptionv3.cpp
+++ b/src/driver/inceptionv3.cpp
@@ -33,802 +33,2832 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program inceptionv3(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-migraphx::module_ref mmain = p.get_main_module();
-auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 299, 299}});
-auto x_main_module_2 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
-auto x_main_module_3 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
-auto x_main_module_4 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 3)));
-auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 4));
-auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 5));
-auto x_main_module_7 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 6)));
-auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 2048, 1, 1}}, 7));
-auto x_main_module_9 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 8)));
-auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 9));
-auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 10));
-auto x_main_module_12 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 11)));
-auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 12));
-auto x_main_module_14 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13)));
-auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 14));
-auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 15));
-auto x_main_module_17 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 16)));
-auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 17));
-auto x_main_module_19 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 18)));
-auto x_main_module_20 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 19));
-auto x_main_module_21 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 20));
-auto x_main_module_22 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 21)));
-auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 22));
-auto x_main_module_24 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 23)));
-auto x_main_module_25 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 24));
-auto x_main_module_26 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 25));
-auto x_main_module_27 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 26)));
-auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448, 2048, 1, 1}}, 27));
-auto x_main_module_29 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 28)));
-auto x_main_module_30 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 29)));
-auto x_main_module_31 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 30));
-auto x_main_module_32 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 31)));
-auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 32));
-auto x_main_module_34 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 33)));
-auto x_main_module_35 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 34)));
-auto x_main_module_36 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 35));
-auto x_main_module_37 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 36)));
-auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 37));
-auto x_main_module_39 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 38)));
-auto x_main_module_40 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 39));
-auto x_main_module_41 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 40));
-auto x_main_module_42 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 41)));
-auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 2048, 1, 1}}, 42));
-auto x_main_module_44 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 43)));
-auto x_main_module_45 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 44));
-auto x_main_module_46 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 45));
-auto x_main_module_47 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 46)));
-auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 2048, 1, 1}}, 47));
-auto x_main_module_49 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 48)));
-auto x_main_module_50 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 49));
-auto x_main_module_51 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 50));
-auto x_main_module_52 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 51)));
-auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 1280, 1, 1}}, 52));
-auto x_main_module_54 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 53)));
-auto x_main_module_55 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 54));
-auto x_main_module_56 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 55));
-auto x_main_module_57 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 56)));
-auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 57));
-auto x_main_module_59 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 58)));
-auto x_main_module_60 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 59));
-auto x_main_module_61 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 60));
-auto x_main_module_62 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 61)));
-auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 62));
-auto x_main_module_64 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 63)));
-auto x_main_module_65 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 64));
-auto x_main_module_66 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 65));
-auto x_main_module_67 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 66)));
-auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 67));
-auto x_main_module_69 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 68)));
-auto x_main_module_70 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 69));
-auto x_main_module_71 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 70));
-auto x_main_module_72 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 71)));
-auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448, 1280, 1, 1}}, 72));
-auto x_main_module_74 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 73)));
-auto x_main_module_75 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 74));
-auto x_main_module_76 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 75));
-auto x_main_module_77 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 76)));
-auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 77));
-auto x_main_module_79 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 78)));
-auto x_main_module_80 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 79));
-auto x_main_module_81 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 80));
-auto x_main_module_82 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 81)));
-auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 82));
-auto x_main_module_84 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 83)));
-auto x_main_module_85 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 84));
-auto x_main_module_86 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 85));
-auto x_main_module_87 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 86)));
-auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 1280, 1, 1}}, 87));
-auto x_main_module_89 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 88)));
-auto x_main_module_90 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 89));
-auto x_main_module_91 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 90));
-auto x_main_module_92 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 91)));
-auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 1280, 1, 1}}, 92));
-auto x_main_module_94 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 93)));
-auto x_main_module_95 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 94));
-auto x_main_module_96 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 95));
-auto x_main_module_97 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 96)));
-auto x_main_module_98 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 3, 3}}, 97));
-auto x_main_module_99 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 98)));
-auto x_main_module_100 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 99));
-auto x_main_module_101 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 100));
-auto x_main_module_102 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 101)));
-auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 102));
-auto x_main_module_104 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 103)));
-auto x_main_module_105 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 104));
-auto x_main_module_106 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 105));
-auto x_main_module_107 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 106)));
-auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 107));
-auto x_main_module_109 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 108)));
-auto x_main_module_110 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 109));
-auto x_main_module_111 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 110));
-auto x_main_module_112 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 111)));
-auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 112));
-auto x_main_module_114 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 113)));
-auto x_main_module_115 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 114));
-auto x_main_module_116 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 115));
-auto x_main_module_117 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 116)));
-auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320, 192, 3, 3}}, 117));
-auto x_main_module_119 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 118)));
-auto x_main_module_120 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 119));
-auto x_main_module_121 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 120));
-auto x_main_module_122 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 121)));
-auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 122));
-auto x_main_module_124 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 123)));
-auto x_main_module_125 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 124));
-auto x_main_module_126 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 125));
-auto x_main_module_127 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 126)));
-auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 127));
-auto x_main_module_129 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 128)));
-auto x_main_module_130 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 129));
-auto x_main_module_131 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 130));
-auto x_main_module_132 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 131)));
-auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 132));
-auto x_main_module_134 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 133)));
-auto x_main_module_135 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 134));
-auto x_main_module_136 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 135));
-auto x_main_module_137 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 136)));
-auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 137));
-auto x_main_module_139 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 138)));
-auto x_main_module_140 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 139));
-auto x_main_module_141 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 140));
-auto x_main_module_142 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 141)));
-auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 142));
-auto x_main_module_144 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 143)));
-auto x_main_module_145 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 144));
-auto x_main_module_146 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 145));
-auto x_main_module_147 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 146)));
-auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 147));
-auto x_main_module_149 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 148)));
-auto x_main_module_150 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 149));
-auto x_main_module_151 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 150));
-auto x_main_module_152 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 151)));
-auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 152));
-auto x_main_module_154 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 153)));
-auto x_main_module_155 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 154));
-auto x_main_module_156 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 155));
-auto x_main_module_157 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 156)));
-auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 157));
-auto x_main_module_159 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 158)));
-auto x_main_module_160 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 159));
-auto x_main_module_161 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 160));
-auto x_main_module_162 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 161)));
-auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 162));
-auto x_main_module_164 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 163)));
-auto x_main_module_165 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 164));
-auto x_main_module_166 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 165));
-auto x_main_module_167 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 166)));
-auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 167));
-auto x_main_module_169 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 168)));
-auto x_main_module_170 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 169));
-auto x_main_module_171 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 170));
-auto x_main_module_172 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 171)));
-auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 172));
-auto x_main_module_174 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 173)));
-auto x_main_module_175 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 174));
-auto x_main_module_176 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 175));
-auto x_main_module_177 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 176)));
-auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 177));
-auto x_main_module_179 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 178)));
-auto x_main_module_180 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 179));
-auto x_main_module_181 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 180));
-auto x_main_module_182 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 181)));
-auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 182));
-auto x_main_module_184 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 183)));
-auto x_main_module_185 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 184));
-auto x_main_module_186 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 185));
-auto x_main_module_187 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 186)));
-auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 187));
-auto x_main_module_189 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 188)));
-auto x_main_module_190 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 189));
-auto x_main_module_191 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 190));
-auto x_main_module_192 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 191)));
-auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 192));
-auto x_main_module_194 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 193)));
-auto x_main_module_195 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 194));
-auto x_main_module_196 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 195));
-auto x_main_module_197 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 196)));
-auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 197));
-auto x_main_module_199 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 198)));
-auto x_main_module_200 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 199));
-auto x_main_module_201 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 200));
-auto x_main_module_202 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 201)));
-auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 202));
-auto x_main_module_204 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 203)));
-auto x_main_module_205 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 204));
-auto x_main_module_206 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 205));
-auto x_main_module_207 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 206)));
-auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 207));
-auto x_main_module_209 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 208)));
-auto x_main_module_210 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 209));
-auto x_main_module_211 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 210));
-auto x_main_module_212 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 211)));
-auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 212));
-auto x_main_module_214 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 213)));
-auto x_main_module_215 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 214));
-auto x_main_module_216 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 215));
-auto x_main_module_217 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 216)));
-auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 217));
-auto x_main_module_219 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 218)));
-auto x_main_module_220 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 219));
-auto x_main_module_221 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 220));
-auto x_main_module_222 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 221)));
-auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 222));
-auto x_main_module_224 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 223)));
-auto x_main_module_225 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 224));
-auto x_main_module_226 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 225));
-auto x_main_module_227 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 226)));
-auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 227));
-auto x_main_module_229 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 228)));
-auto x_main_module_230 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 229));
-auto x_main_module_231 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 230));
-auto x_main_module_232 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 231)));
-auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 232));
-auto x_main_module_234 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 233)));
-auto x_main_module_235 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 234));
-auto x_main_module_236 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 235));
-auto x_main_module_237 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 236)));
-auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 237));
-auto x_main_module_239 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 238)));
-auto x_main_module_240 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 239));
-auto x_main_module_241 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 240));
-auto x_main_module_242 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 241)));
-auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 242));
-auto x_main_module_244 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 243)));
-auto x_main_module_245 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 244));
-auto x_main_module_246 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 245));
-auto x_main_module_247 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 246)));
-auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 247));
-auto x_main_module_249 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 248)));
-auto x_main_module_250 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 249));
-auto x_main_module_251 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 250));
-auto x_main_module_252 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 251)));
-auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 252));
-auto x_main_module_254 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 253)));
-auto x_main_module_255 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 254));
-auto x_main_module_256 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 255));
-auto x_main_module_257 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 256)));
-auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 257));
-auto x_main_module_259 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 258)));
-auto x_main_module_260 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 259));
-auto x_main_module_261 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 260));
-auto x_main_module_262 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 261)));
-auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 262));
-auto x_main_module_264 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 263)));
-auto x_main_module_265 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 264));
-auto x_main_module_266 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 265));
-auto x_main_module_267 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 266)));
-auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 267));
-auto x_main_module_269 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 268)));
-auto x_main_module_270 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 269));
-auto x_main_module_271 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 270));
-auto x_main_module_272 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 271)));
-auto x_main_module_273 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 272));
-auto x_main_module_274 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 273)));
-auto x_main_module_275 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 274));
-auto x_main_module_276 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 275));
-auto x_main_module_277 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 276)));
-auto x_main_module_278 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 277));
-auto x_main_module_279 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 278)));
-auto x_main_module_280 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 279));
-auto x_main_module_281 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 280));
-auto x_main_module_282 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 281)));
-auto x_main_module_283 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 128, 1, 7}}, 282));
-auto x_main_module_284 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 283)));
-auto x_main_module_285 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 284));
-auto x_main_module_286 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 285));
-auto x_main_module_287 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 286)));
-auto x_main_module_288 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 287));
-auto x_main_module_289 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 288)));
-auto x_main_module_290 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 289));
-auto x_main_module_291 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 290));
-auto x_main_module_292 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 291)));
-auto x_main_module_293 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 292));
-auto x_main_module_294 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 293)));
-auto x_main_module_295 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 294));
-auto x_main_module_296 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 295));
-auto x_main_module_297 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 296)));
-auto x_main_module_298 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 297));
-auto x_main_module_299 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 298)));
-auto x_main_module_300 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 299));
-auto x_main_module_301 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 300));
-auto x_main_module_302 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 301)));
-auto x_main_module_303 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 302));
-auto x_main_module_304 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 303)));
-auto x_main_module_305 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 304));
-auto x_main_module_306 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 305));
-auto x_main_module_307 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 306)));
-auto x_main_module_308 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 128, 7, 1}}, 307));
-auto x_main_module_309 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 308)));
-auto x_main_module_310 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 309));
-auto x_main_module_311 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 310));
-auto x_main_module_312 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 311)));
-auto x_main_module_313 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 312));
-auto x_main_module_314 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 313)));
-auto x_main_module_315 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 314));
-auto x_main_module_316 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 315));
-auto x_main_module_317 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 316)));
-auto x_main_module_318 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 317));
-auto x_main_module_319 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 318)));
-auto x_main_module_320 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 319));
-auto x_main_module_321 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 320));
-auto x_main_module_322 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 321)));
-auto x_main_module_323 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 322));
-auto x_main_module_324 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 323)));
-auto x_main_module_325 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 324));
-auto x_main_module_326 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 325));
-auto x_main_module_327 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 326)));
-auto x_main_module_328 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 327));
-auto x_main_module_329 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 328)));
-auto x_main_module_330 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 329));
-auto x_main_module_331 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 330));
-auto x_main_module_332 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 331)));
-auto x_main_module_333 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 332));
-auto x_main_module_334 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 333)));
-auto x_main_module_335 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 334));
-auto x_main_module_336 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 335));
-auto x_main_module_337 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 336)));
-auto x_main_module_338 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 337));
-auto x_main_module_339 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 338)));
-auto x_main_module_340 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 339));
-auto x_main_module_341 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 340));
-auto x_main_module_342 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 341)));
-auto x_main_module_343 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384, 288, 3, 3}}, 342));
-auto x_main_module_344 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 343)));
-auto x_main_module_345 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 344));
-auto x_main_module_346 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 345));
-auto x_main_module_347 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 346)));
-auto x_main_module_348 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 347));
-auto x_main_module_349 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 348)));
-auto x_main_module_350 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 349));
-auto x_main_module_351 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 350));
-auto x_main_module_352 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 351)));
-auto x_main_module_353 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 352));
-auto x_main_module_354 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 353)));
-auto x_main_module_355 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 354));
-auto x_main_module_356 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 355));
-auto x_main_module_357 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 356)));
-auto x_main_module_358 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 357));
-auto x_main_module_359 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 358)));
-auto x_main_module_360 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 359));
-auto x_main_module_361 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 360));
-auto x_main_module_362 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 361)));
-auto x_main_module_363 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 362));
-auto x_main_module_364 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 363)));
-auto x_main_module_365 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 364));
-auto x_main_module_366 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 365));
-auto x_main_module_367 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 366)));
-auto x_main_module_368 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 367));
-auto x_main_module_369 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 368)));
-auto x_main_module_370 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 369));
-auto x_main_module_371 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 370));
-auto x_main_module_372 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 371)));
-auto x_main_module_373 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 288, 1, 1}}, 372));
-auto x_main_module_374 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 373)));
-auto x_main_module_375 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 374));
-auto x_main_module_376 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 375));
-auto x_main_module_377 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 376)));
-auto x_main_module_378 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 377));
-auto x_main_module_379 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 378)));
-auto x_main_module_380 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 379));
-auto x_main_module_381 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 380));
-auto x_main_module_382 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 381)));
-auto x_main_module_383 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 382));
-auto x_main_module_384 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 383)));
-auto x_main_module_385 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 384));
-auto x_main_module_386 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 385));
-auto x_main_module_387 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 386)));
-auto x_main_module_388 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 387));
-auto x_main_module_389 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 388)));
-auto x_main_module_390 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 389));
-auto x_main_module_391 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 390));
-auto x_main_module_392 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 391)));
-auto x_main_module_393 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 392));
-auto x_main_module_394 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 393)));
-auto x_main_module_395 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 394));
-auto x_main_module_396 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 395));
-auto x_main_module_397 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 396)));
-auto x_main_module_398 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 397));
-auto x_main_module_399 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 398)));
-auto x_main_module_400 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 399));
-auto x_main_module_401 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 400));
-auto x_main_module_402 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 401)));
-auto x_main_module_403 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 402));
-auto x_main_module_404 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 403)));
-auto x_main_module_405 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 404));
-auto x_main_module_406 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 405));
-auto x_main_module_407 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 406)));
-auto x_main_module_408 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 256, 1, 1}}, 407));
-auto x_main_module_409 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 408)));
-auto x_main_module_410 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 409));
-auto x_main_module_411 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 410));
-auto x_main_module_412 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 411)));
-auto x_main_module_413 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 412));
-auto x_main_module_414 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 413)));
-auto x_main_module_415 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 414));
-auto x_main_module_416 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 415));
-auto x_main_module_417 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 416)));
-auto x_main_module_418 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 192, 1, 1}}, 417));
-auto x_main_module_419 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 418)));
-auto x_main_module_420 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 419));
-auto x_main_module_421 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 420));
-auto x_main_module_422 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 421)));
-auto x_main_module_423 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 422));
-auto x_main_module_424 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 423)));
-auto x_main_module_425 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 424));
-auto x_main_module_426 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 425));
-auto x_main_module_427 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 426)));
-auto x_main_module_428 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 427));
-auto x_main_module_429 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 428)));
-auto x_main_module_430 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 429));
-auto x_main_module_431 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 430));
-auto x_main_module_432 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 431)));
-auto x_main_module_433 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 432));
-auto x_main_module_434 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 433)));
-auto x_main_module_435 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 434));
-auto x_main_module_436 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 435));
-auto x_main_module_437 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 436)));
-auto x_main_module_438 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 437));
-auto x_main_module_439 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 438)));
-auto x_main_module_440 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 439));
-auto x_main_module_441 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 440));
-auto x_main_module_442 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 441)));
-auto x_main_module_443 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48, 192, 1, 1}}, 442));
-auto x_main_module_444 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 443)));
-auto x_main_module_445 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 444));
-auto x_main_module_446 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 445));
-auto x_main_module_447 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 446)));
-auto x_main_module_448 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 447));
-auto x_main_module_449 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 448)));
-auto x_main_module_450 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 449));
-auto x_main_module_451 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 450));
-auto x_main_module_452 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 451)));
-auto x_main_module_453 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192, 80, 3, 3}}, 452));
-auto x_main_module_454 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 453)));
-auto x_main_module_455 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 454));
-auto x_main_module_456 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 455));
-auto x_main_module_457 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 456)));
-auto x_main_module_458 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80, 64, 1, 1}}, 457));
-auto x_main_module_459 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 458)));
-auto x_main_module_460 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 459));
-auto x_main_module_461 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 460));
-auto x_main_module_462 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 461)));
-auto x_main_module_463 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 32, 3, 3}}, 462));
-auto x_main_module_464 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 463)));
-auto x_main_module_465 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 464));
-auto x_main_module_466 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 465));
-auto x_main_module_467 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 466)));
-auto x_main_module_468 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 32, 3, 3}}, 467));
-auto x_main_module_469 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 468)));
-auto x_main_module_470 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 469));
-auto x_main_module_471 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 470));
-auto x_main_module_472 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 471)));
-auto x_main_module_473 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32, 3, 3, 3}}, 472));
-auto x_main_module_474 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_0, x_main_module_473); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_475 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_474, x_main_module_472, x_main_module_471, x_main_module_470, x_main_module_469); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_476 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_475);
-auto x_main_module_477 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_476, x_main_module_468); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_478 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_477, x_main_module_467, x_main_module_466, x_main_module_465, x_main_module_464); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_479 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_478);
-auto x_main_module_480 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_479, x_main_module_463); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_481 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_480, x_main_module_462, x_main_module_461, x_main_module_460, x_main_module_459); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_482 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_481);
-auto x_main_module_483 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_482); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_484 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_483, x_main_module_458); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_485 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_484, x_main_module_457, x_main_module_456, x_main_module_455, x_main_module_454); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_486 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_485);
-auto x_main_module_487 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_486, x_main_module_453); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_488 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_487, x_main_module_452, x_main_module_451, x_main_module_450, x_main_module_449); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_489 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_488);
-auto x_main_module_490 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_489); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_491 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_490, x_main_module_448); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_492 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_491, x_main_module_447, x_main_module_446, x_main_module_445, x_main_module_444); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_493 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_492);
-auto x_main_module_494 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_490, x_main_module_443); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_495 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_494, x_main_module_442, x_main_module_441, x_main_module_440, x_main_module_439); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_496 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_495);
-auto x_main_module_497 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_496, x_main_module_438); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_498 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_497, x_main_module_437, x_main_module_436, x_main_module_435, x_main_module_434); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_499 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_498);
-auto x_main_module_500 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_490, x_main_module_433); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_501 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_500, x_main_module_432, x_main_module_431, x_main_module_430, x_main_module_429); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_502 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_501);
-auto x_main_module_503 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_502, x_main_module_428); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_504 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_503, x_main_module_427, x_main_module_426, x_main_module_425, x_main_module_424); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_505 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_504);
-auto x_main_module_506 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_505, x_main_module_423); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_507 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_506, x_main_module_422, x_main_module_421, x_main_module_420, x_main_module_419); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_508 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_507);
-auto x_main_module_509 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_490); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_510 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_509, x_main_module_418); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_511 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_510, x_main_module_417, x_main_module_416, x_main_module_415, x_main_module_414); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_512 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_511);
-auto x_main_module_513 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_493, x_main_module_499, x_main_module_508, x_main_module_512); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_514 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_513, x_main_module_413); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_515 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_514, x_main_module_412, x_main_module_411, x_main_module_410, x_main_module_409); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_516 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_515);
-auto x_main_module_517 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_513, x_main_module_408); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_518 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_517, x_main_module_407, x_main_module_406, x_main_module_405, x_main_module_404); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_519 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_518);
-auto x_main_module_520 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_519, x_main_module_403); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_521 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_520, x_main_module_402, x_main_module_401, x_main_module_400, x_main_module_399); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_522 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_521);
-auto x_main_module_523 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_513, x_main_module_398); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_524 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_523, x_main_module_397, x_main_module_396, x_main_module_395, x_main_module_394); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_525 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_524);
-auto x_main_module_526 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_525, x_main_module_393); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_527 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_526, x_main_module_392, x_main_module_391, x_main_module_390, x_main_module_389); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_528 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_527);
-auto x_main_module_529 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_528, x_main_module_388); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_530 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_529, x_main_module_387, x_main_module_386, x_main_module_385, x_main_module_384); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_531 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_530);
-auto x_main_module_532 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_513); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_533 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_532, x_main_module_383); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_534 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_533, x_main_module_382, x_main_module_381, x_main_module_380, x_main_module_379); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_535 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_534);
-auto x_main_module_536 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_516, x_main_module_522, x_main_module_531, x_main_module_535); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_537 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_536, x_main_module_378); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_538 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_537, x_main_module_377, x_main_module_376, x_main_module_375, x_main_module_374); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_539 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_538);
-auto x_main_module_540 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_536, x_main_module_373); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_541 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_540, x_main_module_372, x_main_module_371, x_main_module_370, x_main_module_369); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_542 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_541);
-auto x_main_module_543 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_542, x_main_module_368); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_544 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_543, x_main_module_367, x_main_module_366, x_main_module_365, x_main_module_364); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_545 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_544);
-auto x_main_module_546 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_536, x_main_module_363); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_547 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_546, x_main_module_362, x_main_module_361, x_main_module_360, x_main_module_359); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_548 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_547);
-auto x_main_module_549 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_548, x_main_module_358); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_550 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_549, x_main_module_357, x_main_module_356, x_main_module_355, x_main_module_354); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_551 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_550);
-auto x_main_module_552 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_551, x_main_module_353); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_553 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_552, x_main_module_352, x_main_module_351, x_main_module_350, x_main_module_349); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_554 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_553);
-auto x_main_module_555 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_536); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_556 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_555, x_main_module_348); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_557 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_556, x_main_module_347, x_main_module_346, x_main_module_345, x_main_module_344); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_558 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_557);
-auto x_main_module_559 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_539, x_main_module_545, x_main_module_554, x_main_module_558); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_560 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_559, x_main_module_343); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_561 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_560, x_main_module_342, x_main_module_341, x_main_module_340, x_main_module_339); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_562 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_561);
-auto x_main_module_563 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_559, x_main_module_338); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_564 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_563, x_main_module_337, x_main_module_336, x_main_module_335, x_main_module_334); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_565 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_564);
-auto x_main_module_566 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_565, x_main_module_333); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_567 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_566, x_main_module_332, x_main_module_331, x_main_module_330, x_main_module_329); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_568 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_567);
-auto x_main_module_569 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_568, x_main_module_328); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_570 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_569, x_main_module_327, x_main_module_326, x_main_module_325, x_main_module_324); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_571 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_570);
-auto x_main_module_572 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_559); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_573 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_562, x_main_module_571, x_main_module_572); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_574 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_573, x_main_module_323); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_575 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_574, x_main_module_322, x_main_module_321, x_main_module_320, x_main_module_319); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_576 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_575);
-auto x_main_module_577 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_573, x_main_module_318); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_578 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_577, x_main_module_317, x_main_module_316, x_main_module_315, x_main_module_314); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_579 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_578);
-auto x_main_module_580 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_579, x_main_module_313); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_581 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_580, x_main_module_312, x_main_module_311, x_main_module_310, x_main_module_309); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_582 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_581);
-auto x_main_module_583 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_582, x_main_module_308); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_584 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_583, x_main_module_307, x_main_module_306, x_main_module_305, x_main_module_304); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_585 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_584);
-auto x_main_module_586 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_573, x_main_module_303); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_587 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_586, x_main_module_302, x_main_module_301, x_main_module_300, x_main_module_299); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_588 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_587);
-auto x_main_module_589 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_588, x_main_module_298); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_590 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_589, x_main_module_297, x_main_module_296, x_main_module_295, x_main_module_294); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_591 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_590);
-auto x_main_module_592 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_591, x_main_module_293); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_593 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_592, x_main_module_292, x_main_module_291, x_main_module_290, x_main_module_289); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_594 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_593);
-auto x_main_module_595 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_594, x_main_module_288); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_596 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_595, x_main_module_287, x_main_module_286, x_main_module_285, x_main_module_284); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_597 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_596);
-auto x_main_module_598 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_597, x_main_module_283); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_599 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_598, x_main_module_282, x_main_module_281, x_main_module_280, x_main_module_279); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_600 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_599);
-auto x_main_module_601 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_573); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_602 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_601, x_main_module_278); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_603 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_602, x_main_module_277, x_main_module_276, x_main_module_275, x_main_module_274); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_604 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_603);
-auto x_main_module_605 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_576, x_main_module_585, x_main_module_600, x_main_module_604); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_606 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_605, x_main_module_273); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_607 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_606, x_main_module_272, x_main_module_271, x_main_module_270, x_main_module_269); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_608 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_607);
-auto x_main_module_609 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_605, x_main_module_268); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_610 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_609, x_main_module_267, x_main_module_266, x_main_module_265, x_main_module_264); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_611 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_610);
-auto x_main_module_612 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_611, x_main_module_263); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_613 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_612, x_main_module_262, x_main_module_261, x_main_module_260, x_main_module_259); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_614 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_613);
-auto x_main_module_615 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_614, x_main_module_258); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_616 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_615, x_main_module_257, x_main_module_256, x_main_module_255, x_main_module_254); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_617 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_616);
-auto x_main_module_618 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_605, x_main_module_253); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_619 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_618, x_main_module_252, x_main_module_251, x_main_module_250, x_main_module_249); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_620 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_619);
-auto x_main_module_621 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_620, x_main_module_248); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_622 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_621, x_main_module_247, x_main_module_246, x_main_module_245, x_main_module_244); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_623 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_622);
-auto x_main_module_624 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_623, x_main_module_243); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_625 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_624, x_main_module_242, x_main_module_241, x_main_module_240, x_main_module_239); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_626 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_625);
-auto x_main_module_627 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_626, x_main_module_238); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_628 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_627, x_main_module_237, x_main_module_236, x_main_module_235, x_main_module_234); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_629 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_628);
-auto x_main_module_630 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_629, x_main_module_233); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_631 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_630, x_main_module_232, x_main_module_231, x_main_module_230, x_main_module_229); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_632 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_631);
-auto x_main_module_633 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_605); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_634 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_633, x_main_module_228); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_635 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_634, x_main_module_227, x_main_module_226, x_main_module_225, x_main_module_224); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_636 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_635);
-auto x_main_module_637 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_608, x_main_module_617, x_main_module_632, x_main_module_636); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_638 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_637, x_main_module_223); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_639 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_638, x_main_module_222, x_main_module_221, x_main_module_220, x_main_module_219); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_640 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_639);
-auto x_main_module_641 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_637, x_main_module_218); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_642 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_641, x_main_module_217, x_main_module_216, x_main_module_215, x_main_module_214); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_643 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_642);
-auto x_main_module_644 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_643, x_main_module_213); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_645 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_644, x_main_module_212, x_main_module_211, x_main_module_210, x_main_module_209); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_646 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_645);
-auto x_main_module_647 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_646, x_main_module_208); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_648 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_647, x_main_module_207, x_main_module_206, x_main_module_205, x_main_module_204); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_649 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_648);
-auto x_main_module_650 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_637, x_main_module_203); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_651 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_650, x_main_module_202, x_main_module_201, x_main_module_200, x_main_module_199); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_652 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_651);
-auto x_main_module_653 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_652, x_main_module_198); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_654 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_653, x_main_module_197, x_main_module_196, x_main_module_195, x_main_module_194); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_655 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_654);
-auto x_main_module_656 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_655, x_main_module_193); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_657 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_656, x_main_module_192, x_main_module_191, x_main_module_190, x_main_module_189); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_658 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_657);
-auto x_main_module_659 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_658, x_main_module_188); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_660 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_659, x_main_module_187, x_main_module_186, x_main_module_185, x_main_module_184); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_661 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_660);
-auto x_main_module_662 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_661, x_main_module_183); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_663 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_662, x_main_module_182, x_main_module_181, x_main_module_180, x_main_module_179); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_664 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_663);
-auto x_main_module_665 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_637); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_666 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_665, x_main_module_178); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_667 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_666, x_main_module_177, x_main_module_176, x_main_module_175, x_main_module_174); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_668 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_667);
-auto x_main_module_669 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_640, x_main_module_649, x_main_module_664, x_main_module_668); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_670 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_669, x_main_module_173); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_671 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_670, x_main_module_172, x_main_module_171, x_main_module_170, x_main_module_169); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_672 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_671);
-auto x_main_module_673 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_669, x_main_module_168); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_674 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_673, x_main_module_167, x_main_module_166, x_main_module_165, x_main_module_164); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_675 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_674);
-auto x_main_module_676 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_675, x_main_module_163); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_677 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_676, x_main_module_162, x_main_module_161, x_main_module_160, x_main_module_159); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_678 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_677);
-auto x_main_module_679 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_678, x_main_module_158); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_680 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_679, x_main_module_157, x_main_module_156, x_main_module_155, x_main_module_154); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_681 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_680);
-auto x_main_module_682 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_669, x_main_module_153); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_683 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_682, x_main_module_152, x_main_module_151, x_main_module_150, x_main_module_149); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_684 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_683);
-auto x_main_module_685 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_684, x_main_module_148); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_686 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_685, x_main_module_147, x_main_module_146, x_main_module_145, x_main_module_144); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_687 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_686);
-auto x_main_module_688 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_687, x_main_module_143); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_689 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_688, x_main_module_142, x_main_module_141, x_main_module_140, x_main_module_139); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_690 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_689);
-auto x_main_module_691 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_690, x_main_module_138); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_692 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_691, x_main_module_137, x_main_module_136, x_main_module_135, x_main_module_134); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_693 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_692);
-auto x_main_module_694 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_693, x_main_module_133); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_695 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_694, x_main_module_132, x_main_module_131, x_main_module_130, x_main_module_129); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_696 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_695);
-auto x_main_module_697 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_669); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_698 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_697, x_main_module_128); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_699 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_698, x_main_module_127, x_main_module_126, x_main_module_125, x_main_module_124); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_700 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_699);
-auto x_main_module_701 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_672, x_main_module_681, x_main_module_696, x_main_module_700); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_702 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_701, x_main_module_123); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_703 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_702, x_main_module_122, x_main_module_121, x_main_module_120, x_main_module_119); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_704 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_703);
-auto x_main_module_705 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_704, x_main_module_118); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_706 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_705, x_main_module_117, x_main_module_116, x_main_module_115, x_main_module_114); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_707 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_706);
-auto x_main_module_708 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_701, x_main_module_113); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_709 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_708, x_main_module_112, x_main_module_111, x_main_module_110, x_main_module_109); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_710 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_709);
-auto x_main_module_711 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_710, x_main_module_108); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_712 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_711, x_main_module_107, x_main_module_106, x_main_module_105, x_main_module_104); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_713 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_712);
-auto x_main_module_714 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_713, x_main_module_103); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_715 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_714, x_main_module_102, x_main_module_101, x_main_module_100, x_main_module_99); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_716 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_715);
-auto x_main_module_717 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_716, x_main_module_98); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_718 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_717, x_main_module_97, x_main_module_96, x_main_module_95, x_main_module_94); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_719 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_718);
-auto x_main_module_720 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")), x_main_module_701); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_721 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_707, x_main_module_719, x_main_module_720); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_722 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_721, x_main_module_93); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_723 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_722, x_main_module_92, x_main_module_91, x_main_module_90, x_main_module_89); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_724 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_723);
-auto x_main_module_725 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_721, x_main_module_88); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_726 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_725, x_main_module_87, x_main_module_86, x_main_module_85, x_main_module_84); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_727 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_726);
-auto x_main_module_728 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_727, x_main_module_83); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_729 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_728, x_main_module_82, x_main_module_81, x_main_module_80, x_main_module_79); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_730 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_729);
-auto x_main_module_731 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_727, x_main_module_78); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_732 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_731, x_main_module_77, x_main_module_76, x_main_module_75, x_main_module_74); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_733 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_732);
-auto x_main_module_734 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_730, x_main_module_733); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_735 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_721, x_main_module_73); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_736 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_735, x_main_module_72, x_main_module_71, x_main_module_70, x_main_module_69); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_737 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_736);
-auto x_main_module_738 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_737, x_main_module_68); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_739 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_738, x_main_module_67, x_main_module_66, x_main_module_65, x_main_module_64); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_740 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_739);
-auto x_main_module_741 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_740, x_main_module_63); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_742 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_741, x_main_module_62, x_main_module_61, x_main_module_60, x_main_module_59); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_743 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_742);
-auto x_main_module_744 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_740, x_main_module_58); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_745 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_744, x_main_module_57, x_main_module_56, x_main_module_55, x_main_module_54); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_746 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_745);
-auto x_main_module_747 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_743, x_main_module_746); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_748 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_721); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_749 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_748, x_main_module_53); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_750 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_749, x_main_module_52, x_main_module_51, x_main_module_50, x_main_module_49); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_751 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_750);
-auto x_main_module_752 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_724, x_main_module_734, x_main_module_747, x_main_module_751); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_753 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_752, x_main_module_48); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_754 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_753, x_main_module_47, x_main_module_46, x_main_module_45, x_main_module_44); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_755 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_754);
-auto x_main_module_756 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_752, x_main_module_43); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_757 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_756, x_main_module_42, x_main_module_41, x_main_module_40, x_main_module_39); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_758 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_757);
-auto x_main_module_759 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_758, x_main_module_38); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_760 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_759, x_main_module_37, x_main_module_36, x_main_module_35, x_main_module_34); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_761 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_760);
-auto x_main_module_762 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_758, x_main_module_33); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_763 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_762, x_main_module_32, x_main_module_31, x_main_module_30, x_main_module_29); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_764 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_763);
-auto x_main_module_765 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_761, x_main_module_764); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_766 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_752, x_main_module_28); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_767 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_766, x_main_module_27, x_main_module_26, x_main_module_25, x_main_module_24); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_768 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_767);
-auto x_main_module_769 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_768, x_main_module_23); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_770 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_769, x_main_module_22, x_main_module_21, x_main_module_20, x_main_module_19); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_771 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_770);
-auto x_main_module_772 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_771, x_main_module_18); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_773 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_772, x_main_module_17, x_main_module_16, x_main_module_15, x_main_module_14); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_774 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_773);
-auto x_main_module_775 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_771, x_main_module_13); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_776 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_775, x_main_module_12, x_main_module_11, x_main_module_10, x_main_module_9); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_777 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_776);
-auto x_main_module_778 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_774, x_main_module_777); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_779 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")), x_main_module_752); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_780 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_779, x_main_module_8); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_781 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,\"momentum\":0.8999999761581421}")), x_main_module_780, x_main_module_7, x_main_module_6, x_main_module_5, x_main_module_4); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_782 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_781);
-auto x_main_module_783 = mmain->add_instruction(migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")), x_main_module_755, x_main_module_765, x_main_module_778, x_main_module_782); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_784 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[8,8],\"lp_order\":2,\"mode\":0,\"padding\":[0,0,0,0],\"stride\":[8,8]}")), x_main_module_783); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_785 = mmain->add_instruction(migraphx::make_op("identity"), x_main_module_784);
-auto x_main_module_786 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), x_main_module_785); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_787 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_3); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_788 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_786, x_main_module_787);
-auto x_main_module_789 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_2); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_790 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_0); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_791 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_789, x_main_module_790);
-auto x_main_module_792 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_788, x_main_module_791);
-mmain->add_return({x_main_module_792});
-
+    migraphx::module_ref mmain = p.get_main_module();
+    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+    auto x_0                   = mmain->add_parameter(
+        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 299, 299}});
+    auto x_main_module_2 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
+    auto x_main_module_3 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
+    auto x_main_module_4 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 3)));
+    auto x_main_module_5 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 4));
+    auto x_main_module_6 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 5));
+    auto x_main_module_7  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 6)));
+    auto x_main_module_8  = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 2048, 1, 1}}, 7));
+    auto x_main_module_9  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 8)));
+    auto x_main_module_10 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 9));
+    auto x_main_module_11 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 10));
+    auto x_main_module_12 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 11)));
+    auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 12));
+    auto x_main_module_14 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 13)));
+    auto x_main_module_15 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 14));
+    auto x_main_module_16 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 15));
+    auto x_main_module_17 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 16)));
+    auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 17));
+    auto x_main_module_19 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 18)));
+    auto x_main_module_20 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 19));
+    auto x_main_module_21 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 20));
+    auto x_main_module_22 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 21)));
+    auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 22));
+    auto x_main_module_24 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 23)));
+    auto x_main_module_25 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 24));
+    auto x_main_module_26 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 25));
+    auto x_main_module_27 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 26)));
+    auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {448, 2048, 1, 1}}, 27));
+    auto x_main_module_29 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 28)));
+    auto x_main_module_30 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 29)));
+    auto x_main_module_31 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 30));
+    auto x_main_module_32 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 31)));
+    auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 32));
+    auto x_main_module_34 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 33)));
+    auto x_main_module_35 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 34)));
+    auto x_main_module_36 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 35));
+    auto x_main_module_37 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 36)));
+    auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 37));
+    auto x_main_module_39 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 38)));
+    auto x_main_module_40 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 39));
+    auto x_main_module_41 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 40));
+    auto x_main_module_42 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 41)));
+    auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 2048, 1, 1}}, 42));
+    auto x_main_module_44 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 43)));
+    auto x_main_module_45 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 44));
+    auto x_main_module_46 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 45));
+    auto x_main_module_47 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 46)));
+    auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {320, 2048, 1, 1}}, 47));
+    auto x_main_module_49 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 48)));
+    auto x_main_module_50 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 49));
+    auto x_main_module_51 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 50));
+    auto x_main_module_52 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 51)));
+    auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 1280, 1, 1}}, 52));
+    auto x_main_module_54 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 53)));
+    auto x_main_module_55 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 54));
+    auto x_main_module_56 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 55));
+    auto x_main_module_57 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 56)));
+    auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 57));
+    auto x_main_module_59 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 58)));
+    auto x_main_module_60 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 59));
+    auto x_main_module_61 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 60));
+    auto x_main_module_62 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 61)));
+    auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 62));
+    auto x_main_module_64 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 63)));
+    auto x_main_module_65 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 64));
+    auto x_main_module_66 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 65));
+    auto x_main_module_67 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 66)));
+    auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 448, 3, 3}}, 67));
+    auto x_main_module_69 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 68)));
+    auto x_main_module_70 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 69));
+    auto x_main_module_71 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 70));
+    auto x_main_module_72 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {448}}, 71)));
+    auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {448, 1280, 1, 1}}, 72));
+    auto x_main_module_74 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 73)));
+    auto x_main_module_75 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 74));
+    auto x_main_module_76 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 75));
+    auto x_main_module_77 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 76)));
+    auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 3, 1}}, 77));
+    auto x_main_module_79 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 78)));
+    auto x_main_module_80 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 79));
+    auto x_main_module_81 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 80));
+    auto x_main_module_82 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 81)));
+    auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 384, 1, 3}}, 82));
+    auto x_main_module_84 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 83)));
+    auto x_main_module_85 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 84));
+    auto x_main_module_86 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 85));
+    auto x_main_module_87 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 86)));
+    auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 1280, 1, 1}}, 87));
+    auto x_main_module_89 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 88)));
+    auto x_main_module_90 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 89));
+    auto x_main_module_91 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 90));
+    auto x_main_module_92 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 91)));
+    auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {320, 1280, 1, 1}}, 92));
+    auto x_main_module_94 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 93)));
+    auto x_main_module_95 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 94));
+    auto x_main_module_96 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 95));
+    auto x_main_module_97  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 96)));
+    auto x_main_module_98  = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 3, 3}}, 97));
+    auto x_main_module_99  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 98)));
+    auto x_main_module_100 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 99));
+    auto x_main_module_101 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 100));
+    auto x_main_module_102 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 101)));
+    auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 102));
+    auto x_main_module_104 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 103)));
+    auto x_main_module_105 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 104));
+    auto x_main_module_106 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 105));
+    auto x_main_module_107 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 106)));
+    auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 107));
+    auto x_main_module_109 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 108)));
+    auto x_main_module_110 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 109));
+    auto x_main_module_111 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 110));
+    auto x_main_module_112 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 111)));
+    auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 112));
+    auto x_main_module_114 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 113)));
+    auto x_main_module_115 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 114));
+    auto x_main_module_116 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 115));
+    auto x_main_module_117 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {320}}, 116)));
+    auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {320, 192, 3, 3}}, 117));
+    auto x_main_module_119 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 118)));
+    auto x_main_module_120 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 119));
+    auto x_main_module_121 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 120));
+    auto x_main_module_122 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 121)));
+    auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 122));
+    auto x_main_module_124 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 123)));
+    auto x_main_module_125 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 124));
+    auto x_main_module_126 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 125));
+    auto x_main_module_127 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 126)));
+    auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 127));
+    auto x_main_module_129 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 128)));
+    auto x_main_module_130 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 129));
+    auto x_main_module_131 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 130));
+    auto x_main_module_132 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 131)));
+    auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 132));
+    auto x_main_module_134 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 133)));
+    auto x_main_module_135 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 134));
+    auto x_main_module_136 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 135));
+    auto x_main_module_137 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 136)));
+    auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 137));
+    auto x_main_module_139 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 138)));
+    auto x_main_module_140 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 139));
+    auto x_main_module_141 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 140));
+    auto x_main_module_142 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 141)));
+    auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 142));
+    auto x_main_module_144 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 143)));
+    auto x_main_module_145 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 144));
+    auto x_main_module_146 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 145));
+    auto x_main_module_147 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 146)));
+    auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 147));
+    auto x_main_module_149 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 148)));
+    auto x_main_module_150 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 149));
+    auto x_main_module_151 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 150));
+    auto x_main_module_152 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 151)));
+    auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 152));
+    auto x_main_module_154 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 153)));
+    auto x_main_module_155 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 154));
+    auto x_main_module_156 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 155));
+    auto x_main_module_157 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 156)));
+    auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 7, 1}}, 157));
+    auto x_main_module_159 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 158)));
+    auto x_main_module_160 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 159));
+    auto x_main_module_161 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 160));
+    auto x_main_module_162 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 161)));
+    auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 192, 1, 7}}, 162));
+    auto x_main_module_164 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 163)));
+    auto x_main_module_165 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 164));
+    auto x_main_module_166 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 165));
+    auto x_main_module_167 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 166)));
+    auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 167));
+    auto x_main_module_169 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 168)));
+    auto x_main_module_170 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 169));
+    auto x_main_module_171 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 170));
+    auto x_main_module_172 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 171)));
+    auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 172));
+    auto x_main_module_174 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 173)));
+    auto x_main_module_175 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 174));
+    auto x_main_module_176 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 175));
+    auto x_main_module_177 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 176)));
+    auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 177));
+    auto x_main_module_179 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 178)));
+    auto x_main_module_180 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 179));
+    auto x_main_module_181 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 180));
+    auto x_main_module_182 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 181)));
+    auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 182));
+    auto x_main_module_184 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 183)));
+    auto x_main_module_185 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 184));
+    auto x_main_module_186 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 185));
+    auto x_main_module_187 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 186)));
+    auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 187));
+    auto x_main_module_189 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 188)));
+    auto x_main_module_190 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 189));
+    auto x_main_module_191 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 190));
+    auto x_main_module_192 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 191)));
+    auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 192));
+    auto x_main_module_194 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 193)));
+    auto x_main_module_195 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 194));
+    auto x_main_module_196 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 195));
+    auto x_main_module_197 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 196)));
+    auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 197));
+    auto x_main_module_199 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 198)));
+    auto x_main_module_200 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 199));
+    auto x_main_module_201 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 200));
+    auto x_main_module_202 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 201)));
+    auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 202));
+    auto x_main_module_204 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 203)));
+    auto x_main_module_205 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 204));
+    auto x_main_module_206 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 205));
+    auto x_main_module_207 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 206)));
+    auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 207));
+    auto x_main_module_209 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 208)));
+    auto x_main_module_210 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 209));
+    auto x_main_module_211 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 210));
+    auto x_main_module_212 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 211)));
+    auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 212));
+    auto x_main_module_214 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 213)));
+    auto x_main_module_215 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 214));
+    auto x_main_module_216 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 215));
+    auto x_main_module_217 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 216)));
+    auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 217));
+    auto x_main_module_219 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 218)));
+    auto x_main_module_220 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 219));
+    auto x_main_module_221 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 220));
+    auto x_main_module_222 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 221)));
+    auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 222));
+    auto x_main_module_224 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 223)));
+    auto x_main_module_225 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 224));
+    auto x_main_module_226 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 225));
+    auto x_main_module_227 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 226)));
+    auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 227));
+    auto x_main_module_229 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 228)));
+    auto x_main_module_230 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 229));
+    auto x_main_module_231 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 230));
+    auto x_main_module_232 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 231)));
+    auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 160, 1, 7}}, 232));
+    auto x_main_module_234 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 233)));
+    auto x_main_module_235 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 234));
+    auto x_main_module_236 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 235));
+    auto x_main_module_237 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 236)));
+    auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 237));
+    auto x_main_module_239 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 238)));
+    auto x_main_module_240 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 239));
+    auto x_main_module_241 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 240));
+    auto x_main_module_242 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 241)));
+    auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 242));
+    auto x_main_module_244 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 243)));
+    auto x_main_module_245 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 244));
+    auto x_main_module_246 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 245));
+    auto x_main_module_247 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 246)));
+    auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 7, 1}}, 247));
+    auto x_main_module_249 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 248)));
+    auto x_main_module_250 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 249));
+    auto x_main_module_251 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 250));
+    auto x_main_module_252 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 251)));
+    auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 252));
+    auto x_main_module_254 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 253)));
+    auto x_main_module_255 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 254));
+    auto x_main_module_256 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 255));
+    auto x_main_module_257 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 256)));
+    auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 160, 7, 1}}, 257));
+    auto x_main_module_259 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 258)));
+    auto x_main_module_260 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 259));
+    auto x_main_module_261 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 260));
+    auto x_main_module_262 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 261)));
+    auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 160, 1, 7}}, 262));
+    auto x_main_module_264 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 263)));
+    auto x_main_module_265 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 264));
+    auto x_main_module_266 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 265));
+    auto x_main_module_267 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {160}}, 266)));
+    auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {160, 768, 1, 1}}, 267));
+    auto x_main_module_269 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 268)));
+    auto x_main_module_270 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 269));
+    auto x_main_module_271 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 270));
+    auto x_main_module_272 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 271)));
+    auto x_main_module_273 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 272));
+    auto x_main_module_274 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 273)));
+    auto x_main_module_275 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 274));
+    auto x_main_module_276 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 275));
+    auto x_main_module_277 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 276)));
+    auto x_main_module_278 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 277));
+    auto x_main_module_279 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 278)));
+    auto x_main_module_280 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 279));
+    auto x_main_module_281 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 280));
+    auto x_main_module_282 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 281)));
+    auto x_main_module_283 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 128, 1, 7}}, 282));
+    auto x_main_module_284 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 283)));
+    auto x_main_module_285 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 284));
+    auto x_main_module_286 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 285));
+    auto x_main_module_287 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 286)));
+    auto x_main_module_288 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 287));
+    auto x_main_module_289 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 288)));
+    auto x_main_module_290 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 289));
+    auto x_main_module_291 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 290));
+    auto x_main_module_292 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 291)));
+    auto x_main_module_293 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 292));
+    auto x_main_module_294 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 293)));
+    auto x_main_module_295 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 294));
+    auto x_main_module_296 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 295));
+    auto x_main_module_297 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 296)));
+    auto x_main_module_298 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 7, 1}}, 297));
+    auto x_main_module_299 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 298)));
+    auto x_main_module_300 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 299));
+    auto x_main_module_301 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 300));
+    auto x_main_module_302 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 301)));
+    auto x_main_module_303 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 302));
+    auto x_main_module_304 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 303)));
+    auto x_main_module_305 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 304));
+    auto x_main_module_306 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 305));
+    auto x_main_module_307 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 306)));
+    auto x_main_module_308 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 128, 7, 1}}, 307));
+    auto x_main_module_309 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 308)));
+    auto x_main_module_310 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 309));
+    auto x_main_module_311 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 310));
+    auto x_main_module_312 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 311)));
+    auto x_main_module_313 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 1, 7}}, 312));
+    auto x_main_module_314 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 313)));
+    auto x_main_module_315 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 314));
+    auto x_main_module_316 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 315));
+    auto x_main_module_317 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 316)));
+    auto x_main_module_318 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 768, 1, 1}}, 317));
+    auto x_main_module_319 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 318)));
+    auto x_main_module_320 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 319));
+    auto x_main_module_321 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 320));
+    auto x_main_module_322 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 321)));
+    auto x_main_module_323 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 768, 1, 1}}, 322));
+    auto x_main_module_324 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 323)));
+    auto x_main_module_325 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 324));
+    auto x_main_module_326 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 325));
+    auto x_main_module_327 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 326)));
+    auto x_main_module_328 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 327));
+    auto x_main_module_329 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 328)));
+    auto x_main_module_330 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 329));
+    auto x_main_module_331 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 330));
+    auto x_main_module_332 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 331)));
+    auto x_main_module_333 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 332));
+    auto x_main_module_334 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 333)));
+    auto x_main_module_335 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 334));
+    auto x_main_module_336 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 335));
+    auto x_main_module_337 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 336)));
+    auto x_main_module_338 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 337));
+    auto x_main_module_339 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 338)));
+    auto x_main_module_340 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 339));
+    auto x_main_module_341 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 340));
+    auto x_main_module_342 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {384}}, 341)));
+    auto x_main_module_343 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {384, 288, 3, 3}}, 342));
+    auto x_main_module_344 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 343)));
+    auto x_main_module_345 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 344));
+    auto x_main_module_346 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 345));
+    auto x_main_module_347 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 346)));
+    auto x_main_module_348 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 347));
+    auto x_main_module_349 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 348)));
+    auto x_main_module_350 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 349));
+    auto x_main_module_351 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 350));
+    auto x_main_module_352 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 351)));
+    auto x_main_module_353 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 352));
+    auto x_main_module_354 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 353)));
+    auto x_main_module_355 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 354));
+    auto x_main_module_356 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 355));
+    auto x_main_module_357 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 356)));
+    auto x_main_module_358 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 357));
+    auto x_main_module_359 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 358)));
+    auto x_main_module_360 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 359));
+    auto x_main_module_361 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 360));
+    auto x_main_module_362 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 361)));
+    auto x_main_module_363 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 362));
+    auto x_main_module_364 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 363)));
+    auto x_main_module_365 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 364));
+    auto x_main_module_366 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 365));
+    auto x_main_module_367 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 366)));
+    auto x_main_module_368 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 367));
+    auto x_main_module_369 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 368)));
+    auto x_main_module_370 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 369));
+    auto x_main_module_371 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 370));
+    auto x_main_module_372 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 371)));
+    auto x_main_module_373 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {48, 288, 1, 1}}, 372));
+    auto x_main_module_374 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 373)));
+    auto x_main_module_375 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 374));
+    auto x_main_module_376 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 375));
+    auto x_main_module_377 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 376)));
+    auto x_main_module_378 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 288, 1, 1}}, 377));
+    auto x_main_module_379 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 378)));
+    auto x_main_module_380 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 379));
+    auto x_main_module_381 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 380));
+    auto x_main_module_382 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 381)));
+    auto x_main_module_383 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 382));
+    auto x_main_module_384 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 383)));
+    auto x_main_module_385 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 384));
+    auto x_main_module_386 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 385));
+    auto x_main_module_387 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 386)));
+    auto x_main_module_388 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 387));
+    auto x_main_module_389 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 388)));
+    auto x_main_module_390 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 389));
+    auto x_main_module_391 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 390));
+    auto x_main_module_392 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 391)));
+    auto x_main_module_393 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 392));
+    auto x_main_module_394 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 393)));
+    auto x_main_module_395 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 394));
+    auto x_main_module_396 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 395));
+    auto x_main_module_397 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 396)));
+    auto x_main_module_398 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 397));
+    auto x_main_module_399 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 398)));
+    auto x_main_module_400 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 399));
+    auto x_main_module_401 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 400));
+    auto x_main_module_402 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 401)));
+    auto x_main_module_403 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 402));
+    auto x_main_module_404 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 403)));
+    auto x_main_module_405 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 404));
+    auto x_main_module_406 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 405));
+    auto x_main_module_407 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 406)));
+    auto x_main_module_408 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {48, 256, 1, 1}}, 407));
+    auto x_main_module_409 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 408)));
+    auto x_main_module_410 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 409));
+    auto x_main_module_411 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 410));
+    auto x_main_module_412 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 411)));
+    auto x_main_module_413 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 412));
+    auto x_main_module_414 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 413)));
+    auto x_main_module_415 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 414));
+    auto x_main_module_416 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 415));
+    auto x_main_module_417 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 416)));
+    auto x_main_module_418 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {32, 192, 1, 1}}, 417));
+    auto x_main_module_419 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 418)));
+    auto x_main_module_420 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 419));
+    auto x_main_module_421 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 420));
+    auto x_main_module_422 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 421)));
+    auto x_main_module_423 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 96, 3, 3}}, 422));
+    auto x_main_module_424 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 423)));
+    auto x_main_module_425 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 424));
+    auto x_main_module_426 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 425));
+    auto x_main_module_427 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {96}}, 426)));
+    auto x_main_module_428 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {96, 64, 3, 3}}, 427));
+    auto x_main_module_429 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 428)));
+    auto x_main_module_430 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 429));
+    auto x_main_module_431 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 430));
+    auto x_main_module_432 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 431)));
+    auto x_main_module_433 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 432));
+    auto x_main_module_434 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 433)));
+    auto x_main_module_435 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 434));
+    auto x_main_module_436 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 435));
+    auto x_main_module_437 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 436)));
+    auto x_main_module_438 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 48, 5, 5}}, 437));
+    auto x_main_module_439 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 438)));
+    auto x_main_module_440 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 439));
+    auto x_main_module_441 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 440));
+    auto x_main_module_442 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {48}}, 441)));
+    auto x_main_module_443 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {48, 192, 1, 1}}, 442));
+    auto x_main_module_444 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 443)));
+    auto x_main_module_445 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 444));
+    auto x_main_module_446 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 445));
+    auto x_main_module_447 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 446)));
+    auto x_main_module_448 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 192, 1, 1}}, 447));
+    auto x_main_module_449 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 448)));
+    auto x_main_module_450 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 449));
+    auto x_main_module_451 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 450));
+    auto x_main_module_452 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {192}}, 451)));
+    auto x_main_module_453 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {192, 80, 3, 3}}, 452));
+    auto x_main_module_454 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 453)));
+    auto x_main_module_455 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 454));
+    auto x_main_module_456 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 455));
+    auto x_main_module_457 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {80}}, 456)));
+    auto x_main_module_458 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {80, 64, 1, 1}}, 457));
+    auto x_main_module_459 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 458)));
+    auto x_main_module_460 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 459));
+    auto x_main_module_461 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 460));
+    auto x_main_module_462 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 461)));
+    auto x_main_module_463 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 32, 3, 3}}, 462));
+    auto x_main_module_464 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 463)));
+    auto x_main_module_465 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 464));
+    auto x_main_module_466 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 465));
+    auto x_main_module_467 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 466)));
+    auto x_main_module_468 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {32, 32, 3, 3}}, 467));
+    auto x_main_module_469 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 468)));
+    auto x_main_module_470 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 469));
+    auto x_main_module_471 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 470));
+    auto x_main_module_472 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {32}}, 471)));
+    auto x_main_module_473 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {32, 3, 3, 3}}, 472));
+    auto x_main_module_474 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_0,
+        x_main_module_473); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_475 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_474,
+        x_main_module_472,
+        x_main_module_471,
+        x_main_module_470,
+        x_main_module_469); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_476 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_475);
+    auto x_main_module_477 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_476,
+        x_main_module_468); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_478 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_477,
+        x_main_module_467,
+        x_main_module_466,
+        x_main_module_465,
+        x_main_module_464); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_479 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_478);
+    auto x_main_module_480 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_479,
+        x_main_module_463); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_481 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_480,
+        x_main_module_462,
+        x_main_module_461,
+        x_main_module_460,
+        x_main_module_459); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_482 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_481);
+    auto x_main_module_483 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        x_main_module_482); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_484 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_483,
+        x_main_module_458); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_485 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_484,
+        x_main_module_457,
+        x_main_module_456,
+        x_main_module_455,
+        x_main_module_454); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_486 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_485);
+    auto x_main_module_487 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_486,
+        x_main_module_453); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_488 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_487,
+        x_main_module_452,
+        x_main_module_451,
+        x_main_module_450,
+        x_main_module_449); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_489 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_488);
+    auto x_main_module_490 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        x_main_module_489); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_491 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_490,
+        x_main_module_448); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_492 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_491,
+        x_main_module_447,
+        x_main_module_446,
+        x_main_module_445,
+        x_main_module_444); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_493 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_492);
+    auto x_main_module_494 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_490,
+        x_main_module_443); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_495 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_494,
+        x_main_module_442,
+        x_main_module_441,
+        x_main_module_440,
+        x_main_module_439); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_496 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_495);
+    auto x_main_module_497 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_496,
+        x_main_module_438); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_498 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_497,
+        x_main_module_437,
+        x_main_module_436,
+        x_main_module_435,
+        x_main_module_434); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_499 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_498);
+    auto x_main_module_500 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_490,
+        x_main_module_433); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_501 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_500,
+        x_main_module_432,
+        x_main_module_431,
+        x_main_module_430,
+        x_main_module_429); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_502 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_501);
+    auto x_main_module_503 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_502,
+        x_main_module_428); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_504 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_503,
+        x_main_module_427,
+        x_main_module_426,
+        x_main_module_425,
+        x_main_module_424); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_505 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_504);
+    auto x_main_module_506 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_505,
+        x_main_module_423); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_507 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_506,
+        x_main_module_422,
+        x_main_module_421,
+        x_main_module_420,
+        x_main_module_419); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_508 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_507);
+    auto x_main_module_509 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_490); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_510 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_509,
+        x_main_module_418); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_511 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_510,
+        x_main_module_417,
+        x_main_module_416,
+        x_main_module_415,
+        x_main_module_414); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_512 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_511);
+    auto x_main_module_513 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_493,
+        x_main_module_499,
+        x_main_module_508,
+        x_main_module_512); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_514 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_513,
+        x_main_module_413); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_515 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_514,
+        x_main_module_412,
+        x_main_module_411,
+        x_main_module_410,
+        x_main_module_409); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_516 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_515);
+    auto x_main_module_517 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_513,
+        x_main_module_408); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_518 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_517,
+        x_main_module_407,
+        x_main_module_406,
+        x_main_module_405,
+        x_main_module_404); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_519 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_518);
+    auto x_main_module_520 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_519,
+        x_main_module_403); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_521 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_520,
+        x_main_module_402,
+        x_main_module_401,
+        x_main_module_400,
+        x_main_module_399); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_522 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_521);
+    auto x_main_module_523 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_513,
+        x_main_module_398); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_524 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_523,
+        x_main_module_397,
+        x_main_module_396,
+        x_main_module_395,
+        x_main_module_394); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_525 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_524);
+    auto x_main_module_526 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_525,
+        x_main_module_393); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_527 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_526,
+        x_main_module_392,
+        x_main_module_391,
+        x_main_module_390,
+        x_main_module_389); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_528 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_527);
+    auto x_main_module_529 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_528,
+        x_main_module_388); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_530 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_529,
+        x_main_module_387,
+        x_main_module_386,
+        x_main_module_385,
+        x_main_module_384); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_531 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_530);
+    auto x_main_module_532 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_513); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_533 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_532,
+        x_main_module_383); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_534 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_533,
+        x_main_module_382,
+        x_main_module_381,
+        x_main_module_380,
+        x_main_module_379); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_535 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_534);
+    auto x_main_module_536 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_516,
+        x_main_module_522,
+        x_main_module_531,
+        x_main_module_535); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_537 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_536,
+        x_main_module_378); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_538 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_537,
+        x_main_module_377,
+        x_main_module_376,
+        x_main_module_375,
+        x_main_module_374); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_539 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_538);
+    auto x_main_module_540 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_536,
+        x_main_module_373); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_541 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_540,
+        x_main_module_372,
+        x_main_module_371,
+        x_main_module_370,
+        x_main_module_369); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_542 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_541);
+    auto x_main_module_543 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[2,2,2,2],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_542,
+        x_main_module_368); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_544 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_543,
+        x_main_module_367,
+        x_main_module_366,
+        x_main_module_365,
+        x_main_module_364); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_545 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_544);
+    auto x_main_module_546 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_536,
+        x_main_module_363); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_547 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_546,
+        x_main_module_362,
+        x_main_module_361,
+        x_main_module_360,
+        x_main_module_359); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_548 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_547);
+    auto x_main_module_549 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_548,
+        x_main_module_358); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_550 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_549,
+        x_main_module_357,
+        x_main_module_356,
+        x_main_module_355,
+        x_main_module_354); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_551 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_550);
+    auto x_main_module_552 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_551,
+        x_main_module_353); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_553 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_552,
+        x_main_module_352,
+        x_main_module_351,
+        x_main_module_350,
+        x_main_module_349); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_554 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_553);
+    auto x_main_module_555 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_536); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_556 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_555,
+        x_main_module_348); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_557 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_556,
+        x_main_module_347,
+        x_main_module_346,
+        x_main_module_345,
+        x_main_module_344); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_558 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_557);
+    auto x_main_module_559 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_539,
+        x_main_module_545,
+        x_main_module_554,
+        x_main_module_558); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_560 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_559,
+        x_main_module_343); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_561 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_560,
+        x_main_module_342,
+        x_main_module_341,
+        x_main_module_340,
+        x_main_module_339); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_562 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_561);
+    auto x_main_module_563 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_559,
+        x_main_module_338); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_564 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_563,
+        x_main_module_337,
+        x_main_module_336,
+        x_main_module_335,
+        x_main_module_334); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_565 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_564);
+    auto x_main_module_566 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_565,
+        x_main_module_333); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_567 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_566,
+        x_main_module_332,
+        x_main_module_331,
+        x_main_module_330,
+        x_main_module_329); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_568 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_567);
+    auto x_main_module_569 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_568,
+        x_main_module_328); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_570 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_569,
+        x_main_module_327,
+        x_main_module_326,
+        x_main_module_325,
+        x_main_module_324); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_571 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_570);
+    auto x_main_module_572 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        x_main_module_559); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_573 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_562,
+        x_main_module_571,
+        x_main_module_572); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_574 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_573,
+        x_main_module_323); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_575 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_574,
+        x_main_module_322,
+        x_main_module_321,
+        x_main_module_320,
+        x_main_module_319); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_576 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_575);
+    auto x_main_module_577 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_573,
+        x_main_module_318); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_578 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_577,
+        x_main_module_317,
+        x_main_module_316,
+        x_main_module_315,
+        x_main_module_314); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_579 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_578);
+    auto x_main_module_580 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_579,
+        x_main_module_313); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_581 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_580,
+        x_main_module_312,
+        x_main_module_311,
+        x_main_module_310,
+        x_main_module_309); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_582 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_581);
+    auto x_main_module_583 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_582,
+        x_main_module_308); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_584 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_583,
+        x_main_module_307,
+        x_main_module_306,
+        x_main_module_305,
+        x_main_module_304); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_585 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_584);
+    auto x_main_module_586 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_573,
+        x_main_module_303); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_587 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_586,
+        x_main_module_302,
+        x_main_module_301,
+        x_main_module_300,
+        x_main_module_299); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_588 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_587);
+    auto x_main_module_589 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_588,
+        x_main_module_298); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_590 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_589,
+        x_main_module_297,
+        x_main_module_296,
+        x_main_module_295,
+        x_main_module_294); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_591 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_590);
+    auto x_main_module_592 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_591,
+        x_main_module_293); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_593 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_592,
+        x_main_module_292,
+        x_main_module_291,
+        x_main_module_290,
+        x_main_module_289); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_594 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_593);
+    auto x_main_module_595 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_594,
+        x_main_module_288); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_596 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_595,
+        x_main_module_287,
+        x_main_module_286,
+        x_main_module_285,
+        x_main_module_284); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_597 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_596);
+    auto x_main_module_598 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_597,
+        x_main_module_283); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_599 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_598,
+        x_main_module_282,
+        x_main_module_281,
+        x_main_module_280,
+        x_main_module_279); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_600 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_599);
+    auto x_main_module_601 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_573); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_602 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_601,
+        x_main_module_278); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_603 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_602,
+        x_main_module_277,
+        x_main_module_276,
+        x_main_module_275,
+        x_main_module_274); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_604 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_603);
+    auto x_main_module_605 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_576,
+        x_main_module_585,
+        x_main_module_600,
+        x_main_module_604); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_606 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_605,
+        x_main_module_273); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_607 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_606,
+        x_main_module_272,
+        x_main_module_271,
+        x_main_module_270,
+        x_main_module_269); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_608 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_607);
+    auto x_main_module_609 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_605,
+        x_main_module_268); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_610 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_609,
+        x_main_module_267,
+        x_main_module_266,
+        x_main_module_265,
+        x_main_module_264); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_611 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_610);
+    auto x_main_module_612 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_611,
+        x_main_module_263); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_613 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_612,
+        x_main_module_262,
+        x_main_module_261,
+        x_main_module_260,
+        x_main_module_259); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_614 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_613);
+    auto x_main_module_615 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_614,
+        x_main_module_258); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_616 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_615,
+        x_main_module_257,
+        x_main_module_256,
+        x_main_module_255,
+        x_main_module_254); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_617 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_616);
+    auto x_main_module_618 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_605,
+        x_main_module_253); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_619 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_618,
+        x_main_module_252,
+        x_main_module_251,
+        x_main_module_250,
+        x_main_module_249); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_620 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_619);
+    auto x_main_module_621 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_620,
+        x_main_module_248); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_622 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_621,
+        x_main_module_247,
+        x_main_module_246,
+        x_main_module_245,
+        x_main_module_244); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_623 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_622);
+    auto x_main_module_624 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_623,
+        x_main_module_243); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_625 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_624,
+        x_main_module_242,
+        x_main_module_241,
+        x_main_module_240,
+        x_main_module_239); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_626 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_625);
+    auto x_main_module_627 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_626,
+        x_main_module_238); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_628 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_627,
+        x_main_module_237,
+        x_main_module_236,
+        x_main_module_235,
+        x_main_module_234); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_629 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_628);
+    auto x_main_module_630 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_629,
+        x_main_module_233); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_631 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_630,
+        x_main_module_232,
+        x_main_module_231,
+        x_main_module_230,
+        x_main_module_229); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_632 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_631);
+    auto x_main_module_633 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_605); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_634 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_633,
+        x_main_module_228); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_635 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_634,
+        x_main_module_227,
+        x_main_module_226,
+        x_main_module_225,
+        x_main_module_224); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_636 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_635);
+    auto x_main_module_637 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_608,
+        x_main_module_617,
+        x_main_module_632,
+        x_main_module_636); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_638 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_637,
+        x_main_module_223); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_639 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_638,
+        x_main_module_222,
+        x_main_module_221,
+        x_main_module_220,
+        x_main_module_219); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_640 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_639);
+    auto x_main_module_641 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_637,
+        x_main_module_218); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_642 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_641,
+        x_main_module_217,
+        x_main_module_216,
+        x_main_module_215,
+        x_main_module_214); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_643 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_642);
+    auto x_main_module_644 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_643,
+        x_main_module_213); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_645 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_644,
+        x_main_module_212,
+        x_main_module_211,
+        x_main_module_210,
+        x_main_module_209); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_646 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_645);
+    auto x_main_module_647 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_646,
+        x_main_module_208); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_648 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_647,
+        x_main_module_207,
+        x_main_module_206,
+        x_main_module_205,
+        x_main_module_204); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_649 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_648);
+    auto x_main_module_650 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_637,
+        x_main_module_203); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_651 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_650,
+        x_main_module_202,
+        x_main_module_201,
+        x_main_module_200,
+        x_main_module_199); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_652 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_651);
+    auto x_main_module_653 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_652,
+        x_main_module_198); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_654 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_653,
+        x_main_module_197,
+        x_main_module_196,
+        x_main_module_195,
+        x_main_module_194); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_655 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_654);
+    auto x_main_module_656 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_655,
+        x_main_module_193); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_657 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_656,
+        x_main_module_192,
+        x_main_module_191,
+        x_main_module_190,
+        x_main_module_189); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_658 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_657);
+    auto x_main_module_659 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_658,
+        x_main_module_188); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_660 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_659,
+        x_main_module_187,
+        x_main_module_186,
+        x_main_module_185,
+        x_main_module_184); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_661 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_660);
+    auto x_main_module_662 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_661,
+        x_main_module_183); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_663 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_662,
+        x_main_module_182,
+        x_main_module_181,
+        x_main_module_180,
+        x_main_module_179); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_664 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_663);
+    auto x_main_module_665 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_637); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_666 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_665,
+        x_main_module_178); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_667 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_666,
+        x_main_module_177,
+        x_main_module_176,
+        x_main_module_175,
+        x_main_module_174); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_668 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_667);
+    auto x_main_module_669 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_640,
+        x_main_module_649,
+        x_main_module_664,
+        x_main_module_668); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_670 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_669,
+        x_main_module_173); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_671 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_670,
+        x_main_module_172,
+        x_main_module_171,
+        x_main_module_170,
+        x_main_module_169); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_672 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_671);
+    auto x_main_module_673 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_669,
+        x_main_module_168); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_674 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_673,
+        x_main_module_167,
+        x_main_module_166,
+        x_main_module_165,
+        x_main_module_164); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_675 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_674);
+    auto x_main_module_676 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_675,
+        x_main_module_163); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_677 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_676,
+        x_main_module_162,
+        x_main_module_161,
+        x_main_module_160,
+        x_main_module_159); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_678 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_677);
+    auto x_main_module_679 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_678,
+        x_main_module_158); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_680 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_679,
+        x_main_module_157,
+        x_main_module_156,
+        x_main_module_155,
+        x_main_module_154); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_681 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_680);
+    auto x_main_module_682 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_669,
+        x_main_module_153); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_683 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_682,
+        x_main_module_152,
+        x_main_module_151,
+        x_main_module_150,
+        x_main_module_149); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_684 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_683);
+    auto x_main_module_685 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_684,
+        x_main_module_148); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_686 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_685,
+        x_main_module_147,
+        x_main_module_146,
+        x_main_module_145,
+        x_main_module_144); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_687 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_686);
+    auto x_main_module_688 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_687,
+        x_main_module_143); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_689 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_688,
+        x_main_module_142,
+        x_main_module_141,
+        x_main_module_140,
+        x_main_module_139); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_690 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_689);
+    auto x_main_module_691 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_690,
+        x_main_module_138); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_692 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_691,
+        x_main_module_137,
+        x_main_module_136,
+        x_main_module_135,
+        x_main_module_134); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_693 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_692);
+    auto x_main_module_694 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_693,
+        x_main_module_133); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_695 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_694,
+        x_main_module_132,
+        x_main_module_131,
+        x_main_module_130,
+        x_main_module_129); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_696 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_695);
+    auto x_main_module_697 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_669); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_698 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_697,
+        x_main_module_128); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_699 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_698,
+        x_main_module_127,
+        x_main_module_126,
+        x_main_module_125,
+        x_main_module_124); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_700 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_699);
+    auto x_main_module_701 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_672,
+        x_main_module_681,
+        x_main_module_696,
+        x_main_module_700); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_702 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_701,
+        x_main_module_123); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_703 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_702,
+        x_main_module_122,
+        x_main_module_121,
+        x_main_module_120,
+        x_main_module_119); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_704 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_703);
+    auto x_main_module_705 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_704,
+        x_main_module_118); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_706 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_705,
+        x_main_module_117,
+        x_main_module_116,
+        x_main_module_115,
+        x_main_module_114); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_707 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_706);
+    auto x_main_module_708 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_701,
+        x_main_module_113); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_709 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_708,
+        x_main_module_112,
+        x_main_module_111,
+        x_main_module_110,
+        x_main_module_109); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_710 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_709);
+    auto x_main_module_711 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,3,0,3],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_710,
+        x_main_module_108); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_712 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_711,
+        x_main_module_107,
+        x_main_module_106,
+        x_main_module_105,
+        x_main_module_104); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_713 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_712);
+    auto x_main_module_714 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,0,3,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_713,
+        x_main_module_103); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_715 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_714,
+        x_main_module_102,
+        x_main_module_101,
+        x_main_module_100,
+        x_main_module_99); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_716 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_715);
+    auto x_main_module_717 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_716,
+        x_main_module_98); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_718 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_717,
+        x_main_module_97,
+        x_main_module_96,
+        x_main_module_95,
+        x_main_module_94); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_719 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_718);
+    auto x_main_module_720 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[0,0,0,0],\"stride\":[2,2]}")),
+        x_main_module_701); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_721 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_707,
+        x_main_module_719,
+        x_main_module_720); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_722 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_721,
+        x_main_module_93); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_723 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_722,
+        x_main_module_92,
+        x_main_module_91,
+        x_main_module_90,
+        x_main_module_89); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_724 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_723);
+    auto x_main_module_725 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_721,
+        x_main_module_88); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_726 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_725,
+        x_main_module_87,
+        x_main_module_86,
+        x_main_module_85,
+        x_main_module_84); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_727 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_726);
+    auto x_main_module_728 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_727,
+        x_main_module_83); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_729 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_728,
+        x_main_module_82,
+        x_main_module_81,
+        x_main_module_80,
+        x_main_module_79); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_730 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_729);
+    auto x_main_module_731 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_727,
+        x_main_module_78); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_732 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_731,
+        x_main_module_77,
+        x_main_module_76,
+        x_main_module_75,
+        x_main_module_74); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_733 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_732);
+    auto x_main_module_734 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_730,
+        x_main_module_733); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_735 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_721,
+        x_main_module_73); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_736 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_735,
+        x_main_module_72,
+        x_main_module_71,
+        x_main_module_70,
+        x_main_module_69); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_737 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_736);
+    auto x_main_module_738 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_737,
+        x_main_module_68); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_739 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_738,
+        x_main_module_67,
+        x_main_module_66,
+        x_main_module_65,
+        x_main_module_64); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_740 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_739);
+    auto x_main_module_741 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_740,
+        x_main_module_63); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_742 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_741,
+        x_main_module_62,
+        x_main_module_61,
+        x_main_module_60,
+        x_main_module_59); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_743 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_742);
+    auto x_main_module_744 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_740,
+        x_main_module_58); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_745 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_744,
+        x_main_module_57,
+        x_main_module_56,
+        x_main_module_55,
+        x_main_module_54); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_746 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_745);
+    auto x_main_module_747 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_743,
+        x_main_module_746); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_748 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_721); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_749 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_748,
+        x_main_module_53); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_750 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_749,
+        x_main_module_52,
+        x_main_module_51,
+        x_main_module_50,
+        x_main_module_49); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_751 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_750);
+    auto x_main_module_752 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_724,
+        x_main_module_734,
+        x_main_module_747,
+        x_main_module_751); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_753 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_752,
+        x_main_module_48); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_754 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_753,
+        x_main_module_47,
+        x_main_module_46,
+        x_main_module_45,
+        x_main_module_44); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_755 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_754);
+    auto x_main_module_756 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_752,
+        x_main_module_43); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_757 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_756,
+        x_main_module_42,
+        x_main_module_41,
+        x_main_module_40,
+        x_main_module_39); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_758 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_757);
+    auto x_main_module_759 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_758,
+        x_main_module_38); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_760 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_759,
+        x_main_module_37,
+        x_main_module_36,
+        x_main_module_35,
+        x_main_module_34); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_761 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_760);
+    auto x_main_module_762 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_758,
+        x_main_module_33); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_763 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_762,
+        x_main_module_32,
+        x_main_module_31,
+        x_main_module_30,
+        x_main_module_29); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_764 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_763);
+    auto x_main_module_765 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_761,
+        x_main_module_764); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_766 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_752,
+        x_main_module_28); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_767 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_766,
+        x_main_module_27,
+        x_main_module_26,
+        x_main_module_25,
+        x_main_module_24); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_768 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_767);
+    auto x_main_module_769 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_768,
+        x_main_module_23); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_770 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_769,
+        x_main_module_22,
+        x_main_module_21,
+        x_main_module_20,
+        x_main_module_19); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_771 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_770);
+    auto x_main_module_772 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,1,0,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_771,
+        x_main_module_18); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_773 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_772,
+        x_main_module_17,
+        x_main_module_16,
+        x_main_module_15,
+        x_main_module_14); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_774 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_773);
+    auto x_main_module_775 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,0,1,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_771,
+        x_main_module_13); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_776 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_775,
+        x_main_module_12,
+        x_main_module_11,
+        x_main_module_10,
+        x_main_module_9); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_777 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_776);
+    auto x_main_module_778 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_774,
+        x_main_module_777); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_779 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[1,1,1,1],\"stride\":[1,1]}")),
+        x_main_module_752); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_780 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_779,
+        x_main_module_8); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_781 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":0.0010000000474974513,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_780,
+        x_main_module_7,
+        x_main_module_6,
+        x_main_module_5,
+        x_main_module_4); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_782 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_781);
+    auto x_main_module_783 = mmain->add_instruction(
+        migraphx::make_op("concat", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_755,
+        x_main_module_765,
+        x_main_module_778,
+        x_main_module_782); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_784 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[8,8],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[0,0,0,0],\"stride\":[8,8]}")),
+        x_main_module_783); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_785 =
+        mmain->add_instruction(migraphx::make_op("identity"), x_main_module_784);
+    auto x_main_module_786 = mmain->add_instruction(
+        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_785); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_787 = mmain->add_instruction(
+        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
+        x_main_module_3); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_788 =
+        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_786, x_main_module_787);
+    auto x_main_module_789 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        x_main_module_2); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_790 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        x_main_module_0); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_791 =
+        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_789, x_main_module_790);
+    auto x_main_module_792 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_788, x_main_module_791);
+    mmain->add_return({x_main_module_792});
 
     return p;
 }

--- a/src/driver/resnet50.cpp
+++ b/src/driver/resnet50.cpp
@@ -33,458 +33,1558 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program resnet50(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-migraphx::module_ref mmain = p.get_main_module();
-auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
-auto x_main_module_2 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
-auto x_main_module_3 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
-auto x_main_module_4 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 3)));
-auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 4));
-auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 5));
-auto x_main_module_7 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 6)));
-auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 7));
-auto x_main_module_9 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 8)));
-auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 9));
-auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 10));
-auto x_main_module_12 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 11)));
-auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 12));
-auto x_main_module_14 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 13)));
-auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 14));
-auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 15));
-auto x_main_module_17 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 16)));
-auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 17));
-auto x_main_module_19 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 18)));
-auto x_main_module_20 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 19));
-auto x_main_module_21 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 20));
-auto x_main_module_22 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 21)));
-auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 22));
-auto x_main_module_24 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 23)));
-auto x_main_module_25 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 24));
-auto x_main_module_26 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 25));
-auto x_main_module_27 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 26)));
-auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 27));
-auto x_main_module_29 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 28)));
-auto x_main_module_30 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 29));
-auto x_main_module_31 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 30));
-auto x_main_module_32 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 31)));
-auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 32));
-auto x_main_module_34 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 33)));
-auto x_main_module_35 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 34));
-auto x_main_module_36 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 35));
-auto x_main_module_37 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 36)));
-auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 1024, 1, 1}}, 37));
-auto x_main_module_39 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 38)));
-auto x_main_module_40 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 39));
-auto x_main_module_41 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 40));
-auto x_main_module_42 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 41)));
-auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 42));
-auto x_main_module_44 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 43)));
-auto x_main_module_45 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 44));
-auto x_main_module_46 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 45));
-auto x_main_module_47 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 46)));
-auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 47));
-auto x_main_module_49 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 48)));
-auto x_main_module_50 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 49));
-auto x_main_module_51 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 50));
-auto x_main_module_52 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 51)));
-auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 1024, 1, 1}}, 52));
-auto x_main_module_54 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 53)));
-auto x_main_module_55 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 54));
-auto x_main_module_56 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 55));
-auto x_main_module_57 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 56));
-auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 57));
-auto x_main_module_59 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 58)));
-auto x_main_module_60 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 59));
-auto x_main_module_61 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 60));
-auto x_main_module_62 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 61)));
-auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 62));
-auto x_main_module_64 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 63)));
-auto x_main_module_65 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 64));
-auto x_main_module_66 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 65));
-auto x_main_module_67 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 66)));
-auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 67));
-auto x_main_module_69 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 68)));
-auto x_main_module_70 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 69));
-auto x_main_module_71 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 70));
-auto x_main_module_72 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 71));
-auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 72));
-auto x_main_module_74 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 73)));
-auto x_main_module_75 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 74));
-auto x_main_module_76 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 75));
-auto x_main_module_77 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 76)));
-auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 77));
-auto x_main_module_79 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 78)));
-auto x_main_module_80 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 79));
-auto x_main_module_81 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 80));
-auto x_main_module_82 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 81)));
-auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 82));
-auto x_main_module_84 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 83)));
-auto x_main_module_85 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 84));
-auto x_main_module_86 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 85));
-auto x_main_module_87 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 86));
-auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 87));
-auto x_main_module_89 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 88)));
-auto x_main_module_90 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 89));
-auto x_main_module_91 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 90));
-auto x_main_module_92 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 91)));
-auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 92));
-auto x_main_module_94 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 93)));
-auto x_main_module_95 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 94));
-auto x_main_module_96 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 95));
-auto x_main_module_97 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 96)));
-auto x_main_module_98 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 97));
-auto x_main_module_99 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 98)));
-auto x_main_module_100 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 99));
-auto x_main_module_101 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 100));
-auto x_main_module_102 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 101));
-auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 102));
-auto x_main_module_104 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 103)));
-auto x_main_module_105 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 104));
-auto x_main_module_106 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 105));
-auto x_main_module_107 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 106)));
-auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 107));
-auto x_main_module_109 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 108)));
-auto x_main_module_110 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 109));
-auto x_main_module_111 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 110));
-auto x_main_module_112 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 111)));
-auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 112));
-auto x_main_module_114 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 113)));
-auto x_main_module_115 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 114));
-auto x_main_module_116 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 115));
-auto x_main_module_117 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 116));
-auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 117));
-auto x_main_module_119 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 118)));
-auto x_main_module_120 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 119));
-auto x_main_module_121 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 120));
-auto x_main_module_122 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 121)));
-auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 122));
-auto x_main_module_124 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 123)));
-auto x_main_module_125 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 124));
-auto x_main_module_126 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 125));
-auto x_main_module_127 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 126)));
-auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 127));
-auto x_main_module_129 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 128)));
-auto x_main_module_130 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 129));
-auto x_main_module_131 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 130));
-auto x_main_module_132 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 131));
-auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 512, 1, 1}}, 132));
-auto x_main_module_134 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 133)));
-auto x_main_module_135 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 134));
-auto x_main_module_136 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 135));
-auto x_main_module_137 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 136));
-auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 137));
-auto x_main_module_139 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 138)));
-auto x_main_module_140 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 139));
-auto x_main_module_141 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 140));
-auto x_main_module_142 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 141)));
-auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 142));
-auto x_main_module_144 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 143)));
-auto x_main_module_145 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 144));
-auto x_main_module_146 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 145));
-auto x_main_module_147 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 146)));
-auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 512, 1, 1}}, 147));
-auto x_main_module_149 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 148)));
-auto x_main_module_150 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 149));
-auto x_main_module_151 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 150));
-auto x_main_module_152 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 151));
-auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 152));
-auto x_main_module_154 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 153)));
-auto x_main_module_155 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 154));
-auto x_main_module_156 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 155));
-auto x_main_module_157 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 156)));
-auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 157));
-auto x_main_module_159 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 158)));
-auto x_main_module_160 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 159));
-auto x_main_module_161 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 160));
-auto x_main_module_162 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 161)));
-auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 162));
-auto x_main_module_164 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 163)));
-auto x_main_module_165 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 164));
-auto x_main_module_166 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 165));
-auto x_main_module_167 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 166));
-auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 167));
-auto x_main_module_169 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 168)));
-auto x_main_module_170 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 169));
-auto x_main_module_171 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 170));
-auto x_main_module_172 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 171)));
-auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 172));
-auto x_main_module_174 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 173)));
-auto x_main_module_175 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 174));
-auto x_main_module_176 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 175));
-auto x_main_module_177 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 176)));
-auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 177));
-auto x_main_module_179 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 178)));
-auto x_main_module_180 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 179));
-auto x_main_module_181 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 180));
-auto x_main_module_182 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 181));
-auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 182));
-auto x_main_module_184 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 183)));
-auto x_main_module_185 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 184));
-auto x_main_module_186 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 185));
-auto x_main_module_187 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 186)));
-auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 187));
-auto x_main_module_189 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 188)));
-auto x_main_module_190 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 189));
-auto x_main_module_191 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 190));
-auto x_main_module_192 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 191)));
-auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 192));
-auto x_main_module_194 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 193)));
-auto x_main_module_195 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 194));
-auto x_main_module_196 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 195));
-auto x_main_module_197 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 196));
-auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 256, 1, 1}}, 197));
-auto x_main_module_199 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 198)));
-auto x_main_module_200 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 199));
-auto x_main_module_201 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 200));
-auto x_main_module_202 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 201));
-auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 202));
-auto x_main_module_204 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 203)));
-auto x_main_module_205 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 204));
-auto x_main_module_206 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 205));
-auto x_main_module_207 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 206)));
-auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 207));
-auto x_main_module_209 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 208)));
-auto x_main_module_210 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 209));
-auto x_main_module_211 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 210));
-auto x_main_module_212 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 211)));
-auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 256, 1, 1}}, 212));
-auto x_main_module_214 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 213)));
-auto x_main_module_215 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 214));
-auto x_main_module_216 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 215));
-auto x_main_module_217 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 216));
-auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 217));
-auto x_main_module_219 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 218)));
-auto x_main_module_220 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 219));
-auto x_main_module_221 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 220));
-auto x_main_module_222 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 221)));
-auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 222));
-auto x_main_module_224 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 223)));
-auto x_main_module_225 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 224));
-auto x_main_module_226 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 225));
-auto x_main_module_227 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 226)));
-auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 227));
-auto x_main_module_229 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 228)));
-auto x_main_module_230 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 229));
-auto x_main_module_231 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 230));
-auto x_main_module_232 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 231));
-auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 232));
-auto x_main_module_234 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 233)));
-auto x_main_module_235 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 234));
-auto x_main_module_236 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 235));
-auto x_main_module_237 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 236)));
-auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 237));
-auto x_main_module_239 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 238)));
-auto x_main_module_240 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 239));
-auto x_main_module_241 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 240));
-auto x_main_module_242 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 241)));
-auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 242));
-auto x_main_module_244 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 243)));
-auto x_main_module_245 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 244));
-auto x_main_module_246 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 245));
-auto x_main_module_247 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 246));
-auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 247));
-auto x_main_module_249 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 248)));
-auto x_main_module_250 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 249));
-auto x_main_module_251 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 250));
-auto x_main_module_252 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 251));
-auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 252));
-auto x_main_module_254 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 253)));
-auto x_main_module_255 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 254));
-auto x_main_module_256 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 255));
-auto x_main_module_257 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 256)));
-auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 257));
-auto x_main_module_259 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 258)));
-auto x_main_module_260 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 259));
-auto x_main_module_261 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 260));
-auto x_main_module_262 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 261)));
-auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 1, 1}}, 262));
-auto x_main_module_264 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 263)));
-auto x_main_module_265 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 264));
-auto x_main_module_266 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 265));
-auto x_main_module_267 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 266)));
-auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 3, 7, 7}}, 267));
-auto x_main_module_269 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,3,3,3],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_0, x_main_module_268); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_270 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_269, x_main_module_267, x_main_module_266, x_main_module_265, x_main_module_264); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_271 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_270);
-auto x_main_module_272 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[1,1,1,1],\"stride\":[2,2]}")), x_main_module_271); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_273 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_272, x_main_module_263); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_274 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_273, x_main_module_262, x_main_module_261, x_main_module_260, x_main_module_259); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_275 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_274);
-auto x_main_module_276 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_275, x_main_module_258); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_277 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_276, x_main_module_257, x_main_module_256, x_main_module_255, x_main_module_254); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_278 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_277);
-auto x_main_module_279 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_278, x_main_module_253); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_280 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_279, x_main_module_252, x_main_module_251, x_main_module_250, x_main_module_249); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_281 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_272, x_main_module_248); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_282 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_281, x_main_module_247, x_main_module_246, x_main_module_245, x_main_module_244); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_283 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_280, x_main_module_282);
-auto x_main_module_284 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_283);
-auto x_main_module_285 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_284, x_main_module_243); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_286 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_285, x_main_module_242, x_main_module_241, x_main_module_240, x_main_module_239); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_287 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_286);
-auto x_main_module_288 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_287, x_main_module_238); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_289 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_288, x_main_module_237, x_main_module_236, x_main_module_235, x_main_module_234); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_290 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_289);
-auto x_main_module_291 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_290, x_main_module_233); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_292 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_291, x_main_module_232, x_main_module_231, x_main_module_230, x_main_module_229); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_293 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_292, x_main_module_284);
-auto x_main_module_294 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_293);
-auto x_main_module_295 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_294, x_main_module_228); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_296 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_295, x_main_module_227, x_main_module_226, x_main_module_225, x_main_module_224); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_297 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_296);
-auto x_main_module_298 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_297, x_main_module_223); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_299 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_298, x_main_module_222, x_main_module_221, x_main_module_220, x_main_module_219); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_300 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_299);
-auto x_main_module_301 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_300, x_main_module_218); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_302 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_301, x_main_module_217, x_main_module_216, x_main_module_215, x_main_module_214); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_303 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_302, x_main_module_294);
-auto x_main_module_304 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_303);
-auto x_main_module_305 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_304, x_main_module_213); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_306 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_305, x_main_module_212, x_main_module_211, x_main_module_210, x_main_module_209); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_307 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_306);
-auto x_main_module_308 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_307, x_main_module_208); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_309 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_308, x_main_module_207, x_main_module_206, x_main_module_205, x_main_module_204); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_310 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_309);
-auto x_main_module_311 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_310, x_main_module_203); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_312 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_311, x_main_module_202, x_main_module_201, x_main_module_200, x_main_module_199); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_313 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_304, x_main_module_198); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_314 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_313, x_main_module_197, x_main_module_196, x_main_module_195, x_main_module_194); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_315 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_312, x_main_module_314);
-auto x_main_module_316 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_315);
-auto x_main_module_317 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_316, x_main_module_193); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_318 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_317, x_main_module_192, x_main_module_191, x_main_module_190, x_main_module_189); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_319 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_318);
-auto x_main_module_320 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_319, x_main_module_188); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_321 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_320, x_main_module_187, x_main_module_186, x_main_module_185, x_main_module_184); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_322 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_321);
-auto x_main_module_323 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_322, x_main_module_183); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_324 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_323, x_main_module_182, x_main_module_181, x_main_module_180, x_main_module_179); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_325 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_324, x_main_module_316);
-auto x_main_module_326 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_325);
-auto x_main_module_327 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_326, x_main_module_178); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_328 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_327, x_main_module_177, x_main_module_176, x_main_module_175, x_main_module_174); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_329 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_328);
-auto x_main_module_330 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_329, x_main_module_173); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_331 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_330, x_main_module_172, x_main_module_171, x_main_module_170, x_main_module_169); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_332 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_331);
-auto x_main_module_333 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_332, x_main_module_168); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_334 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_333, x_main_module_167, x_main_module_166, x_main_module_165, x_main_module_164); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_335 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_334, x_main_module_326);
-auto x_main_module_336 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_335);
-auto x_main_module_337 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_336, x_main_module_163); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_338 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_337, x_main_module_162, x_main_module_161, x_main_module_160, x_main_module_159); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_339 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_338);
-auto x_main_module_340 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_339, x_main_module_158); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_341 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_340, x_main_module_157, x_main_module_156, x_main_module_155, x_main_module_154); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_342 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_341);
-auto x_main_module_343 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_342, x_main_module_153); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_344 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_343, x_main_module_152, x_main_module_151, x_main_module_150, x_main_module_149); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_345 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_344, x_main_module_336);
-auto x_main_module_346 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_345);
-auto x_main_module_347 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_346, x_main_module_148); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_348 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_347, x_main_module_147, x_main_module_146, x_main_module_145, x_main_module_144); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_349 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_348);
-auto x_main_module_350 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_349, x_main_module_143); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_351 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_350, x_main_module_142, x_main_module_141, x_main_module_140, x_main_module_139); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_352 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_351);
-auto x_main_module_353 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_352, x_main_module_138); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_354 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_353, x_main_module_137, x_main_module_136, x_main_module_135, x_main_module_134); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_355 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_346, x_main_module_133); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_356 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_355, x_main_module_132, x_main_module_131, x_main_module_130, x_main_module_129); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_357 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_354, x_main_module_356);
-auto x_main_module_358 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_357);
-auto x_main_module_359 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_358, x_main_module_128); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_360 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_359, x_main_module_127, x_main_module_126, x_main_module_125, x_main_module_124); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_361 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_360);
-auto x_main_module_362 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_361, x_main_module_123); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_363 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_362, x_main_module_122, x_main_module_121, x_main_module_120, x_main_module_119); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_364 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_363);
-auto x_main_module_365 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_364, x_main_module_118); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_366 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_365, x_main_module_117, x_main_module_116, x_main_module_115, x_main_module_114); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_367 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_366, x_main_module_358);
-auto x_main_module_368 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_367);
-auto x_main_module_369 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_368, x_main_module_113); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_370 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_369, x_main_module_112, x_main_module_111, x_main_module_110, x_main_module_109); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_371 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_370);
-auto x_main_module_372 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_371, x_main_module_108); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_373 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_372, x_main_module_107, x_main_module_106, x_main_module_105, x_main_module_104); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_374 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_373);
-auto x_main_module_375 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_374, x_main_module_103); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_376 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_375, x_main_module_102, x_main_module_101, x_main_module_100, x_main_module_99); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_377 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_376, x_main_module_368);
-auto x_main_module_378 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_377);
-auto x_main_module_379 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_378, x_main_module_98); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_380 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_379, x_main_module_97, x_main_module_96, x_main_module_95, x_main_module_94); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_381 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_380);
-auto x_main_module_382 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_381, x_main_module_93); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_383 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_382, x_main_module_92, x_main_module_91, x_main_module_90, x_main_module_89); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_384 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_383);
-auto x_main_module_385 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_384, x_main_module_88); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_386 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_385, x_main_module_87, x_main_module_86, x_main_module_85, x_main_module_84); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_387 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_386, x_main_module_378);
-auto x_main_module_388 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_387);
-auto x_main_module_389 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_388, x_main_module_83); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_390 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_389, x_main_module_82, x_main_module_81, x_main_module_80, x_main_module_79); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_391 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_390);
-auto x_main_module_392 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_391, x_main_module_78); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_393 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_392, x_main_module_77, x_main_module_76, x_main_module_75, x_main_module_74); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_394 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_393);
-auto x_main_module_395 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_394, x_main_module_73); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_396 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_395, x_main_module_72, x_main_module_71, x_main_module_70, x_main_module_69); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_397 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_396, x_main_module_388);
-auto x_main_module_398 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_397);
-auto x_main_module_399 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_398, x_main_module_68); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_400 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_399, x_main_module_67, x_main_module_66, x_main_module_65, x_main_module_64); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_401 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_400);
-auto x_main_module_402 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_401, x_main_module_63); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_403 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_402, x_main_module_62, x_main_module_61, x_main_module_60, x_main_module_59); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_404 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_403);
-auto x_main_module_405 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_404, x_main_module_58); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_406 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_405, x_main_module_57, x_main_module_56, x_main_module_55, x_main_module_54); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_407 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_406, x_main_module_398);
-auto x_main_module_408 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_407);
-auto x_main_module_409 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_408, x_main_module_53); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_410 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_409, x_main_module_52, x_main_module_51, x_main_module_50, x_main_module_49); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_411 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_410);
-auto x_main_module_412 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_411, x_main_module_48); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_413 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_412, x_main_module_47, x_main_module_46, x_main_module_45, x_main_module_44); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_414 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_413);
-auto x_main_module_415 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_414, x_main_module_43); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_416 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_415, x_main_module_42, x_main_module_41, x_main_module_40, x_main_module_39); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_417 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_408, x_main_module_38); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_418 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_417, x_main_module_37, x_main_module_36, x_main_module_35, x_main_module_34); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_419 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_416, x_main_module_418);
-auto x_main_module_420 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_419);
-auto x_main_module_421 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_420, x_main_module_33); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_422 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_421, x_main_module_32, x_main_module_31, x_main_module_30, x_main_module_29); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_423 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_422);
-auto x_main_module_424 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_423, x_main_module_28); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_425 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_424, x_main_module_27, x_main_module_26, x_main_module_25, x_main_module_24); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_426 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_425);
-auto x_main_module_427 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_426, x_main_module_23); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_428 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_427, x_main_module_22, x_main_module_21, x_main_module_20, x_main_module_19); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_429 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_428, x_main_module_420);
-auto x_main_module_430 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_429);
-auto x_main_module_431 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_430, x_main_module_18); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_432 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_431, x_main_module_17, x_main_module_16, x_main_module_15, x_main_module_14); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_433 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_432);
-auto x_main_module_434 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_433, x_main_module_13); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_435 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_434, x_main_module_12, x_main_module_11, x_main_module_10, x_main_module_9); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_436 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_435);
-auto x_main_module_437 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_436, x_main_module_8); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_438 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_437, x_main_module_7, x_main_module_6, x_main_module_5, x_main_module_4); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_439 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_438, x_main_module_430);
-auto x_main_module_440 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_439);
-auto x_main_module_441 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[7,7],\"lp_order\":2,\"mode\":0,\"padding\":[0,0,0,0],\"stride\":[1,1]}")), x_main_module_440); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_442 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), x_main_module_441); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_443 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_3); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_444 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_442, x_main_module_443);
-auto x_main_module_445 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_2); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_446 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_0); //NOLINT(modernize-raw-string-literal)
-auto x_main_module_447 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_445, x_main_module_446);
-auto x_main_module_448 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_444, x_main_module_447);
-mmain->add_return({x_main_module_448});
-
+    migraphx::module_ref mmain = p.get_main_module();
+    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+    auto x_0                   = mmain->add_parameter(
+        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
+    auto x_main_module_2 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
+    auto x_main_module_3 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
+    auto x_main_module_4 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 3)));
+    auto x_main_module_5 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 4));
+    auto x_main_module_6 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 5));
+    auto x_main_module_7  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 6)));
+    auto x_main_module_8  = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 7));
+    auto x_main_module_9  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 8)));
+    auto x_main_module_10 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 9));
+    auto x_main_module_11 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 10));
+    auto x_main_module_12 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 11)));
+    auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 12));
+    auto x_main_module_14 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 13)));
+    auto x_main_module_15 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 14));
+    auto x_main_module_16 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 15));
+    auto x_main_module_17 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 16)));
+    auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 17));
+    auto x_main_module_19 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 18)));
+    auto x_main_module_20 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 19));
+    auto x_main_module_21 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 20));
+    auto x_main_module_22 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 21)));
+    auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 22));
+    auto x_main_module_24 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 23)));
+    auto x_main_module_25 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 24));
+    auto x_main_module_26 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 25));
+    auto x_main_module_27 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 26)));
+    auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 27));
+    auto x_main_module_29 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 28)));
+    auto x_main_module_30 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 29));
+    auto x_main_module_31 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 30));
+    auto x_main_module_32 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 31)));
+    auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 32));
+    auto x_main_module_34 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 33)));
+    auto x_main_module_35 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 34));
+    auto x_main_module_36 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 35));
+    auto x_main_module_37 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 36)));
+    auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {2048, 1024, 1, 1}}, 37));
+    auto x_main_module_39 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 38)));
+    auto x_main_module_40 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 39));
+    auto x_main_module_41 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 40));
+    auto x_main_module_42 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 41)));
+    auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 42));
+    auto x_main_module_44 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 43)));
+    auto x_main_module_45 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 44));
+    auto x_main_module_46 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 45));
+    auto x_main_module_47 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 46)));
+    auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 47));
+    auto x_main_module_49 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 48)));
+    auto x_main_module_50 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 49));
+    auto x_main_module_51 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 50));
+    auto x_main_module_52 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 51)));
+    auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 1024, 1, 1}}, 52));
+    auto x_main_module_54 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 53)));
+    auto x_main_module_55 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 54));
+    auto x_main_module_56 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 55));
+    auto x_main_module_57 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 56));
+    auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 57));
+    auto x_main_module_59 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 58)));
+    auto x_main_module_60 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 59));
+    auto x_main_module_61 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 60));
+    auto x_main_module_62 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 61)));
+    auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 62));
+    auto x_main_module_64 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 63)));
+    auto x_main_module_65 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 64));
+    auto x_main_module_66 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 65));
+    auto x_main_module_67 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 66)));
+    auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 67));
+    auto x_main_module_69 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 68)));
+    auto x_main_module_70 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 69));
+    auto x_main_module_71 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 70));
+    auto x_main_module_72 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 71));
+    auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 72));
+    auto x_main_module_74 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 73)));
+    auto x_main_module_75 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 74));
+    auto x_main_module_76 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 75));
+    auto x_main_module_77 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 76)));
+    auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 77));
+    auto x_main_module_79 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 78)));
+    auto x_main_module_80 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 79));
+    auto x_main_module_81 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 80));
+    auto x_main_module_82 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 81)));
+    auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 82));
+    auto x_main_module_84 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 83)));
+    auto x_main_module_85 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 84));
+    auto x_main_module_86 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 85));
+    auto x_main_module_87 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 86));
+    auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 87));
+    auto x_main_module_89 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 88)));
+    auto x_main_module_90 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 89));
+    auto x_main_module_91 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 90));
+    auto x_main_module_92 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 91)));
+    auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 92));
+    auto x_main_module_94 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 93)));
+    auto x_main_module_95 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 94));
+    auto x_main_module_96 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 95));
+    auto x_main_module_97  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 96)));
+    auto x_main_module_98  = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 97));
+    auto x_main_module_99  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 98)));
+    auto x_main_module_100 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 99));
+    auto x_main_module_101 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 100));
+    auto x_main_module_102 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 101));
+    auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 102));
+    auto x_main_module_104 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 103)));
+    auto x_main_module_105 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 104));
+    auto x_main_module_106 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 105));
+    auto x_main_module_107 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 106)));
+    auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 107));
+    auto x_main_module_109 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 108)));
+    auto x_main_module_110 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 109));
+    auto x_main_module_111 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 110));
+    auto x_main_module_112 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 111)));
+    auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 112));
+    auto x_main_module_114 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 113)));
+    auto x_main_module_115 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 114));
+    auto x_main_module_116 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 115));
+    auto x_main_module_117 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 116));
+    auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 117));
+    auto x_main_module_119 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 118)));
+    auto x_main_module_120 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 119));
+    auto x_main_module_121 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 120));
+    auto x_main_module_122 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 121)));
+    auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 122));
+    auto x_main_module_124 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 123)));
+    auto x_main_module_125 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 124));
+    auto x_main_module_126 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 125));
+    auto x_main_module_127 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 126)));
+    auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 127));
+    auto x_main_module_129 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 128)));
+    auto x_main_module_130 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 129));
+    auto x_main_module_131 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 130));
+    auto x_main_module_132 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 131));
+    auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 512, 1, 1}}, 132));
+    auto x_main_module_134 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 133)));
+    auto x_main_module_135 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 134));
+    auto x_main_module_136 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 135));
+    auto x_main_module_137 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 136));
+    auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 137));
+    auto x_main_module_139 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 138)));
+    auto x_main_module_140 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 139));
+    auto x_main_module_141 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 140));
+    auto x_main_module_142 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 141)));
+    auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 142));
+    auto x_main_module_144 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 143)));
+    auto x_main_module_145 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 144));
+    auto x_main_module_146 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 145));
+    auto x_main_module_147 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 146)));
+    auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 512, 1, 1}}, 147));
+    auto x_main_module_149 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 148)));
+    auto x_main_module_150 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 149));
+    auto x_main_module_151 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 150));
+    auto x_main_module_152 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 151));
+    auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 152));
+    auto x_main_module_154 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 153)));
+    auto x_main_module_155 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 154));
+    auto x_main_module_156 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 155));
+    auto x_main_module_157 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 156)));
+    auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 157));
+    auto x_main_module_159 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 158)));
+    auto x_main_module_160 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 159));
+    auto x_main_module_161 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 160));
+    auto x_main_module_162 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 161)));
+    auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 162));
+    auto x_main_module_164 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 163)));
+    auto x_main_module_165 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 164));
+    auto x_main_module_166 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 165));
+    auto x_main_module_167 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 166));
+    auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 167));
+    auto x_main_module_169 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 168)));
+    auto x_main_module_170 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 169));
+    auto x_main_module_171 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 170));
+    auto x_main_module_172 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 171)));
+    auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 172));
+    auto x_main_module_174 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 173)));
+    auto x_main_module_175 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 174));
+    auto x_main_module_176 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 175));
+    auto x_main_module_177 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 176)));
+    auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 177));
+    auto x_main_module_179 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 178)));
+    auto x_main_module_180 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 179));
+    auto x_main_module_181 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 180));
+    auto x_main_module_182 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 181));
+    auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 182));
+    auto x_main_module_184 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 183)));
+    auto x_main_module_185 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 184));
+    auto x_main_module_186 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 185));
+    auto x_main_module_187 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 186)));
+    auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 187));
+    auto x_main_module_189 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 188)));
+    auto x_main_module_190 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 189));
+    auto x_main_module_191 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 190));
+    auto x_main_module_192 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 191)));
+    auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 192));
+    auto x_main_module_194 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 193)));
+    auto x_main_module_195 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 194));
+    auto x_main_module_196 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 195));
+    auto x_main_module_197 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 196));
+    auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 256, 1, 1}}, 197));
+    auto x_main_module_199 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 198)));
+    auto x_main_module_200 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 199));
+    auto x_main_module_201 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 200));
+    auto x_main_module_202 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 201));
+    auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 202));
+    auto x_main_module_204 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 203)));
+    auto x_main_module_205 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 204));
+    auto x_main_module_206 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 205));
+    auto x_main_module_207 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 206)));
+    auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 207));
+    auto x_main_module_209 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 208)));
+    auto x_main_module_210 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 209));
+    auto x_main_module_211 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 210));
+    auto x_main_module_212 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 211)));
+    auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 256, 1, 1}}, 212));
+    auto x_main_module_214 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 213)));
+    auto x_main_module_215 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 214));
+    auto x_main_module_216 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 215));
+    auto x_main_module_217 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 216));
+    auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 217));
+    auto x_main_module_219 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 218)));
+    auto x_main_module_220 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 219));
+    auto x_main_module_221 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 220));
+    auto x_main_module_222 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 221)));
+    auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 222));
+    auto x_main_module_224 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 223)));
+    auto x_main_module_225 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 224));
+    auto x_main_module_226 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 225));
+    auto x_main_module_227 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 226)));
+    auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 227));
+    auto x_main_module_229 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 228)));
+    auto x_main_module_230 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 229));
+    auto x_main_module_231 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 230));
+    auto x_main_module_232 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 231));
+    auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 232));
+    auto x_main_module_234 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 233)));
+    auto x_main_module_235 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 234));
+    auto x_main_module_236 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 235));
+    auto x_main_module_237 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 236)));
+    auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 237));
+    auto x_main_module_239 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 238)));
+    auto x_main_module_240 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 239));
+    auto x_main_module_241 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 240));
+    auto x_main_module_242 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 241)));
+    auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 242));
+    auto x_main_module_244 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 243)));
+    auto x_main_module_245 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 244));
+    auto x_main_module_246 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 245));
+    auto x_main_module_247 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 246));
+    auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 247));
+    auto x_main_module_249 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 248)));
+    auto x_main_module_250 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 249));
+    auto x_main_module_251 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 250));
+    auto x_main_module_252 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 251));
+    auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 252));
+    auto x_main_module_254 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 253)));
+    auto x_main_module_255 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 254));
+    auto x_main_module_256 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 255));
+    auto x_main_module_257 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 256)));
+    auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 257));
+    auto x_main_module_259 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 258)));
+    auto x_main_module_260 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 259));
+    auto x_main_module_261 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 260));
+    auto x_main_module_262 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 261)));
+    auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 64, 1, 1}}, 262));
+    auto x_main_module_264 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 263)));
+    auto x_main_module_265 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 264));
+    auto x_main_module_266 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 265));
+    auto x_main_module_267 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 266)));
+    auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 3, 7, 7}}, 267));
+    auto x_main_module_269 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,3,3,3],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_0,
+        x_main_module_268); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_270 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_269,
+        x_main_module_267,
+        x_main_module_266,
+        x_main_module_265,
+        x_main_module_264); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_271 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_270);
+    auto x_main_module_272 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[1,1,1,1],\"stride\":[2,2]}")),
+        x_main_module_271); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_273 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_272,
+        x_main_module_263); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_274 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_273,
+        x_main_module_262,
+        x_main_module_261,
+        x_main_module_260,
+        x_main_module_259); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_275 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_274);
+    auto x_main_module_276 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_275,
+        x_main_module_258); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_277 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_276,
+        x_main_module_257,
+        x_main_module_256,
+        x_main_module_255,
+        x_main_module_254); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_278 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_277);
+    auto x_main_module_279 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_278,
+        x_main_module_253); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_280 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_279,
+        x_main_module_252,
+        x_main_module_251,
+        x_main_module_250,
+        x_main_module_249); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_281 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_272,
+        x_main_module_248); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_282 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_281,
+        x_main_module_247,
+        x_main_module_246,
+        x_main_module_245,
+        x_main_module_244); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_283 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_280, x_main_module_282);
+    auto x_main_module_284 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_283);
+    auto x_main_module_285 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_284,
+        x_main_module_243); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_286 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_285,
+        x_main_module_242,
+        x_main_module_241,
+        x_main_module_240,
+        x_main_module_239); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_287 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_286);
+    auto x_main_module_288 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_287,
+        x_main_module_238); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_289 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_288,
+        x_main_module_237,
+        x_main_module_236,
+        x_main_module_235,
+        x_main_module_234); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_290 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_289);
+    auto x_main_module_291 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_290,
+        x_main_module_233); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_292 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_291,
+        x_main_module_232,
+        x_main_module_231,
+        x_main_module_230,
+        x_main_module_229); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_293 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_292, x_main_module_284);
+    auto x_main_module_294 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_293);
+    auto x_main_module_295 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_294,
+        x_main_module_228); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_296 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_295,
+        x_main_module_227,
+        x_main_module_226,
+        x_main_module_225,
+        x_main_module_224); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_297 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_296);
+    auto x_main_module_298 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_297,
+        x_main_module_223); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_299 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_298,
+        x_main_module_222,
+        x_main_module_221,
+        x_main_module_220,
+        x_main_module_219); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_300 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_299);
+    auto x_main_module_301 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_300,
+        x_main_module_218); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_302 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_301,
+        x_main_module_217,
+        x_main_module_216,
+        x_main_module_215,
+        x_main_module_214); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_303 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_302, x_main_module_294);
+    auto x_main_module_304 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_303);
+    auto x_main_module_305 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_304,
+        x_main_module_213); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_306 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_305,
+        x_main_module_212,
+        x_main_module_211,
+        x_main_module_210,
+        x_main_module_209); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_307 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_306);
+    auto x_main_module_308 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_307,
+        x_main_module_208); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_309 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_308,
+        x_main_module_207,
+        x_main_module_206,
+        x_main_module_205,
+        x_main_module_204); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_310 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_309);
+    auto x_main_module_311 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_310,
+        x_main_module_203); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_312 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_311,
+        x_main_module_202,
+        x_main_module_201,
+        x_main_module_200,
+        x_main_module_199); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_313 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_304,
+        x_main_module_198); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_314 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_313,
+        x_main_module_197,
+        x_main_module_196,
+        x_main_module_195,
+        x_main_module_194); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_315 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_312, x_main_module_314);
+    auto x_main_module_316 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_315);
+    auto x_main_module_317 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_316,
+        x_main_module_193); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_318 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_317,
+        x_main_module_192,
+        x_main_module_191,
+        x_main_module_190,
+        x_main_module_189); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_319 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_318);
+    auto x_main_module_320 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_319,
+        x_main_module_188); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_321 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_320,
+        x_main_module_187,
+        x_main_module_186,
+        x_main_module_185,
+        x_main_module_184); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_322 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_321);
+    auto x_main_module_323 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_322,
+        x_main_module_183); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_324 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_323,
+        x_main_module_182,
+        x_main_module_181,
+        x_main_module_180,
+        x_main_module_179); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_325 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_324, x_main_module_316);
+    auto x_main_module_326 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_325);
+    auto x_main_module_327 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_326,
+        x_main_module_178); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_328 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_327,
+        x_main_module_177,
+        x_main_module_176,
+        x_main_module_175,
+        x_main_module_174); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_329 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_328);
+    auto x_main_module_330 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_329,
+        x_main_module_173); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_331 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_330,
+        x_main_module_172,
+        x_main_module_171,
+        x_main_module_170,
+        x_main_module_169); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_332 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_331);
+    auto x_main_module_333 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_332,
+        x_main_module_168); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_334 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_333,
+        x_main_module_167,
+        x_main_module_166,
+        x_main_module_165,
+        x_main_module_164); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_335 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_334, x_main_module_326);
+    auto x_main_module_336 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_335);
+    auto x_main_module_337 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_336,
+        x_main_module_163); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_338 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_337,
+        x_main_module_162,
+        x_main_module_161,
+        x_main_module_160,
+        x_main_module_159); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_339 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_338);
+    auto x_main_module_340 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_339,
+        x_main_module_158); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_341 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_340,
+        x_main_module_157,
+        x_main_module_156,
+        x_main_module_155,
+        x_main_module_154); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_342 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_341);
+    auto x_main_module_343 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_342,
+        x_main_module_153); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_344 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_343,
+        x_main_module_152,
+        x_main_module_151,
+        x_main_module_150,
+        x_main_module_149); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_345 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_344, x_main_module_336);
+    auto x_main_module_346 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_345);
+    auto x_main_module_347 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_346,
+        x_main_module_148); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_348 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_347,
+        x_main_module_147,
+        x_main_module_146,
+        x_main_module_145,
+        x_main_module_144); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_349 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_348);
+    auto x_main_module_350 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_349,
+        x_main_module_143); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_351 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_350,
+        x_main_module_142,
+        x_main_module_141,
+        x_main_module_140,
+        x_main_module_139); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_352 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_351);
+    auto x_main_module_353 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_352,
+        x_main_module_138); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_354 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_353,
+        x_main_module_137,
+        x_main_module_136,
+        x_main_module_135,
+        x_main_module_134); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_355 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_346,
+        x_main_module_133); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_356 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_355,
+        x_main_module_132,
+        x_main_module_131,
+        x_main_module_130,
+        x_main_module_129); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_357 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_354, x_main_module_356);
+    auto x_main_module_358 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_357);
+    auto x_main_module_359 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_358,
+        x_main_module_128); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_360 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_359,
+        x_main_module_127,
+        x_main_module_126,
+        x_main_module_125,
+        x_main_module_124); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_361 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_360);
+    auto x_main_module_362 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_361,
+        x_main_module_123); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_363 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_362,
+        x_main_module_122,
+        x_main_module_121,
+        x_main_module_120,
+        x_main_module_119); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_364 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_363);
+    auto x_main_module_365 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_364,
+        x_main_module_118); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_366 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_365,
+        x_main_module_117,
+        x_main_module_116,
+        x_main_module_115,
+        x_main_module_114); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_367 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_366, x_main_module_358);
+    auto x_main_module_368 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_367);
+    auto x_main_module_369 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_368,
+        x_main_module_113); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_370 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_369,
+        x_main_module_112,
+        x_main_module_111,
+        x_main_module_110,
+        x_main_module_109); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_371 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_370);
+    auto x_main_module_372 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_371,
+        x_main_module_108); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_373 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_372,
+        x_main_module_107,
+        x_main_module_106,
+        x_main_module_105,
+        x_main_module_104); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_374 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_373);
+    auto x_main_module_375 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_374,
+        x_main_module_103); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_376 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_375,
+        x_main_module_102,
+        x_main_module_101,
+        x_main_module_100,
+        x_main_module_99); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_377 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_376, x_main_module_368);
+    auto x_main_module_378 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_377);
+    auto x_main_module_379 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_378,
+        x_main_module_98); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_380 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_379,
+        x_main_module_97,
+        x_main_module_96,
+        x_main_module_95,
+        x_main_module_94); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_381 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_380);
+    auto x_main_module_382 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_381,
+        x_main_module_93); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_383 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_382,
+        x_main_module_92,
+        x_main_module_91,
+        x_main_module_90,
+        x_main_module_89); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_384 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_383);
+    auto x_main_module_385 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_384,
+        x_main_module_88); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_386 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_385,
+        x_main_module_87,
+        x_main_module_86,
+        x_main_module_85,
+        x_main_module_84); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_387 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_386, x_main_module_378);
+    auto x_main_module_388 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_387);
+    auto x_main_module_389 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_388,
+        x_main_module_83); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_390 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_389,
+        x_main_module_82,
+        x_main_module_81,
+        x_main_module_80,
+        x_main_module_79); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_391 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_390);
+    auto x_main_module_392 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_391,
+        x_main_module_78); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_393 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_392,
+        x_main_module_77,
+        x_main_module_76,
+        x_main_module_75,
+        x_main_module_74); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_394 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_393);
+    auto x_main_module_395 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_394,
+        x_main_module_73); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_396 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_395,
+        x_main_module_72,
+        x_main_module_71,
+        x_main_module_70,
+        x_main_module_69); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_397 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_396, x_main_module_388);
+    auto x_main_module_398 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_397);
+    auto x_main_module_399 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_398,
+        x_main_module_68); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_400 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_399,
+        x_main_module_67,
+        x_main_module_66,
+        x_main_module_65,
+        x_main_module_64); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_401 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_400);
+    auto x_main_module_402 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_401,
+        x_main_module_63); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_403 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_402,
+        x_main_module_62,
+        x_main_module_61,
+        x_main_module_60,
+        x_main_module_59); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_404 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_403);
+    auto x_main_module_405 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_404,
+        x_main_module_58); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_406 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_405,
+        x_main_module_57,
+        x_main_module_56,
+        x_main_module_55,
+        x_main_module_54); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_407 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_406, x_main_module_398);
+    auto x_main_module_408 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_407);
+    auto x_main_module_409 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_408,
+        x_main_module_53); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_410 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_409,
+        x_main_module_52,
+        x_main_module_51,
+        x_main_module_50,
+        x_main_module_49); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_411 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_410);
+    auto x_main_module_412 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_411,
+        x_main_module_48); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_413 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_412,
+        x_main_module_47,
+        x_main_module_46,
+        x_main_module_45,
+        x_main_module_44); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_414 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_413);
+    auto x_main_module_415 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_414,
+        x_main_module_43); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_416 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_415,
+        x_main_module_42,
+        x_main_module_41,
+        x_main_module_40,
+        x_main_module_39); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_417 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_408,
+        x_main_module_38); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_418 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_417,
+        x_main_module_37,
+        x_main_module_36,
+        x_main_module_35,
+        x_main_module_34); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_419 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_416, x_main_module_418);
+    auto x_main_module_420 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_419);
+    auto x_main_module_421 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_420,
+        x_main_module_33); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_422 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_421,
+        x_main_module_32,
+        x_main_module_31,
+        x_main_module_30,
+        x_main_module_29); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_423 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_422);
+    auto x_main_module_424 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_423,
+        x_main_module_28); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_425 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_424,
+        x_main_module_27,
+        x_main_module_26,
+        x_main_module_25,
+        x_main_module_24); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_426 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_425);
+    auto x_main_module_427 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_426,
+        x_main_module_23); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_428 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_427,
+        x_main_module_22,
+        x_main_module_21,
+        x_main_module_20,
+        x_main_module_19); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_429 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_428, x_main_module_420);
+    auto x_main_module_430 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_429);
+    auto x_main_module_431 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_430,
+        x_main_module_18); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_432 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_431,
+        x_main_module_17,
+        x_main_module_16,
+        x_main_module_15,
+        x_main_module_14); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_433 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_432);
+    auto x_main_module_434 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_433,
+        x_main_module_13); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_435 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_434,
+        x_main_module_12,
+        x_main_module_11,
+        x_main_module_10,
+        x_main_module_9); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_436 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_435);
+    auto x_main_module_437 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_436,
+        x_main_module_8); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_438 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_437,
+        x_main_module_7,
+        x_main_module_6,
+        x_main_module_5,
+        x_main_module_4); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_439 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_438, x_main_module_430);
+    auto x_main_module_440 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_439);
+    auto x_main_module_441 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[7,7],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[0,0,0,0],\"stride\":[1,1]}")),
+        x_main_module_440); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_442 = mmain->add_instruction(
+        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_441); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_443 = mmain->add_instruction(
+        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
+        x_main_module_3); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_444 =
+        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_442, x_main_module_443);
+    auto x_main_module_445 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        x_main_module_2); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_446 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        x_main_module_0); // NOLINT(modernize-raw-string-literal)
+    auto x_main_module_447 =
+        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_445, x_main_module_446);
+    auto x_main_module_448 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_444, x_main_module_447);
+    mmain->add_return({x_main_module_448});
 
     return p;
 }

--- a/src/driver/resnet50.cpp
+++ b/src/driver/resnet50.cpp
@@ -33,1558 +33,458 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program resnet50(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-    migraphx::module_ref mmain = p.get_main_module();
-    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-    auto x_0                   = mmain->add_parameter(
-        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
-    auto x_main_module_2 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
-    auto x_main_module_3 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
-    auto x_main_module_4 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 3)));
-    auto x_main_module_5 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 4));
-    auto x_main_module_6 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 5));
-    auto x_main_module_7  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 6)));
-    auto x_main_module_8  = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 7));
-    auto x_main_module_9  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 8)));
-    auto x_main_module_10 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 9));
-    auto x_main_module_11 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 10));
-    auto x_main_module_12 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 11)));
-    auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 12));
-    auto x_main_module_14 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 13)));
-    auto x_main_module_15 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 14));
-    auto x_main_module_16 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 15));
-    auto x_main_module_17 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 16)));
-    auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 17));
-    auto x_main_module_19 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 18)));
-    auto x_main_module_20 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 19));
-    auto x_main_module_21 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 20));
-    auto x_main_module_22 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 21)));
-    auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 22));
-    auto x_main_module_24 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 23)));
-    auto x_main_module_25 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 24));
-    auto x_main_module_26 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 25));
-    auto x_main_module_27 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 26)));
-    auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 27));
-    auto x_main_module_29 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 28)));
-    auto x_main_module_30 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 29));
-    auto x_main_module_31 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 30));
-    auto x_main_module_32 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 31)));
-    auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 32));
-    auto x_main_module_34 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 33)));
-    auto x_main_module_35 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 34));
-    auto x_main_module_36 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 35));
-    auto x_main_module_37 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 36)));
-    auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {2048, 1024, 1, 1}}, 37));
-    auto x_main_module_39 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 38)));
-    auto x_main_module_40 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 39));
-    auto x_main_module_41 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 40));
-    auto x_main_module_42 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 41)));
-    auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 42));
-    auto x_main_module_44 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 43)));
-    auto x_main_module_45 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 44));
-    auto x_main_module_46 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 45));
-    auto x_main_module_47 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 46)));
-    auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 47));
-    auto x_main_module_49 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 48)));
-    auto x_main_module_50 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 49));
-    auto x_main_module_51 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 50));
-    auto x_main_module_52 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 51)));
-    auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 1024, 1, 1}}, 52));
-    auto x_main_module_54 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 53)));
-    auto x_main_module_55 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 54));
-    auto x_main_module_56 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 55));
-    auto x_main_module_57 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 56));
-    auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 57));
-    auto x_main_module_59 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 58)));
-    auto x_main_module_60 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 59));
-    auto x_main_module_61 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 60));
-    auto x_main_module_62 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 61)));
-    auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 62));
-    auto x_main_module_64 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 63)));
-    auto x_main_module_65 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 64));
-    auto x_main_module_66 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 65));
-    auto x_main_module_67 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 66)));
-    auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 67));
-    auto x_main_module_69 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 68)));
-    auto x_main_module_70 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 69));
-    auto x_main_module_71 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 70));
-    auto x_main_module_72 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 71));
-    auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 72));
-    auto x_main_module_74 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 73)));
-    auto x_main_module_75 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 74));
-    auto x_main_module_76 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 75));
-    auto x_main_module_77 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 76)));
-    auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 77));
-    auto x_main_module_79 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 78)));
-    auto x_main_module_80 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 79));
-    auto x_main_module_81 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 80));
-    auto x_main_module_82 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 81)));
-    auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 82));
-    auto x_main_module_84 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 83)));
-    auto x_main_module_85 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 84));
-    auto x_main_module_86 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 85));
-    auto x_main_module_87 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 86));
-    auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 87));
-    auto x_main_module_89 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 88)));
-    auto x_main_module_90 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 89));
-    auto x_main_module_91 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 90));
-    auto x_main_module_92 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 91)));
-    auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 92));
-    auto x_main_module_94 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 93)));
-    auto x_main_module_95 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 94));
-    auto x_main_module_96 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 95));
-    auto x_main_module_97  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 96)));
-    auto x_main_module_98  = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 97));
-    auto x_main_module_99  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 98)));
-    auto x_main_module_100 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 99));
-    auto x_main_module_101 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 100));
-    auto x_main_module_102 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 101));
-    auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 102));
-    auto x_main_module_104 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 103)));
-    auto x_main_module_105 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 104));
-    auto x_main_module_106 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 105));
-    auto x_main_module_107 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 106)));
-    auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 107));
-    auto x_main_module_109 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 108)));
-    auto x_main_module_110 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 109));
-    auto x_main_module_111 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 110));
-    auto x_main_module_112 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 111)));
-    auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 112));
-    auto x_main_module_114 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 113)));
-    auto x_main_module_115 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 114));
-    auto x_main_module_116 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 115));
-    auto x_main_module_117 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 116));
-    auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 117));
-    auto x_main_module_119 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 118)));
-    auto x_main_module_120 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 119));
-    auto x_main_module_121 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 120));
-    auto x_main_module_122 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 121)));
-    auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 122));
-    auto x_main_module_124 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 123)));
-    auto x_main_module_125 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 124));
-    auto x_main_module_126 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 125));
-    auto x_main_module_127 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 126)));
-    auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 127));
-    auto x_main_module_129 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 128)));
-    auto x_main_module_130 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 129));
-    auto x_main_module_131 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 130));
-    auto x_main_module_132 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 131));
-    auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 512, 1, 1}}, 132));
-    auto x_main_module_134 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 133)));
-    auto x_main_module_135 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 134));
-    auto x_main_module_136 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 135));
-    auto x_main_module_137 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 136));
-    auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 137));
-    auto x_main_module_139 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 138)));
-    auto x_main_module_140 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 139));
-    auto x_main_module_141 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 140));
-    auto x_main_module_142 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 141)));
-    auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 142));
-    auto x_main_module_144 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 143)));
-    auto x_main_module_145 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 144));
-    auto x_main_module_146 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 145));
-    auto x_main_module_147 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 146)));
-    auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 512, 1, 1}}, 147));
-    auto x_main_module_149 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 148)));
-    auto x_main_module_150 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 149));
-    auto x_main_module_151 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 150));
-    auto x_main_module_152 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 151));
-    auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 152));
-    auto x_main_module_154 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 153)));
-    auto x_main_module_155 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 154));
-    auto x_main_module_156 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 155));
-    auto x_main_module_157 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 156)));
-    auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 157));
-    auto x_main_module_159 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 158)));
-    auto x_main_module_160 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 159));
-    auto x_main_module_161 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 160));
-    auto x_main_module_162 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 161)));
-    auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 162));
-    auto x_main_module_164 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 163)));
-    auto x_main_module_165 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 164));
-    auto x_main_module_166 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 165));
-    auto x_main_module_167 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 166));
-    auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 167));
-    auto x_main_module_169 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 168)));
-    auto x_main_module_170 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 169));
-    auto x_main_module_171 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 170));
-    auto x_main_module_172 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 171)));
-    auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 172));
-    auto x_main_module_174 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 173)));
-    auto x_main_module_175 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 174));
-    auto x_main_module_176 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 175));
-    auto x_main_module_177 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 176)));
-    auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 177));
-    auto x_main_module_179 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 178)));
-    auto x_main_module_180 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 179));
-    auto x_main_module_181 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 180));
-    auto x_main_module_182 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 181));
-    auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 182));
-    auto x_main_module_184 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 183)));
-    auto x_main_module_185 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 184));
-    auto x_main_module_186 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 185));
-    auto x_main_module_187 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 186)));
-    auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 187));
-    auto x_main_module_189 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 188)));
-    auto x_main_module_190 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 189));
-    auto x_main_module_191 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 190));
-    auto x_main_module_192 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 191)));
-    auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 192));
-    auto x_main_module_194 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 193)));
-    auto x_main_module_195 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 194));
-    auto x_main_module_196 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 195));
-    auto x_main_module_197 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 196));
-    auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 256, 1, 1}}, 197));
-    auto x_main_module_199 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 198)));
-    auto x_main_module_200 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 199));
-    auto x_main_module_201 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 200));
-    auto x_main_module_202 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 201));
-    auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 202));
-    auto x_main_module_204 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 203)));
-    auto x_main_module_205 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 204));
-    auto x_main_module_206 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 205));
-    auto x_main_module_207 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 206)));
-    auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 207));
-    auto x_main_module_209 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 208)));
-    auto x_main_module_210 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 209));
-    auto x_main_module_211 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 210));
-    auto x_main_module_212 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 211)));
-    auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 256, 1, 1}}, 212));
-    auto x_main_module_214 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 213)));
-    auto x_main_module_215 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 214));
-    auto x_main_module_216 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 215));
-    auto x_main_module_217 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 216));
-    auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 217));
-    auto x_main_module_219 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 218)));
-    auto x_main_module_220 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 219));
-    auto x_main_module_221 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 220));
-    auto x_main_module_222 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 221)));
-    auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 222));
-    auto x_main_module_224 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 223)));
-    auto x_main_module_225 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 224));
-    auto x_main_module_226 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 225));
-    auto x_main_module_227 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 226)));
-    auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 227));
-    auto x_main_module_229 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 228)));
-    auto x_main_module_230 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 229));
-    auto x_main_module_231 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 230));
-    auto x_main_module_232 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 231));
-    auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 232));
-    auto x_main_module_234 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 233)));
-    auto x_main_module_235 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 234));
-    auto x_main_module_236 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 235));
-    auto x_main_module_237 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 236)));
-    auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 237));
-    auto x_main_module_239 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 238)));
-    auto x_main_module_240 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 239));
-    auto x_main_module_241 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 240));
-    auto x_main_module_242 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 241)));
-    auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 242));
-    auto x_main_module_244 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 243)));
-    auto x_main_module_245 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 244));
-    auto x_main_module_246 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 245));
-    auto x_main_module_247 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 246));
-    auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 247));
-    auto x_main_module_249 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 248)));
-    auto x_main_module_250 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 249));
-    auto x_main_module_251 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 250));
-    auto x_main_module_252 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 251));
-    auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 252));
-    auto x_main_module_254 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 253)));
-    auto x_main_module_255 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 254));
-    auto x_main_module_256 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 255));
-    auto x_main_module_257 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 256)));
-    auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 257));
-    auto x_main_module_259 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 258)));
-    auto x_main_module_260 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 259));
-    auto x_main_module_261 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 260));
-    auto x_main_module_262 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 261)));
-    auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 64, 1, 1}}, 262));
-    auto x_main_module_264 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 263)));
-    auto x_main_module_265 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 264));
-    auto x_main_module_266 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 265));
-    auto x_main_module_267 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 266)));
-    auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 3, 7, 7}}, 267));
-    auto x_main_module_269 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,3,3,3],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_0,
-        x_main_module_268);
-    auto x_main_module_270 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_269,
-        x_main_module_267,
-        x_main_module_266,
-        x_main_module_265,
-        x_main_module_264);
-    auto x_main_module_271 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_270);
-    auto x_main_module_272 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[1,1,1,1],\"stride\":[2,2]}")),
-        x_main_module_271);
-    auto x_main_module_273 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_272,
-        x_main_module_263);
-    auto x_main_module_274 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_273,
-        x_main_module_262,
-        x_main_module_261,
-        x_main_module_260,
-        x_main_module_259);
-    auto x_main_module_275 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_274);
-    auto x_main_module_276 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_275,
-        x_main_module_258);
-    auto x_main_module_277 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_276,
-        x_main_module_257,
-        x_main_module_256,
-        x_main_module_255,
-        x_main_module_254);
-    auto x_main_module_278 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_277);
-    auto x_main_module_279 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_278,
-        x_main_module_253);
-    auto x_main_module_280 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_279,
-        x_main_module_252,
-        x_main_module_251,
-        x_main_module_250,
-        x_main_module_249);
-    auto x_main_module_281 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_272,
-        x_main_module_248);
-    auto x_main_module_282 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_281,
-        x_main_module_247,
-        x_main_module_246,
-        x_main_module_245,
-        x_main_module_244);
-    auto x_main_module_283 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_280, x_main_module_282);
-    auto x_main_module_284 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_283);
-    auto x_main_module_285 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_284,
-        x_main_module_243);
-    auto x_main_module_286 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_285,
-        x_main_module_242,
-        x_main_module_241,
-        x_main_module_240,
-        x_main_module_239);
-    auto x_main_module_287 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_286);
-    auto x_main_module_288 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_287,
-        x_main_module_238);
-    auto x_main_module_289 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_288,
-        x_main_module_237,
-        x_main_module_236,
-        x_main_module_235,
-        x_main_module_234);
-    auto x_main_module_290 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_289);
-    auto x_main_module_291 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_290,
-        x_main_module_233);
-    auto x_main_module_292 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_291,
-        x_main_module_232,
-        x_main_module_231,
-        x_main_module_230,
-        x_main_module_229);
-    auto x_main_module_293 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_292, x_main_module_284);
-    auto x_main_module_294 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_293);
-    auto x_main_module_295 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_294,
-        x_main_module_228);
-    auto x_main_module_296 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_295,
-        x_main_module_227,
-        x_main_module_226,
-        x_main_module_225,
-        x_main_module_224);
-    auto x_main_module_297 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_296);
-    auto x_main_module_298 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_297,
-        x_main_module_223);
-    auto x_main_module_299 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_298,
-        x_main_module_222,
-        x_main_module_221,
-        x_main_module_220,
-        x_main_module_219);
-    auto x_main_module_300 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_299);
-    auto x_main_module_301 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_300,
-        x_main_module_218);
-    auto x_main_module_302 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_301,
-        x_main_module_217,
-        x_main_module_216,
-        x_main_module_215,
-        x_main_module_214);
-    auto x_main_module_303 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_302, x_main_module_294);
-    auto x_main_module_304 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_303);
-    auto x_main_module_305 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_304,
-        x_main_module_213);
-    auto x_main_module_306 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_305,
-        x_main_module_212,
-        x_main_module_211,
-        x_main_module_210,
-        x_main_module_209);
-    auto x_main_module_307 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_306);
-    auto x_main_module_308 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_307,
-        x_main_module_208);
-    auto x_main_module_309 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_308,
-        x_main_module_207,
-        x_main_module_206,
-        x_main_module_205,
-        x_main_module_204);
-    auto x_main_module_310 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_309);
-    auto x_main_module_311 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_310,
-        x_main_module_203);
-    auto x_main_module_312 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_311,
-        x_main_module_202,
-        x_main_module_201,
-        x_main_module_200,
-        x_main_module_199);
-    auto x_main_module_313 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_304,
-        x_main_module_198);
-    auto x_main_module_314 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_313,
-        x_main_module_197,
-        x_main_module_196,
-        x_main_module_195,
-        x_main_module_194);
-    auto x_main_module_315 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_312, x_main_module_314);
-    auto x_main_module_316 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_315);
-    auto x_main_module_317 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_316,
-        x_main_module_193);
-    auto x_main_module_318 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_317,
-        x_main_module_192,
-        x_main_module_191,
-        x_main_module_190,
-        x_main_module_189);
-    auto x_main_module_319 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_318);
-    auto x_main_module_320 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_319,
-        x_main_module_188);
-    auto x_main_module_321 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_320,
-        x_main_module_187,
-        x_main_module_186,
-        x_main_module_185,
-        x_main_module_184);
-    auto x_main_module_322 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_321);
-    auto x_main_module_323 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_322,
-        x_main_module_183);
-    auto x_main_module_324 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_323,
-        x_main_module_182,
-        x_main_module_181,
-        x_main_module_180,
-        x_main_module_179);
-    auto x_main_module_325 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_324, x_main_module_316);
-    auto x_main_module_326 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_325);
-    auto x_main_module_327 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_326,
-        x_main_module_178);
-    auto x_main_module_328 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_327,
-        x_main_module_177,
-        x_main_module_176,
-        x_main_module_175,
-        x_main_module_174);
-    auto x_main_module_329 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_328);
-    auto x_main_module_330 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_329,
-        x_main_module_173);
-    auto x_main_module_331 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_330,
-        x_main_module_172,
-        x_main_module_171,
-        x_main_module_170,
-        x_main_module_169);
-    auto x_main_module_332 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_331);
-    auto x_main_module_333 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_332,
-        x_main_module_168);
-    auto x_main_module_334 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_333,
-        x_main_module_167,
-        x_main_module_166,
-        x_main_module_165,
-        x_main_module_164);
-    auto x_main_module_335 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_334, x_main_module_326);
-    auto x_main_module_336 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_335);
-    auto x_main_module_337 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_336,
-        x_main_module_163);
-    auto x_main_module_338 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_337,
-        x_main_module_162,
-        x_main_module_161,
-        x_main_module_160,
-        x_main_module_159);
-    auto x_main_module_339 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_338);
-    auto x_main_module_340 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_339,
-        x_main_module_158);
-    auto x_main_module_341 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_340,
-        x_main_module_157,
-        x_main_module_156,
-        x_main_module_155,
-        x_main_module_154);
-    auto x_main_module_342 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_341);
-    auto x_main_module_343 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_342,
-        x_main_module_153);
-    auto x_main_module_344 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_343,
-        x_main_module_152,
-        x_main_module_151,
-        x_main_module_150,
-        x_main_module_149);
-    auto x_main_module_345 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_344, x_main_module_336);
-    auto x_main_module_346 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_345);
-    auto x_main_module_347 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_346,
-        x_main_module_148);
-    auto x_main_module_348 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_347,
-        x_main_module_147,
-        x_main_module_146,
-        x_main_module_145,
-        x_main_module_144);
-    auto x_main_module_349 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_348);
-    auto x_main_module_350 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_349,
-        x_main_module_143);
-    auto x_main_module_351 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_350,
-        x_main_module_142,
-        x_main_module_141,
-        x_main_module_140,
-        x_main_module_139);
-    auto x_main_module_352 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_351);
-    auto x_main_module_353 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_352,
-        x_main_module_138);
-    auto x_main_module_354 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_353,
-        x_main_module_137,
-        x_main_module_136,
-        x_main_module_135,
-        x_main_module_134);
-    auto x_main_module_355 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_346,
-        x_main_module_133);
-    auto x_main_module_356 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_355,
-        x_main_module_132,
-        x_main_module_131,
-        x_main_module_130,
-        x_main_module_129);
-    auto x_main_module_357 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_354, x_main_module_356);
-    auto x_main_module_358 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_357);
-    auto x_main_module_359 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_358,
-        x_main_module_128);
-    auto x_main_module_360 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_359,
-        x_main_module_127,
-        x_main_module_126,
-        x_main_module_125,
-        x_main_module_124);
-    auto x_main_module_361 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_360);
-    auto x_main_module_362 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_361,
-        x_main_module_123);
-    auto x_main_module_363 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_362,
-        x_main_module_122,
-        x_main_module_121,
-        x_main_module_120,
-        x_main_module_119);
-    auto x_main_module_364 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_363);
-    auto x_main_module_365 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_364,
-        x_main_module_118);
-    auto x_main_module_366 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_365,
-        x_main_module_117,
-        x_main_module_116,
-        x_main_module_115,
-        x_main_module_114);
-    auto x_main_module_367 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_366, x_main_module_358);
-    auto x_main_module_368 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_367);
-    auto x_main_module_369 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_368,
-        x_main_module_113);
-    auto x_main_module_370 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_369,
-        x_main_module_112,
-        x_main_module_111,
-        x_main_module_110,
-        x_main_module_109);
-    auto x_main_module_371 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_370);
-    auto x_main_module_372 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_371,
-        x_main_module_108);
-    auto x_main_module_373 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_372,
-        x_main_module_107,
-        x_main_module_106,
-        x_main_module_105,
-        x_main_module_104);
-    auto x_main_module_374 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_373);
-    auto x_main_module_375 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_374,
-        x_main_module_103);
-    auto x_main_module_376 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_375,
-        x_main_module_102,
-        x_main_module_101,
-        x_main_module_100,
-        x_main_module_99);
-    auto x_main_module_377 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_376, x_main_module_368);
-    auto x_main_module_378 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_377);
-    auto x_main_module_379 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_378,
-        x_main_module_98);
-    auto x_main_module_380 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_379,
-        x_main_module_97,
-        x_main_module_96,
-        x_main_module_95,
-        x_main_module_94);
-    auto x_main_module_381 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_380);
-    auto x_main_module_382 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_381,
-        x_main_module_93);
-    auto x_main_module_383 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_382,
-        x_main_module_92,
-        x_main_module_91,
-        x_main_module_90,
-        x_main_module_89);
-    auto x_main_module_384 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_383);
-    auto x_main_module_385 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_384,
-        x_main_module_88);
-    auto x_main_module_386 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_385,
-        x_main_module_87,
-        x_main_module_86,
-        x_main_module_85,
-        x_main_module_84);
-    auto x_main_module_387 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_386, x_main_module_378);
-    auto x_main_module_388 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_387);
-    auto x_main_module_389 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_388,
-        x_main_module_83);
-    auto x_main_module_390 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_389,
-        x_main_module_82,
-        x_main_module_81,
-        x_main_module_80,
-        x_main_module_79);
-    auto x_main_module_391 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_390);
-    auto x_main_module_392 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_391,
-        x_main_module_78);
-    auto x_main_module_393 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_392,
-        x_main_module_77,
-        x_main_module_76,
-        x_main_module_75,
-        x_main_module_74);
-    auto x_main_module_394 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_393);
-    auto x_main_module_395 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_394,
-        x_main_module_73);
-    auto x_main_module_396 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_395,
-        x_main_module_72,
-        x_main_module_71,
-        x_main_module_70,
-        x_main_module_69);
-    auto x_main_module_397 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_396, x_main_module_388);
-    auto x_main_module_398 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_397);
-    auto x_main_module_399 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_398,
-        x_main_module_68);
-    auto x_main_module_400 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_399,
-        x_main_module_67,
-        x_main_module_66,
-        x_main_module_65,
-        x_main_module_64);
-    auto x_main_module_401 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_400);
-    auto x_main_module_402 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_401,
-        x_main_module_63);
-    auto x_main_module_403 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_402,
-        x_main_module_62,
-        x_main_module_61,
-        x_main_module_60,
-        x_main_module_59);
-    auto x_main_module_404 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_403);
-    auto x_main_module_405 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_404,
-        x_main_module_58);
-    auto x_main_module_406 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_405,
-        x_main_module_57,
-        x_main_module_56,
-        x_main_module_55,
-        x_main_module_54);
-    auto x_main_module_407 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_406, x_main_module_398);
-    auto x_main_module_408 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_407);
-    auto x_main_module_409 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_408,
-        x_main_module_53);
-    auto x_main_module_410 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_409,
-        x_main_module_52,
-        x_main_module_51,
-        x_main_module_50,
-        x_main_module_49);
-    auto x_main_module_411 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_410);
-    auto x_main_module_412 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_411,
-        x_main_module_48);
-    auto x_main_module_413 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_412,
-        x_main_module_47,
-        x_main_module_46,
-        x_main_module_45,
-        x_main_module_44);
-    auto x_main_module_414 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_413);
-    auto x_main_module_415 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_414,
-        x_main_module_43);
-    auto x_main_module_416 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_415,
-        x_main_module_42,
-        x_main_module_41,
-        x_main_module_40,
-        x_main_module_39);
-    auto x_main_module_417 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_408,
-        x_main_module_38);
-    auto x_main_module_418 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_417,
-        x_main_module_37,
-        x_main_module_36,
-        x_main_module_35,
-        x_main_module_34);
-    auto x_main_module_419 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_416, x_main_module_418);
-    auto x_main_module_420 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_419);
-    auto x_main_module_421 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_420,
-        x_main_module_33);
-    auto x_main_module_422 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_421,
-        x_main_module_32,
-        x_main_module_31,
-        x_main_module_30,
-        x_main_module_29);
-    auto x_main_module_423 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_422);
-    auto x_main_module_424 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_423,
-        x_main_module_28);
-    auto x_main_module_425 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_424,
-        x_main_module_27,
-        x_main_module_26,
-        x_main_module_25,
-        x_main_module_24);
-    auto x_main_module_426 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_425);
-    auto x_main_module_427 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_426,
-        x_main_module_23);
-    auto x_main_module_428 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_427,
-        x_main_module_22,
-        x_main_module_21,
-        x_main_module_20,
-        x_main_module_19);
-    auto x_main_module_429 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_428, x_main_module_420);
-    auto x_main_module_430 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_429);
-    auto x_main_module_431 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_430,
-        x_main_module_18);
-    auto x_main_module_432 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_431,
-        x_main_module_17,
-        x_main_module_16,
-        x_main_module_15,
-        x_main_module_14);
-    auto x_main_module_433 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_432);
-    auto x_main_module_434 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_433,
-        x_main_module_13);
-    auto x_main_module_435 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_434,
-        x_main_module_12,
-        x_main_module_11,
-        x_main_module_10,
-        x_main_module_9);
-    auto x_main_module_436 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_435);
-    auto x_main_module_437 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_436,
-        x_main_module_8);
-    auto x_main_module_438 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_437,
-        x_main_module_7,
-        x_main_module_6,
-        x_main_module_5,
-        x_main_module_4);
-    auto x_main_module_439 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_438, x_main_module_430);
-    auto x_main_module_440 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_439);
-    auto x_main_module_441 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[7,7],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[0,0,0,0],\"stride\":[1,1]}")),
-        x_main_module_440);
-    auto x_main_module_442 = mmain->add_instruction(
-        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_441);
-    auto x_main_module_443 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
-        x_main_module_3);
-    auto x_main_module_444 =
-        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_442, x_main_module_443);
-    auto x_main_module_445 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        x_main_module_2);
-    auto x_main_module_446 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        x_main_module_0);
-    auto x_main_module_447 =
-        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_445, x_main_module_446);
-    auto x_main_module_448 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_444, x_main_module_447);
-    mmain->add_return({x_main_module_448});
+migraphx::module_ref mmain = p.get_main_module();
+auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
+auto x_main_module_2 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
+auto x_main_module_3 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
+auto x_main_module_4 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 3)));
+auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 4));
+auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 5));
+auto x_main_module_7 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 6)));
+auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 7));
+auto x_main_module_9 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 8)));
+auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 9));
+auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 10));
+auto x_main_module_12 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 11)));
+auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 12));
+auto x_main_module_14 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 13)));
+auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 14));
+auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 15));
+auto x_main_module_17 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 16)));
+auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 17));
+auto x_main_module_19 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 18)));
+auto x_main_module_20 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 19));
+auto x_main_module_21 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 20));
+auto x_main_module_22 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 21)));
+auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 22));
+auto x_main_module_24 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 23)));
+auto x_main_module_25 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 24));
+auto x_main_module_26 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 25));
+auto x_main_module_27 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 26)));
+auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 27));
+auto x_main_module_29 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 28)));
+auto x_main_module_30 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 29));
+auto x_main_module_31 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 30));
+auto x_main_module_32 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 31)));
+auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 32));
+auto x_main_module_34 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 33)));
+auto x_main_module_35 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 34));
+auto x_main_module_36 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 35));
+auto x_main_module_37 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 36)));
+auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 1024, 1, 1}}, 37));
+auto x_main_module_39 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 38)));
+auto x_main_module_40 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 39));
+auto x_main_module_41 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 40));
+auto x_main_module_42 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 41)));
+auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 42));
+auto x_main_module_44 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 43)));
+auto x_main_module_45 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 44));
+auto x_main_module_46 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 45));
+auto x_main_module_47 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 46)));
+auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 47));
+auto x_main_module_49 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 48)));
+auto x_main_module_50 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 49));
+auto x_main_module_51 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 50));
+auto x_main_module_52 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 51)));
+auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 1024, 1, 1}}, 52));
+auto x_main_module_54 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 53)));
+auto x_main_module_55 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 54));
+auto x_main_module_56 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 55));
+auto x_main_module_57 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 56));
+auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 57));
+auto x_main_module_59 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 58)));
+auto x_main_module_60 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 59));
+auto x_main_module_61 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 60));
+auto x_main_module_62 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 61)));
+auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 62));
+auto x_main_module_64 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 63)));
+auto x_main_module_65 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 64));
+auto x_main_module_66 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 65));
+auto x_main_module_67 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 66)));
+auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 67));
+auto x_main_module_69 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 68)));
+auto x_main_module_70 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 69));
+auto x_main_module_71 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 70));
+auto x_main_module_72 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 71));
+auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 72));
+auto x_main_module_74 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 73)));
+auto x_main_module_75 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 74));
+auto x_main_module_76 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 75));
+auto x_main_module_77 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 76)));
+auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 77));
+auto x_main_module_79 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 78)));
+auto x_main_module_80 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 79));
+auto x_main_module_81 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 80));
+auto x_main_module_82 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 81)));
+auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 82));
+auto x_main_module_84 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 83)));
+auto x_main_module_85 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 84));
+auto x_main_module_86 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 85));
+auto x_main_module_87 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 86));
+auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 87));
+auto x_main_module_89 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 88)));
+auto x_main_module_90 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 89));
+auto x_main_module_91 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 90));
+auto x_main_module_92 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 91)));
+auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 92));
+auto x_main_module_94 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 93)));
+auto x_main_module_95 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 94));
+auto x_main_module_96 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 95));
+auto x_main_module_97 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 96)));
+auto x_main_module_98 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 97));
+auto x_main_module_99 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 98)));
+auto x_main_module_100 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 99));
+auto x_main_module_101 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 100));
+auto x_main_module_102 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 101));
+auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 102));
+auto x_main_module_104 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 103)));
+auto x_main_module_105 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 104));
+auto x_main_module_106 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 105));
+auto x_main_module_107 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 106)));
+auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 107));
+auto x_main_module_109 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 108)));
+auto x_main_module_110 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 109));
+auto x_main_module_111 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 110));
+auto x_main_module_112 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 111)));
+auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 112));
+auto x_main_module_114 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 113)));
+auto x_main_module_115 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 114));
+auto x_main_module_116 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 115));
+auto x_main_module_117 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 116));
+auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 117));
+auto x_main_module_119 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 118)));
+auto x_main_module_120 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 119));
+auto x_main_module_121 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 120));
+auto x_main_module_122 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 121)));
+auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 122));
+auto x_main_module_124 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 123)));
+auto x_main_module_125 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 124));
+auto x_main_module_126 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 125));
+auto x_main_module_127 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 126)));
+auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 127));
+auto x_main_module_129 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 128)));
+auto x_main_module_130 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 129));
+auto x_main_module_131 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 130));
+auto x_main_module_132 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 131));
+auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 512, 1, 1}}, 132));
+auto x_main_module_134 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 133)));
+auto x_main_module_135 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 134));
+auto x_main_module_136 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 135));
+auto x_main_module_137 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 136));
+auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 137));
+auto x_main_module_139 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 138)));
+auto x_main_module_140 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 139));
+auto x_main_module_141 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 140));
+auto x_main_module_142 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 141)));
+auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 142));
+auto x_main_module_144 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 143)));
+auto x_main_module_145 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 144));
+auto x_main_module_146 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 145));
+auto x_main_module_147 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 146)));
+auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 512, 1, 1}}, 147));
+auto x_main_module_149 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 148)));
+auto x_main_module_150 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 149));
+auto x_main_module_151 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 150));
+auto x_main_module_152 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 151));
+auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 152));
+auto x_main_module_154 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 153)));
+auto x_main_module_155 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 154));
+auto x_main_module_156 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 155));
+auto x_main_module_157 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 156)));
+auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 157));
+auto x_main_module_159 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 158)));
+auto x_main_module_160 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 159));
+auto x_main_module_161 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 160));
+auto x_main_module_162 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 161)));
+auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 162));
+auto x_main_module_164 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 163)));
+auto x_main_module_165 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 164));
+auto x_main_module_166 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 165));
+auto x_main_module_167 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 166));
+auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 167));
+auto x_main_module_169 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 168)));
+auto x_main_module_170 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 169));
+auto x_main_module_171 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 170));
+auto x_main_module_172 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 171)));
+auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 172));
+auto x_main_module_174 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 173)));
+auto x_main_module_175 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 174));
+auto x_main_module_176 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 175));
+auto x_main_module_177 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 176)));
+auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 177));
+auto x_main_module_179 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 178)));
+auto x_main_module_180 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 179));
+auto x_main_module_181 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 180));
+auto x_main_module_182 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 181));
+auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 182));
+auto x_main_module_184 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 183)));
+auto x_main_module_185 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 184));
+auto x_main_module_186 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 185));
+auto x_main_module_187 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 186)));
+auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 187));
+auto x_main_module_189 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 188)));
+auto x_main_module_190 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 189));
+auto x_main_module_191 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 190));
+auto x_main_module_192 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 191)));
+auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 192));
+auto x_main_module_194 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 193)));
+auto x_main_module_195 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 194));
+auto x_main_module_196 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 195));
+auto x_main_module_197 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 196));
+auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 256, 1, 1}}, 197));
+auto x_main_module_199 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 198)));
+auto x_main_module_200 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 199));
+auto x_main_module_201 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 200));
+auto x_main_module_202 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 201));
+auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 202));
+auto x_main_module_204 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 203)));
+auto x_main_module_205 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 204));
+auto x_main_module_206 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 205));
+auto x_main_module_207 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 206)));
+auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 207));
+auto x_main_module_209 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 208)));
+auto x_main_module_210 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 209));
+auto x_main_module_211 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 210));
+auto x_main_module_212 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 211)));
+auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 256, 1, 1}}, 212));
+auto x_main_module_214 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 213)));
+auto x_main_module_215 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 214));
+auto x_main_module_216 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 215));
+auto x_main_module_217 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 216));
+auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 217));
+auto x_main_module_219 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 218)));
+auto x_main_module_220 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 219));
+auto x_main_module_221 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 220));
+auto x_main_module_222 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 221)));
+auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 222));
+auto x_main_module_224 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 223)));
+auto x_main_module_225 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 224));
+auto x_main_module_226 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 225));
+auto x_main_module_227 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 226)));
+auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 227));
+auto x_main_module_229 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 228)));
+auto x_main_module_230 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 229));
+auto x_main_module_231 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 230));
+auto x_main_module_232 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 231));
+auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 232));
+auto x_main_module_234 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 233)));
+auto x_main_module_235 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 234));
+auto x_main_module_236 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 235));
+auto x_main_module_237 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 236)));
+auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 237));
+auto x_main_module_239 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 238)));
+auto x_main_module_240 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 239));
+auto x_main_module_241 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 240));
+auto x_main_module_242 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 241)));
+auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 242));
+auto x_main_module_244 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 243)));
+auto x_main_module_245 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 244));
+auto x_main_module_246 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 245));
+auto x_main_module_247 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 246));
+auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 247));
+auto x_main_module_249 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 248)));
+auto x_main_module_250 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 249));
+auto x_main_module_251 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 250));
+auto x_main_module_252 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 251));
+auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 252));
+auto x_main_module_254 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 253)));
+auto x_main_module_255 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 254));
+auto x_main_module_256 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 255));
+auto x_main_module_257 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 256)));
+auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 257));
+auto x_main_module_259 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 258)));
+auto x_main_module_260 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 259));
+auto x_main_module_261 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 260));
+auto x_main_module_262 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 261)));
+auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 1, 1}}, 262));
+auto x_main_module_264 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 263)));
+auto x_main_module_265 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 264));
+auto x_main_module_266 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 265));
+auto x_main_module_267 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 266)));
+auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 3, 7, 7}}, 267));
+auto x_main_module_269 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,3,3,3],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_0, x_main_module_268); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_270 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_269, x_main_module_267, x_main_module_266, x_main_module_265, x_main_module_264); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_271 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_270);
+auto x_main_module_272 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[1,1,1,1],\"stride\":[2,2]}")), x_main_module_271); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_273 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_272, x_main_module_263); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_274 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_273, x_main_module_262, x_main_module_261, x_main_module_260, x_main_module_259); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_275 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_274);
+auto x_main_module_276 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_275, x_main_module_258); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_277 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_276, x_main_module_257, x_main_module_256, x_main_module_255, x_main_module_254); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_278 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_277);
+auto x_main_module_279 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_278, x_main_module_253); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_280 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_279, x_main_module_252, x_main_module_251, x_main_module_250, x_main_module_249); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_281 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_272, x_main_module_248); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_282 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_281, x_main_module_247, x_main_module_246, x_main_module_245, x_main_module_244); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_283 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_280, x_main_module_282);
+auto x_main_module_284 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_283);
+auto x_main_module_285 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_284, x_main_module_243); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_286 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_285, x_main_module_242, x_main_module_241, x_main_module_240, x_main_module_239); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_287 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_286);
+auto x_main_module_288 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_287, x_main_module_238); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_289 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_288, x_main_module_237, x_main_module_236, x_main_module_235, x_main_module_234); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_290 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_289);
+auto x_main_module_291 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_290, x_main_module_233); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_292 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_291, x_main_module_232, x_main_module_231, x_main_module_230, x_main_module_229); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_293 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_292, x_main_module_284);
+auto x_main_module_294 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_293);
+auto x_main_module_295 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_294, x_main_module_228); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_296 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_295, x_main_module_227, x_main_module_226, x_main_module_225, x_main_module_224); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_297 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_296);
+auto x_main_module_298 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_297, x_main_module_223); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_299 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_298, x_main_module_222, x_main_module_221, x_main_module_220, x_main_module_219); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_300 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_299);
+auto x_main_module_301 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_300, x_main_module_218); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_302 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_301, x_main_module_217, x_main_module_216, x_main_module_215, x_main_module_214); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_303 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_302, x_main_module_294);
+auto x_main_module_304 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_303);
+auto x_main_module_305 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_304, x_main_module_213); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_306 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_305, x_main_module_212, x_main_module_211, x_main_module_210, x_main_module_209); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_307 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_306);
+auto x_main_module_308 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_307, x_main_module_208); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_309 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_308, x_main_module_207, x_main_module_206, x_main_module_205, x_main_module_204); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_310 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_309);
+auto x_main_module_311 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_310, x_main_module_203); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_312 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_311, x_main_module_202, x_main_module_201, x_main_module_200, x_main_module_199); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_313 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_304, x_main_module_198); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_314 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_313, x_main_module_197, x_main_module_196, x_main_module_195, x_main_module_194); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_315 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_312, x_main_module_314);
+auto x_main_module_316 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_315);
+auto x_main_module_317 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_316, x_main_module_193); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_318 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_317, x_main_module_192, x_main_module_191, x_main_module_190, x_main_module_189); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_319 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_318);
+auto x_main_module_320 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_319, x_main_module_188); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_321 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_320, x_main_module_187, x_main_module_186, x_main_module_185, x_main_module_184); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_322 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_321);
+auto x_main_module_323 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_322, x_main_module_183); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_324 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_323, x_main_module_182, x_main_module_181, x_main_module_180, x_main_module_179); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_325 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_324, x_main_module_316);
+auto x_main_module_326 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_325);
+auto x_main_module_327 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_326, x_main_module_178); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_328 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_327, x_main_module_177, x_main_module_176, x_main_module_175, x_main_module_174); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_329 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_328);
+auto x_main_module_330 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_329, x_main_module_173); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_331 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_330, x_main_module_172, x_main_module_171, x_main_module_170, x_main_module_169); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_332 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_331);
+auto x_main_module_333 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_332, x_main_module_168); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_334 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_333, x_main_module_167, x_main_module_166, x_main_module_165, x_main_module_164); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_335 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_334, x_main_module_326);
+auto x_main_module_336 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_335);
+auto x_main_module_337 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_336, x_main_module_163); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_338 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_337, x_main_module_162, x_main_module_161, x_main_module_160, x_main_module_159); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_339 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_338);
+auto x_main_module_340 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_339, x_main_module_158); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_341 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_340, x_main_module_157, x_main_module_156, x_main_module_155, x_main_module_154); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_342 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_341);
+auto x_main_module_343 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_342, x_main_module_153); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_344 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_343, x_main_module_152, x_main_module_151, x_main_module_150, x_main_module_149); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_345 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_344, x_main_module_336);
+auto x_main_module_346 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_345);
+auto x_main_module_347 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_346, x_main_module_148); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_348 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_347, x_main_module_147, x_main_module_146, x_main_module_145, x_main_module_144); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_349 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_348);
+auto x_main_module_350 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_349, x_main_module_143); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_351 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_350, x_main_module_142, x_main_module_141, x_main_module_140, x_main_module_139); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_352 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_351);
+auto x_main_module_353 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_352, x_main_module_138); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_354 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_353, x_main_module_137, x_main_module_136, x_main_module_135, x_main_module_134); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_355 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_346, x_main_module_133); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_356 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_355, x_main_module_132, x_main_module_131, x_main_module_130, x_main_module_129); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_357 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_354, x_main_module_356);
+auto x_main_module_358 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_357);
+auto x_main_module_359 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_358, x_main_module_128); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_360 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_359, x_main_module_127, x_main_module_126, x_main_module_125, x_main_module_124); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_361 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_360);
+auto x_main_module_362 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_361, x_main_module_123); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_363 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_362, x_main_module_122, x_main_module_121, x_main_module_120, x_main_module_119); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_364 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_363);
+auto x_main_module_365 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_364, x_main_module_118); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_366 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_365, x_main_module_117, x_main_module_116, x_main_module_115, x_main_module_114); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_367 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_366, x_main_module_358);
+auto x_main_module_368 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_367);
+auto x_main_module_369 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_368, x_main_module_113); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_370 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_369, x_main_module_112, x_main_module_111, x_main_module_110, x_main_module_109); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_371 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_370);
+auto x_main_module_372 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_371, x_main_module_108); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_373 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_372, x_main_module_107, x_main_module_106, x_main_module_105, x_main_module_104); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_374 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_373);
+auto x_main_module_375 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_374, x_main_module_103); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_376 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_375, x_main_module_102, x_main_module_101, x_main_module_100, x_main_module_99); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_377 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_376, x_main_module_368);
+auto x_main_module_378 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_377);
+auto x_main_module_379 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_378, x_main_module_98); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_380 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_379, x_main_module_97, x_main_module_96, x_main_module_95, x_main_module_94); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_381 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_380);
+auto x_main_module_382 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_381, x_main_module_93); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_383 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_382, x_main_module_92, x_main_module_91, x_main_module_90, x_main_module_89); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_384 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_383);
+auto x_main_module_385 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_384, x_main_module_88); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_386 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_385, x_main_module_87, x_main_module_86, x_main_module_85, x_main_module_84); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_387 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_386, x_main_module_378);
+auto x_main_module_388 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_387);
+auto x_main_module_389 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_388, x_main_module_83); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_390 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_389, x_main_module_82, x_main_module_81, x_main_module_80, x_main_module_79); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_391 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_390);
+auto x_main_module_392 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_391, x_main_module_78); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_393 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_392, x_main_module_77, x_main_module_76, x_main_module_75, x_main_module_74); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_394 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_393);
+auto x_main_module_395 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_394, x_main_module_73); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_396 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_395, x_main_module_72, x_main_module_71, x_main_module_70, x_main_module_69); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_397 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_396, x_main_module_388);
+auto x_main_module_398 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_397);
+auto x_main_module_399 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_398, x_main_module_68); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_400 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_399, x_main_module_67, x_main_module_66, x_main_module_65, x_main_module_64); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_401 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_400);
+auto x_main_module_402 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_401, x_main_module_63); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_403 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_402, x_main_module_62, x_main_module_61, x_main_module_60, x_main_module_59); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_404 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_403);
+auto x_main_module_405 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_404, x_main_module_58); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_406 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_405, x_main_module_57, x_main_module_56, x_main_module_55, x_main_module_54); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_407 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_406, x_main_module_398);
+auto x_main_module_408 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_407);
+auto x_main_module_409 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_408, x_main_module_53); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_410 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_409, x_main_module_52, x_main_module_51, x_main_module_50, x_main_module_49); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_411 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_410);
+auto x_main_module_412 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_411, x_main_module_48); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_413 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_412, x_main_module_47, x_main_module_46, x_main_module_45, x_main_module_44); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_414 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_413);
+auto x_main_module_415 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_414, x_main_module_43); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_416 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_415, x_main_module_42, x_main_module_41, x_main_module_40, x_main_module_39); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_417 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_408, x_main_module_38); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_418 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_417, x_main_module_37, x_main_module_36, x_main_module_35, x_main_module_34); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_419 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_416, x_main_module_418);
+auto x_main_module_420 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_419);
+auto x_main_module_421 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_420, x_main_module_33); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_422 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_421, x_main_module_32, x_main_module_31, x_main_module_30, x_main_module_29); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_423 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_422);
+auto x_main_module_424 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_423, x_main_module_28); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_425 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_424, x_main_module_27, x_main_module_26, x_main_module_25, x_main_module_24); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_426 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_425);
+auto x_main_module_427 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_426, x_main_module_23); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_428 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_427, x_main_module_22, x_main_module_21, x_main_module_20, x_main_module_19); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_429 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_428, x_main_module_420);
+auto x_main_module_430 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_429);
+auto x_main_module_431 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_430, x_main_module_18); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_432 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_431, x_main_module_17, x_main_module_16, x_main_module_15, x_main_module_14); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_433 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_432);
+auto x_main_module_434 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_433, x_main_module_13); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_435 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_434, x_main_module_12, x_main_module_11, x_main_module_10, x_main_module_9); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_436 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_435);
+auto x_main_module_437 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_436, x_main_module_8); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_438 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_437, x_main_module_7, x_main_module_6, x_main_module_5, x_main_module_4); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_439 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_438, x_main_module_430);
+auto x_main_module_440 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_439);
+auto x_main_module_441 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[7,7],\"lp_order\":2,\"mode\":0,\"padding\":[0,0,0,0],\"stride\":[1,1]}")), x_main_module_440); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_442 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), x_main_module_441); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_443 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_3); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_444 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_442, x_main_module_443);
+auto x_main_module_445 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_2); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_446 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_0); //NOLINT(modernize-raw-string-literal)
+auto x_main_module_447 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_445, x_main_module_446);
+auto x_main_module_448 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_444, x_main_module_447);
+mmain->add_return({x_main_module_448});
+
 
     return p;
 }

--- a/src/driver/resnet50.cpp
+++ b/src/driver/resnet50.cpp
@@ -33,458 +33,1558 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program resnet50(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-migraphx::module_ref mmain = p.get_main_module();
-auto _x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-auto _x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
-auto _x_main_module_2 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
-auto _x_main_module_3 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
-auto _x_main_module_4 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 3)));
-auto _x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 4));
-auto _x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 5));
-auto _x_main_module_7 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 6)));
-auto _x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 7));
-auto _x_main_module_9 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 8)));
-auto _x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 9));
-auto _x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 10));
-auto _x_main_module_12 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 11)));
-auto _x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 12));
-auto _x_main_module_14 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 13)));
-auto _x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 14));
-auto _x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 15));
-auto _x_main_module_17 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 16)));
-auto _x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 17));
-auto _x_main_module_19 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 18)));
-auto _x_main_module_20 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 19));
-auto _x_main_module_21 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 20));
-auto _x_main_module_22 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 21)));
-auto _x_main_module_23 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 22));
-auto _x_main_module_24 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 23)));
-auto _x_main_module_25 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 24));
-auto _x_main_module_26 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 25));
-auto _x_main_module_27 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 26)));
-auto _x_main_module_28 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 27));
-auto _x_main_module_29 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 28)));
-auto _x_main_module_30 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 29));
-auto _x_main_module_31 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 30));
-auto _x_main_module_32 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 31)));
-auto _x_main_module_33 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 32));
-auto _x_main_module_34 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 33)));
-auto _x_main_module_35 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 34));
-auto _x_main_module_36 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 35));
-auto _x_main_module_37 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 36)));
-auto _x_main_module_38 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 1024, 1, 1}}, 37));
-auto _x_main_module_39 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 38)));
-auto _x_main_module_40 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 39));
-auto _x_main_module_41 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 40));
-auto _x_main_module_42 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 41)));
-auto _x_main_module_43 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 42));
-auto _x_main_module_44 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 43)));
-auto _x_main_module_45 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 44));
-auto _x_main_module_46 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 45));
-auto _x_main_module_47 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 46)));
-auto _x_main_module_48 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 47));
-auto _x_main_module_49 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 48)));
-auto _x_main_module_50 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 49));
-auto _x_main_module_51 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 50));
-auto _x_main_module_52 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 51)));
-auto _x_main_module_53 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 1024, 1, 1}}, 52));
-auto _x_main_module_54 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 53)));
-auto _x_main_module_55 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 54));
-auto _x_main_module_56 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 55));
-auto _x_main_module_57 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 56));
-auto _x_main_module_58 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 57));
-auto _x_main_module_59 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 58)));
-auto _x_main_module_60 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 59));
-auto _x_main_module_61 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 60));
-auto _x_main_module_62 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 61)));
-auto _x_main_module_63 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 62));
-auto _x_main_module_64 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 63)));
-auto _x_main_module_65 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 64));
-auto _x_main_module_66 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 65));
-auto _x_main_module_67 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 66)));
-auto _x_main_module_68 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 67));
-auto _x_main_module_69 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 68)));
-auto _x_main_module_70 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 69));
-auto _x_main_module_71 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 70));
-auto _x_main_module_72 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 71));
-auto _x_main_module_73 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 72));
-auto _x_main_module_74 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 73)));
-auto _x_main_module_75 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 74));
-auto _x_main_module_76 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 75));
-auto _x_main_module_77 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 76)));
-auto _x_main_module_78 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 77));
-auto _x_main_module_79 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 78)));
-auto _x_main_module_80 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 79));
-auto _x_main_module_81 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 80));
-auto _x_main_module_82 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 81)));
-auto _x_main_module_83 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 82));
-auto _x_main_module_84 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 83)));
-auto _x_main_module_85 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 84));
-auto _x_main_module_86 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 85));
-auto _x_main_module_87 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 86));
-auto _x_main_module_88 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 87));
-auto _x_main_module_89 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 88)));
-auto _x_main_module_90 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 89));
-auto _x_main_module_91 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 90));
-auto _x_main_module_92 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 91)));
-auto _x_main_module_93 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 92));
-auto _x_main_module_94 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 93)));
-auto _x_main_module_95 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 94));
-auto _x_main_module_96 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 95));
-auto _x_main_module_97 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 96)));
-auto _x_main_module_98 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 97));
-auto _x_main_module_99 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 98)));
-auto _x_main_module_100 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 99));
-auto _x_main_module_101 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 100));
-auto _x_main_module_102 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 101));
-auto _x_main_module_103 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 102));
-auto _x_main_module_104 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 103)));
-auto _x_main_module_105 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 104));
-auto _x_main_module_106 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 105));
-auto _x_main_module_107 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 106)));
-auto _x_main_module_108 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 107));
-auto _x_main_module_109 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 108)));
-auto _x_main_module_110 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 109));
-auto _x_main_module_111 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 110));
-auto _x_main_module_112 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 111)));
-auto _x_main_module_113 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 112));
-auto _x_main_module_114 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 113)));
-auto _x_main_module_115 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 114));
-auto _x_main_module_116 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 115));
-auto _x_main_module_117 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 116));
-auto _x_main_module_118 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 117));
-auto _x_main_module_119 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 118)));
-auto _x_main_module_120 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 119));
-auto _x_main_module_121 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 120));
-auto _x_main_module_122 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 121)));
-auto _x_main_module_123 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 122));
-auto _x_main_module_124 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 123)));
-auto _x_main_module_125 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 124));
-auto _x_main_module_126 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 125));
-auto _x_main_module_127 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 126)));
-auto _x_main_module_128 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 127));
-auto _x_main_module_129 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 128)));
-auto _x_main_module_130 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 129));
-auto _x_main_module_131 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 130));
-auto _x_main_module_132 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 131));
-auto _x_main_module_133 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 512, 1, 1}}, 132));
-auto _x_main_module_134 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 133)));
-auto _x_main_module_135 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 134));
-auto _x_main_module_136 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 135));
-auto _x_main_module_137 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 136));
-auto _x_main_module_138 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 137));
-auto _x_main_module_139 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 138)));
-auto _x_main_module_140 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 139));
-auto _x_main_module_141 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 140));
-auto _x_main_module_142 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 141)));
-auto _x_main_module_143 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 142));
-auto _x_main_module_144 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 143)));
-auto _x_main_module_145 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 144));
-auto _x_main_module_146 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 145));
-auto _x_main_module_147 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 146)));
-auto _x_main_module_148 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 512, 1, 1}}, 147));
-auto _x_main_module_149 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 148)));
-auto _x_main_module_150 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 149));
-auto _x_main_module_151 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 150));
-auto _x_main_module_152 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 151));
-auto _x_main_module_153 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 152));
-auto _x_main_module_154 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 153)));
-auto _x_main_module_155 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 154));
-auto _x_main_module_156 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 155));
-auto _x_main_module_157 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 156)));
-auto _x_main_module_158 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 157));
-auto _x_main_module_159 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 158)));
-auto _x_main_module_160 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 159));
-auto _x_main_module_161 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 160));
-auto _x_main_module_162 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 161)));
-auto _x_main_module_163 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 162));
-auto _x_main_module_164 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 163)));
-auto _x_main_module_165 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 164));
-auto _x_main_module_166 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 165));
-auto _x_main_module_167 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 166));
-auto _x_main_module_168 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 167));
-auto _x_main_module_169 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 168)));
-auto _x_main_module_170 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 169));
-auto _x_main_module_171 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 170));
-auto _x_main_module_172 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 171)));
-auto _x_main_module_173 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 172));
-auto _x_main_module_174 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 173)));
-auto _x_main_module_175 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 174));
-auto _x_main_module_176 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 175));
-auto _x_main_module_177 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 176)));
-auto _x_main_module_178 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 177));
-auto _x_main_module_179 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 178)));
-auto _x_main_module_180 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 179));
-auto _x_main_module_181 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 180));
-auto _x_main_module_182 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 181));
-auto _x_main_module_183 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 182));
-auto _x_main_module_184 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 183)));
-auto _x_main_module_185 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 184));
-auto _x_main_module_186 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 185));
-auto _x_main_module_187 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 186)));
-auto _x_main_module_188 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 187));
-auto _x_main_module_189 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 188)));
-auto _x_main_module_190 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 189));
-auto _x_main_module_191 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 190));
-auto _x_main_module_192 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 191)));
-auto _x_main_module_193 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 192));
-auto _x_main_module_194 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 193)));
-auto _x_main_module_195 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 194));
-auto _x_main_module_196 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 195));
-auto _x_main_module_197 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 196));
-auto _x_main_module_198 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 256, 1, 1}}, 197));
-auto _x_main_module_199 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 198)));
-auto _x_main_module_200 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 199));
-auto _x_main_module_201 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 200));
-auto _x_main_module_202 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 201));
-auto _x_main_module_203 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 202));
-auto _x_main_module_204 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 203)));
-auto _x_main_module_205 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 204));
-auto _x_main_module_206 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 205));
-auto _x_main_module_207 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 206)));
-auto _x_main_module_208 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 207));
-auto _x_main_module_209 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 208)));
-auto _x_main_module_210 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 209));
-auto _x_main_module_211 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 210));
-auto _x_main_module_212 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 211)));
-auto _x_main_module_213 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 256, 1, 1}}, 212));
-auto _x_main_module_214 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 213)));
-auto _x_main_module_215 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 214));
-auto _x_main_module_216 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 215));
-auto _x_main_module_217 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 216));
-auto _x_main_module_218 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 217));
-auto _x_main_module_219 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 218)));
-auto _x_main_module_220 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 219));
-auto _x_main_module_221 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 220));
-auto _x_main_module_222 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 221)));
-auto _x_main_module_223 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 222));
-auto _x_main_module_224 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 223)));
-auto _x_main_module_225 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 224));
-auto _x_main_module_226 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 225));
-auto _x_main_module_227 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 226)));
-auto _x_main_module_228 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 227));
-auto _x_main_module_229 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 228)));
-auto _x_main_module_230 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 229));
-auto _x_main_module_231 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 230));
-auto _x_main_module_232 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 231));
-auto _x_main_module_233 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 232));
-auto _x_main_module_234 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 233)));
-auto _x_main_module_235 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 234));
-auto _x_main_module_236 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 235));
-auto _x_main_module_237 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 236)));
-auto _x_main_module_238 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 237));
-auto _x_main_module_239 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 238)));
-auto _x_main_module_240 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 239));
-auto _x_main_module_241 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 240));
-auto _x_main_module_242 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 241)));
-auto _x_main_module_243 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 242));
-auto _x_main_module_244 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 243)));
-auto _x_main_module_245 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 244));
-auto _x_main_module_246 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 245));
-auto _x_main_module_247 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 246));
-auto _x_main_module_248 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 247));
-auto _x_main_module_249 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 248)));
-auto _x_main_module_250 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 249));
-auto _x_main_module_251 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 250));
-auto _x_main_module_252 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 251));
-auto _x_main_module_253 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 252));
-auto _x_main_module_254 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 253)));
-auto _x_main_module_255 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 254));
-auto _x_main_module_256 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 255));
-auto _x_main_module_257 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 256)));
-auto _x_main_module_258 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 257));
-auto _x_main_module_259 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 258)));
-auto _x_main_module_260 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 259));
-auto _x_main_module_261 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 260));
-auto _x_main_module_262 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 261)));
-auto _x_main_module_263 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 1, 1}}, 262));
-auto _x_main_module_264 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 263)));
-auto _x_main_module_265 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 264));
-auto _x_main_module_266 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 265));
-auto _x_main_module_267 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 266)));
-auto _x_main_module_268 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 3, 7, 7}}, 267));
-auto _x_main_module_269 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,3,3,3],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_0, _x_main_module_268);
-auto _x_main_module_270 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_269, _x_main_module_267, _x_main_module_266, _x_main_module_265, _x_main_module_264);
-auto _x_main_module_271 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_270);
-auto _x_main_module_272 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[1,1,1,1],\"stride\":[2,2]}")), _x_main_module_271);
-auto _x_main_module_273 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_272, _x_main_module_263);
-auto _x_main_module_274 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_273, _x_main_module_262, _x_main_module_261, _x_main_module_260, _x_main_module_259);
-auto _x_main_module_275 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_274);
-auto _x_main_module_276 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_275, _x_main_module_258);
-auto _x_main_module_277 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_276, _x_main_module_257, _x_main_module_256, _x_main_module_255, _x_main_module_254);
-auto _x_main_module_278 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_277);
-auto _x_main_module_279 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_278, _x_main_module_253);
-auto _x_main_module_280 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_279, _x_main_module_252, _x_main_module_251, _x_main_module_250, _x_main_module_249);
-auto _x_main_module_281 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_272, _x_main_module_248);
-auto _x_main_module_282 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_281, _x_main_module_247, _x_main_module_246, _x_main_module_245, _x_main_module_244);
-auto _x_main_module_283 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_280, _x_main_module_282);
-auto _x_main_module_284 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_283);
-auto _x_main_module_285 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_284, _x_main_module_243);
-auto _x_main_module_286 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_285, _x_main_module_242, _x_main_module_241, _x_main_module_240, _x_main_module_239);
-auto _x_main_module_287 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_286);
-auto _x_main_module_288 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_287, _x_main_module_238);
-auto _x_main_module_289 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_288, _x_main_module_237, _x_main_module_236, _x_main_module_235, _x_main_module_234);
-auto _x_main_module_290 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_289);
-auto _x_main_module_291 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_290, _x_main_module_233);
-auto _x_main_module_292 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_291, _x_main_module_232, _x_main_module_231, _x_main_module_230, _x_main_module_229);
-auto _x_main_module_293 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_292, _x_main_module_284);
-auto _x_main_module_294 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_293);
-auto _x_main_module_295 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_294, _x_main_module_228);
-auto _x_main_module_296 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_295, _x_main_module_227, _x_main_module_226, _x_main_module_225, _x_main_module_224);
-auto _x_main_module_297 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_296);
-auto _x_main_module_298 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_297, _x_main_module_223);
-auto _x_main_module_299 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_298, _x_main_module_222, _x_main_module_221, _x_main_module_220, _x_main_module_219);
-auto _x_main_module_300 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_299);
-auto _x_main_module_301 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_300, _x_main_module_218);
-auto _x_main_module_302 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_301, _x_main_module_217, _x_main_module_216, _x_main_module_215, _x_main_module_214);
-auto _x_main_module_303 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_302, _x_main_module_294);
-auto _x_main_module_304 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_303);
-auto _x_main_module_305 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_304, _x_main_module_213);
-auto _x_main_module_306 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_305, _x_main_module_212, _x_main_module_211, _x_main_module_210, _x_main_module_209);
-auto _x_main_module_307 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_306);
-auto _x_main_module_308 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_307, _x_main_module_208);
-auto _x_main_module_309 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_308, _x_main_module_207, _x_main_module_206, _x_main_module_205, _x_main_module_204);
-auto _x_main_module_310 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_309);
-auto _x_main_module_311 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_310, _x_main_module_203);
-auto _x_main_module_312 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_311, _x_main_module_202, _x_main_module_201, _x_main_module_200, _x_main_module_199);
-auto _x_main_module_313 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_304, _x_main_module_198);
-auto _x_main_module_314 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_313, _x_main_module_197, _x_main_module_196, _x_main_module_195, _x_main_module_194);
-auto _x_main_module_315 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_312, _x_main_module_314);
-auto _x_main_module_316 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_315);
-auto _x_main_module_317 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_316, _x_main_module_193);
-auto _x_main_module_318 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_317, _x_main_module_192, _x_main_module_191, _x_main_module_190, _x_main_module_189);
-auto _x_main_module_319 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_318);
-auto _x_main_module_320 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_319, _x_main_module_188);
-auto _x_main_module_321 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_320, _x_main_module_187, _x_main_module_186, _x_main_module_185, _x_main_module_184);
-auto _x_main_module_322 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_321);
-auto _x_main_module_323 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_322, _x_main_module_183);
-auto _x_main_module_324 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_323, _x_main_module_182, _x_main_module_181, _x_main_module_180, _x_main_module_179);
-auto _x_main_module_325 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_324, _x_main_module_316);
-auto _x_main_module_326 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_325);
-auto _x_main_module_327 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_326, _x_main_module_178);
-auto _x_main_module_328 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_327, _x_main_module_177, _x_main_module_176, _x_main_module_175, _x_main_module_174);
-auto _x_main_module_329 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_328);
-auto _x_main_module_330 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_329, _x_main_module_173);
-auto _x_main_module_331 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_330, _x_main_module_172, _x_main_module_171, _x_main_module_170, _x_main_module_169);
-auto _x_main_module_332 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_331);
-auto _x_main_module_333 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_332, _x_main_module_168);
-auto _x_main_module_334 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_333, _x_main_module_167, _x_main_module_166, _x_main_module_165, _x_main_module_164);
-auto _x_main_module_335 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_334, _x_main_module_326);
-auto _x_main_module_336 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_335);
-auto _x_main_module_337 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_336, _x_main_module_163);
-auto _x_main_module_338 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_337, _x_main_module_162, _x_main_module_161, _x_main_module_160, _x_main_module_159);
-auto _x_main_module_339 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_338);
-auto _x_main_module_340 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_339, _x_main_module_158);
-auto _x_main_module_341 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_340, _x_main_module_157, _x_main_module_156, _x_main_module_155, _x_main_module_154);
-auto _x_main_module_342 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_341);
-auto _x_main_module_343 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_342, _x_main_module_153);
-auto _x_main_module_344 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_343, _x_main_module_152, _x_main_module_151, _x_main_module_150, _x_main_module_149);
-auto _x_main_module_345 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_344, _x_main_module_336);
-auto _x_main_module_346 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_345);
-auto _x_main_module_347 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_346, _x_main_module_148);
-auto _x_main_module_348 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_347, _x_main_module_147, _x_main_module_146, _x_main_module_145, _x_main_module_144);
-auto _x_main_module_349 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_348);
-auto _x_main_module_350 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_349, _x_main_module_143);
-auto _x_main_module_351 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_350, _x_main_module_142, _x_main_module_141, _x_main_module_140, _x_main_module_139);
-auto _x_main_module_352 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_351);
-auto _x_main_module_353 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_352, _x_main_module_138);
-auto _x_main_module_354 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_353, _x_main_module_137, _x_main_module_136, _x_main_module_135, _x_main_module_134);
-auto _x_main_module_355 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_346, _x_main_module_133);
-auto _x_main_module_356 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_355, _x_main_module_132, _x_main_module_131, _x_main_module_130, _x_main_module_129);
-auto _x_main_module_357 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_354, _x_main_module_356);
-auto _x_main_module_358 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_357);
-auto _x_main_module_359 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_358, _x_main_module_128);
-auto _x_main_module_360 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_359, _x_main_module_127, _x_main_module_126, _x_main_module_125, _x_main_module_124);
-auto _x_main_module_361 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_360);
-auto _x_main_module_362 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_361, _x_main_module_123);
-auto _x_main_module_363 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_362, _x_main_module_122, _x_main_module_121, _x_main_module_120, _x_main_module_119);
-auto _x_main_module_364 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_363);
-auto _x_main_module_365 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_364, _x_main_module_118);
-auto _x_main_module_366 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_365, _x_main_module_117, _x_main_module_116, _x_main_module_115, _x_main_module_114);
-auto _x_main_module_367 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_366, _x_main_module_358);
-auto _x_main_module_368 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_367);
-auto _x_main_module_369 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_368, _x_main_module_113);
-auto _x_main_module_370 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_369, _x_main_module_112, _x_main_module_111, _x_main_module_110, _x_main_module_109);
-auto _x_main_module_371 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_370);
-auto _x_main_module_372 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_371, _x_main_module_108);
-auto _x_main_module_373 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_372, _x_main_module_107, _x_main_module_106, _x_main_module_105, _x_main_module_104);
-auto _x_main_module_374 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_373);
-auto _x_main_module_375 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_374, _x_main_module_103);
-auto _x_main_module_376 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_375, _x_main_module_102, _x_main_module_101, _x_main_module_100, _x_main_module_99);
-auto _x_main_module_377 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_376, _x_main_module_368);
-auto _x_main_module_378 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_377);
-auto _x_main_module_379 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_378, _x_main_module_98);
-auto _x_main_module_380 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_379, _x_main_module_97, _x_main_module_96, _x_main_module_95, _x_main_module_94);
-auto _x_main_module_381 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_380);
-auto _x_main_module_382 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_381, _x_main_module_93);
-auto _x_main_module_383 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_382, _x_main_module_92, _x_main_module_91, _x_main_module_90, _x_main_module_89);
-auto _x_main_module_384 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_383);
-auto _x_main_module_385 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_384, _x_main_module_88);
-auto _x_main_module_386 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_385, _x_main_module_87, _x_main_module_86, _x_main_module_85, _x_main_module_84);
-auto _x_main_module_387 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_386, _x_main_module_378);
-auto _x_main_module_388 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_387);
-auto _x_main_module_389 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_388, _x_main_module_83);
-auto _x_main_module_390 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_389, _x_main_module_82, _x_main_module_81, _x_main_module_80, _x_main_module_79);
-auto _x_main_module_391 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_390);
-auto _x_main_module_392 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_391, _x_main_module_78);
-auto _x_main_module_393 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_392, _x_main_module_77, _x_main_module_76, _x_main_module_75, _x_main_module_74);
-auto _x_main_module_394 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_393);
-auto _x_main_module_395 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_394, _x_main_module_73);
-auto _x_main_module_396 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_395, _x_main_module_72, _x_main_module_71, _x_main_module_70, _x_main_module_69);
-auto _x_main_module_397 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_396, _x_main_module_388);
-auto _x_main_module_398 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_397);
-auto _x_main_module_399 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_398, _x_main_module_68);
-auto _x_main_module_400 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_399, _x_main_module_67, _x_main_module_66, _x_main_module_65, _x_main_module_64);
-auto _x_main_module_401 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_400);
-auto _x_main_module_402 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_401, _x_main_module_63);
-auto _x_main_module_403 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_402, _x_main_module_62, _x_main_module_61, _x_main_module_60, _x_main_module_59);
-auto _x_main_module_404 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_403);
-auto _x_main_module_405 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_404, _x_main_module_58);
-auto _x_main_module_406 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_405, _x_main_module_57, _x_main_module_56, _x_main_module_55, _x_main_module_54);
-auto _x_main_module_407 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_406, _x_main_module_398);
-auto _x_main_module_408 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_407);
-auto _x_main_module_409 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_408, _x_main_module_53);
-auto _x_main_module_410 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_409, _x_main_module_52, _x_main_module_51, _x_main_module_50, _x_main_module_49);
-auto _x_main_module_411 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_410);
-auto _x_main_module_412 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_411, _x_main_module_48);
-auto _x_main_module_413 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_412, _x_main_module_47, _x_main_module_46, _x_main_module_45, _x_main_module_44);
-auto _x_main_module_414 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_413);
-auto _x_main_module_415 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_414, _x_main_module_43);
-auto _x_main_module_416 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_415, _x_main_module_42, _x_main_module_41, _x_main_module_40, _x_main_module_39);
-auto _x_main_module_417 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_408, _x_main_module_38);
-auto _x_main_module_418 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_417, _x_main_module_37, _x_main_module_36, _x_main_module_35, _x_main_module_34);
-auto _x_main_module_419 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_416, _x_main_module_418);
-auto _x_main_module_420 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_419);
-auto _x_main_module_421 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_420, _x_main_module_33);
-auto _x_main_module_422 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_421, _x_main_module_32, _x_main_module_31, _x_main_module_30, _x_main_module_29);
-auto _x_main_module_423 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_422);
-auto _x_main_module_424 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_423, _x_main_module_28);
-auto _x_main_module_425 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_424, _x_main_module_27, _x_main_module_26, _x_main_module_25, _x_main_module_24);
-auto _x_main_module_426 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_425);
-auto _x_main_module_427 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_426, _x_main_module_23);
-auto _x_main_module_428 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_427, _x_main_module_22, _x_main_module_21, _x_main_module_20, _x_main_module_19);
-auto _x_main_module_429 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_428, _x_main_module_420);
-auto _x_main_module_430 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_429);
-auto _x_main_module_431 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_430, _x_main_module_18);
-auto _x_main_module_432 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_431, _x_main_module_17, _x_main_module_16, _x_main_module_15, _x_main_module_14);
-auto _x_main_module_433 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_432);
-auto _x_main_module_434 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_433, _x_main_module_13);
-auto _x_main_module_435 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_434, _x_main_module_12, _x_main_module_11, _x_main_module_10, _x_main_module_9);
-auto _x_main_module_436 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_435);
-auto _x_main_module_437 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_436, _x_main_module_8);
-auto _x_main_module_438 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_437, _x_main_module_7, _x_main_module_6, _x_main_module_5, _x_main_module_4);
-auto _x_main_module_439 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_438, _x_main_module_430);
-auto _x_main_module_440 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_439);
-auto _x_main_module_441 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[7,7],\"lp_order\":2,\"mode\":0,\"padding\":[0,0,0,0],\"stride\":[1,1]}")), _x_main_module_440);
-auto _x_main_module_442 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_441);
-auto _x_main_module_443 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), _x_main_module_3);
-auto _x_main_module_444 = mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_442, _x_main_module_443);
-auto _x_main_module_445 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), _x_main_module_2);
-auto _x_main_module_446 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), _x_main_module_0);
-auto _x_main_module_447 = mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_445, _x_main_module_446);
-auto _x_main_module_448 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_444, _x_main_module_447);
-mmain->add_return({_x_main_module_448});
-
+    migraphx::module_ref mmain = p.get_main_module();
+    auto _x_main_module_0      = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+    auto _x_0                  = mmain->add_parameter(
+        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
+    auto _x_main_module_2 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
+    auto _x_main_module_3 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
+    auto _x_main_module_4 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 3)));
+    auto _x_main_module_5 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 4));
+    auto _x_main_module_6 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 5));
+    auto _x_main_module_7  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 6)));
+    auto _x_main_module_8  = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 7));
+    auto _x_main_module_9  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 8)));
+    auto _x_main_module_10 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 9));
+    auto _x_main_module_11 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 10));
+    auto _x_main_module_12 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 11)));
+    auto _x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 12));
+    auto _x_main_module_14 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 13)));
+    auto _x_main_module_15 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 14));
+    auto _x_main_module_16 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 15));
+    auto _x_main_module_17 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 16)));
+    auto _x_main_module_18 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 17));
+    auto _x_main_module_19 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 18)));
+    auto _x_main_module_20 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 19));
+    auto _x_main_module_21 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 20));
+    auto _x_main_module_22 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 21)));
+    auto _x_main_module_23 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 22));
+    auto _x_main_module_24 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 23)));
+    auto _x_main_module_25 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 24));
+    auto _x_main_module_26 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 25));
+    auto _x_main_module_27 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 26)));
+    auto _x_main_module_28 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 27));
+    auto _x_main_module_29 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 28)));
+    auto _x_main_module_30 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 29));
+    auto _x_main_module_31 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 30));
+    auto _x_main_module_32 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 31)));
+    auto _x_main_module_33 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 32));
+    auto _x_main_module_34 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 33)));
+    auto _x_main_module_35 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 34));
+    auto _x_main_module_36 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 35));
+    auto _x_main_module_37 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 36)));
+    auto _x_main_module_38 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {2048, 1024, 1, 1}}, 37));
+    auto _x_main_module_39 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 38)));
+    auto _x_main_module_40 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 39));
+    auto _x_main_module_41 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 40));
+    auto _x_main_module_42 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 41)));
+    auto _x_main_module_43 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 42));
+    auto _x_main_module_44 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 43)));
+    auto _x_main_module_45 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 44));
+    auto _x_main_module_46 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 45));
+    auto _x_main_module_47 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 46)));
+    auto _x_main_module_48 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 47));
+    auto _x_main_module_49 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 48)));
+    auto _x_main_module_50 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 49));
+    auto _x_main_module_51 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 50));
+    auto _x_main_module_52 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 51)));
+    auto _x_main_module_53 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 1024, 1, 1}}, 52));
+    auto _x_main_module_54 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 53)));
+    auto _x_main_module_55 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 54));
+    auto _x_main_module_56 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 55));
+    auto _x_main_module_57 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 56));
+    auto _x_main_module_58 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 57));
+    auto _x_main_module_59 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 58)));
+    auto _x_main_module_60 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 59));
+    auto _x_main_module_61 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 60));
+    auto _x_main_module_62 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 61)));
+    auto _x_main_module_63 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 62));
+    auto _x_main_module_64 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 63)));
+    auto _x_main_module_65 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 64));
+    auto _x_main_module_66 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 65));
+    auto _x_main_module_67 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 66)));
+    auto _x_main_module_68 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 67));
+    auto _x_main_module_69 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 68)));
+    auto _x_main_module_70 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 69));
+    auto _x_main_module_71 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 70));
+    auto _x_main_module_72 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 71));
+    auto _x_main_module_73 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 72));
+    auto _x_main_module_74 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 73)));
+    auto _x_main_module_75 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 74));
+    auto _x_main_module_76 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 75));
+    auto _x_main_module_77 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 76)));
+    auto _x_main_module_78 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 77));
+    auto _x_main_module_79 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 78)));
+    auto _x_main_module_80 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 79));
+    auto _x_main_module_81 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 80));
+    auto _x_main_module_82 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 81)));
+    auto _x_main_module_83 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 82));
+    auto _x_main_module_84 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 83)));
+    auto _x_main_module_85 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 84));
+    auto _x_main_module_86 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 85));
+    auto _x_main_module_87 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 86));
+    auto _x_main_module_88 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 87));
+    auto _x_main_module_89 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 88)));
+    auto _x_main_module_90 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 89));
+    auto _x_main_module_91 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 90));
+    auto _x_main_module_92 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 91)));
+    auto _x_main_module_93 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 92));
+    auto _x_main_module_94 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 93)));
+    auto _x_main_module_95 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 94));
+    auto _x_main_module_96 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 95));
+    auto _x_main_module_97  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 96)));
+    auto _x_main_module_98  = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 97));
+    auto _x_main_module_99  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 98)));
+    auto _x_main_module_100 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 99));
+    auto _x_main_module_101 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 100));
+    auto _x_main_module_102 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 101));
+    auto _x_main_module_103 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 102));
+    auto _x_main_module_104 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 103)));
+    auto _x_main_module_105 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 104));
+    auto _x_main_module_106 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 105));
+    auto _x_main_module_107 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 106)));
+    auto _x_main_module_108 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 107));
+    auto _x_main_module_109 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 108)));
+    auto _x_main_module_110 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 109));
+    auto _x_main_module_111 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 110));
+    auto _x_main_module_112 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 111)));
+    auto _x_main_module_113 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 112));
+    auto _x_main_module_114 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 113)));
+    auto _x_main_module_115 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 114));
+    auto _x_main_module_116 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 115));
+    auto _x_main_module_117 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 116));
+    auto _x_main_module_118 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 117));
+    auto _x_main_module_119 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 118)));
+    auto _x_main_module_120 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 119));
+    auto _x_main_module_121 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 120));
+    auto _x_main_module_122 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 121)));
+    auto _x_main_module_123 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 122));
+    auto _x_main_module_124 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 123)));
+    auto _x_main_module_125 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 124));
+    auto _x_main_module_126 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 125));
+    auto _x_main_module_127 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 126)));
+    auto _x_main_module_128 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 127));
+    auto _x_main_module_129 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 128)));
+    auto _x_main_module_130 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 129));
+    auto _x_main_module_131 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 130));
+    auto _x_main_module_132 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 131));
+    auto _x_main_module_133 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 512, 1, 1}}, 132));
+    auto _x_main_module_134 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 133)));
+    auto _x_main_module_135 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 134));
+    auto _x_main_module_136 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 135));
+    auto _x_main_module_137 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 136));
+    auto _x_main_module_138 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 137));
+    auto _x_main_module_139 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 138)));
+    auto _x_main_module_140 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 139));
+    auto _x_main_module_141 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 140));
+    auto _x_main_module_142 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 141)));
+    auto _x_main_module_143 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 142));
+    auto _x_main_module_144 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 143)));
+    auto _x_main_module_145 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 144));
+    auto _x_main_module_146 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 145));
+    auto _x_main_module_147 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 146)));
+    auto _x_main_module_148 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 512, 1, 1}}, 147));
+    auto _x_main_module_149 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 148)));
+    auto _x_main_module_150 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 149));
+    auto _x_main_module_151 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 150));
+    auto _x_main_module_152 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 151));
+    auto _x_main_module_153 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 152));
+    auto _x_main_module_154 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 153)));
+    auto _x_main_module_155 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 154));
+    auto _x_main_module_156 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 155));
+    auto _x_main_module_157 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 156)));
+    auto _x_main_module_158 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 157));
+    auto _x_main_module_159 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 158)));
+    auto _x_main_module_160 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 159));
+    auto _x_main_module_161 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 160));
+    auto _x_main_module_162 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 161)));
+    auto _x_main_module_163 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 162));
+    auto _x_main_module_164 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 163)));
+    auto _x_main_module_165 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 164));
+    auto _x_main_module_166 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 165));
+    auto _x_main_module_167 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 166));
+    auto _x_main_module_168 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 167));
+    auto _x_main_module_169 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 168)));
+    auto _x_main_module_170 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 169));
+    auto _x_main_module_171 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 170));
+    auto _x_main_module_172 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 171)));
+    auto _x_main_module_173 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 172));
+    auto _x_main_module_174 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 173)));
+    auto _x_main_module_175 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 174));
+    auto _x_main_module_176 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 175));
+    auto _x_main_module_177 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 176)));
+    auto _x_main_module_178 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 177));
+    auto _x_main_module_179 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 178)));
+    auto _x_main_module_180 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 179));
+    auto _x_main_module_181 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 180));
+    auto _x_main_module_182 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 181));
+    auto _x_main_module_183 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 182));
+    auto _x_main_module_184 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 183)));
+    auto _x_main_module_185 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 184));
+    auto _x_main_module_186 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 185));
+    auto _x_main_module_187 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 186)));
+    auto _x_main_module_188 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 187));
+    auto _x_main_module_189 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 188)));
+    auto _x_main_module_190 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 189));
+    auto _x_main_module_191 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 190));
+    auto _x_main_module_192 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 191)));
+    auto _x_main_module_193 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 192));
+    auto _x_main_module_194 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 193)));
+    auto _x_main_module_195 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 194));
+    auto _x_main_module_196 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 195));
+    auto _x_main_module_197 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 196));
+    auto _x_main_module_198 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 256, 1, 1}}, 197));
+    auto _x_main_module_199 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 198)));
+    auto _x_main_module_200 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 199));
+    auto _x_main_module_201 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 200));
+    auto _x_main_module_202 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 201));
+    auto _x_main_module_203 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 202));
+    auto _x_main_module_204 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 203)));
+    auto _x_main_module_205 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 204));
+    auto _x_main_module_206 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 205));
+    auto _x_main_module_207 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 206)));
+    auto _x_main_module_208 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 207));
+    auto _x_main_module_209 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 208)));
+    auto _x_main_module_210 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 209));
+    auto _x_main_module_211 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 210));
+    auto _x_main_module_212 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 211)));
+    auto _x_main_module_213 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 256, 1, 1}}, 212));
+    auto _x_main_module_214 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 213)));
+    auto _x_main_module_215 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 214));
+    auto _x_main_module_216 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 215));
+    auto _x_main_module_217 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 216));
+    auto _x_main_module_218 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 217));
+    auto _x_main_module_219 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 218)));
+    auto _x_main_module_220 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 219));
+    auto _x_main_module_221 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 220));
+    auto _x_main_module_222 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 221)));
+    auto _x_main_module_223 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 222));
+    auto _x_main_module_224 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 223)));
+    auto _x_main_module_225 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 224));
+    auto _x_main_module_226 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 225));
+    auto _x_main_module_227 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 226)));
+    auto _x_main_module_228 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 227));
+    auto _x_main_module_229 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 228)));
+    auto _x_main_module_230 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 229));
+    auto _x_main_module_231 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 230));
+    auto _x_main_module_232 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 231));
+    auto _x_main_module_233 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 232));
+    auto _x_main_module_234 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 233)));
+    auto _x_main_module_235 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 234));
+    auto _x_main_module_236 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 235));
+    auto _x_main_module_237 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 236)));
+    auto _x_main_module_238 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 237));
+    auto _x_main_module_239 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 238)));
+    auto _x_main_module_240 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 239));
+    auto _x_main_module_241 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 240));
+    auto _x_main_module_242 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 241)));
+    auto _x_main_module_243 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 242));
+    auto _x_main_module_244 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 243)));
+    auto _x_main_module_245 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 244));
+    auto _x_main_module_246 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 245));
+    auto _x_main_module_247 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 246));
+    auto _x_main_module_248 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 247));
+    auto _x_main_module_249 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 248)));
+    auto _x_main_module_250 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 249));
+    auto _x_main_module_251 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 250));
+    auto _x_main_module_252 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 251));
+    auto _x_main_module_253 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 252));
+    auto _x_main_module_254 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 253)));
+    auto _x_main_module_255 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 254));
+    auto _x_main_module_256 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 255));
+    auto _x_main_module_257 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 256)));
+    auto _x_main_module_258 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 257));
+    auto _x_main_module_259 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 258)));
+    auto _x_main_module_260 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 259));
+    auto _x_main_module_261 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 260));
+    auto _x_main_module_262 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 261)));
+    auto _x_main_module_263 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 64, 1, 1}}, 262));
+    auto _x_main_module_264 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 263)));
+    auto _x_main_module_265 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 264));
+    auto _x_main_module_266 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 265));
+    auto _x_main_module_267 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 266)));
+    auto _x_main_module_268 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 3, 7, 7}}, 267));
+    auto _x_main_module_269 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,3,3,3],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        _x_0,
+        _x_main_module_268);
+    auto _x_main_module_270 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_269,
+        _x_main_module_267,
+        _x_main_module_266,
+        _x_main_module_265,
+        _x_main_module_264);
+    auto _x_main_module_271 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_270);
+    auto _x_main_module_272 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[1,1,1,1],\"stride\":[2,2]}")),
+        _x_main_module_271);
+    auto _x_main_module_273 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_272,
+        _x_main_module_263);
+    auto _x_main_module_274 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_273,
+        _x_main_module_262,
+        _x_main_module_261,
+        _x_main_module_260,
+        _x_main_module_259);
+    auto _x_main_module_275 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_274);
+    auto _x_main_module_276 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_275,
+        _x_main_module_258);
+    auto _x_main_module_277 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_276,
+        _x_main_module_257,
+        _x_main_module_256,
+        _x_main_module_255,
+        _x_main_module_254);
+    auto _x_main_module_278 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_277);
+    auto _x_main_module_279 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_278,
+        _x_main_module_253);
+    auto _x_main_module_280 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_279,
+        _x_main_module_252,
+        _x_main_module_251,
+        _x_main_module_250,
+        _x_main_module_249);
+    auto _x_main_module_281 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_272,
+        _x_main_module_248);
+    auto _x_main_module_282 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_281,
+        _x_main_module_247,
+        _x_main_module_246,
+        _x_main_module_245,
+        _x_main_module_244);
+    auto _x_main_module_283 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_280, _x_main_module_282);
+    auto _x_main_module_284 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_283);
+    auto _x_main_module_285 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_284,
+        _x_main_module_243);
+    auto _x_main_module_286 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_285,
+        _x_main_module_242,
+        _x_main_module_241,
+        _x_main_module_240,
+        _x_main_module_239);
+    auto _x_main_module_287 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_286);
+    auto _x_main_module_288 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_287,
+        _x_main_module_238);
+    auto _x_main_module_289 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_288,
+        _x_main_module_237,
+        _x_main_module_236,
+        _x_main_module_235,
+        _x_main_module_234);
+    auto _x_main_module_290 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_289);
+    auto _x_main_module_291 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_290,
+        _x_main_module_233);
+    auto _x_main_module_292 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_291,
+        _x_main_module_232,
+        _x_main_module_231,
+        _x_main_module_230,
+        _x_main_module_229);
+    auto _x_main_module_293 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_292, _x_main_module_284);
+    auto _x_main_module_294 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_293);
+    auto _x_main_module_295 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_294,
+        _x_main_module_228);
+    auto _x_main_module_296 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_295,
+        _x_main_module_227,
+        _x_main_module_226,
+        _x_main_module_225,
+        _x_main_module_224);
+    auto _x_main_module_297 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_296);
+    auto _x_main_module_298 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_297,
+        _x_main_module_223);
+    auto _x_main_module_299 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_298,
+        _x_main_module_222,
+        _x_main_module_221,
+        _x_main_module_220,
+        _x_main_module_219);
+    auto _x_main_module_300 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_299);
+    auto _x_main_module_301 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_300,
+        _x_main_module_218);
+    auto _x_main_module_302 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_301,
+        _x_main_module_217,
+        _x_main_module_216,
+        _x_main_module_215,
+        _x_main_module_214);
+    auto _x_main_module_303 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_302, _x_main_module_294);
+    auto _x_main_module_304 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_303);
+    auto _x_main_module_305 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_304,
+        _x_main_module_213);
+    auto _x_main_module_306 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_305,
+        _x_main_module_212,
+        _x_main_module_211,
+        _x_main_module_210,
+        _x_main_module_209);
+    auto _x_main_module_307 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_306);
+    auto _x_main_module_308 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_307,
+        _x_main_module_208);
+    auto _x_main_module_309 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_308,
+        _x_main_module_207,
+        _x_main_module_206,
+        _x_main_module_205,
+        _x_main_module_204);
+    auto _x_main_module_310 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_309);
+    auto _x_main_module_311 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_310,
+        _x_main_module_203);
+    auto _x_main_module_312 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_311,
+        _x_main_module_202,
+        _x_main_module_201,
+        _x_main_module_200,
+        _x_main_module_199);
+    auto _x_main_module_313 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_304,
+        _x_main_module_198);
+    auto _x_main_module_314 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_313,
+        _x_main_module_197,
+        _x_main_module_196,
+        _x_main_module_195,
+        _x_main_module_194);
+    auto _x_main_module_315 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_312, _x_main_module_314);
+    auto _x_main_module_316 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_315);
+    auto _x_main_module_317 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_316,
+        _x_main_module_193);
+    auto _x_main_module_318 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_317,
+        _x_main_module_192,
+        _x_main_module_191,
+        _x_main_module_190,
+        _x_main_module_189);
+    auto _x_main_module_319 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_318);
+    auto _x_main_module_320 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_319,
+        _x_main_module_188);
+    auto _x_main_module_321 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_320,
+        _x_main_module_187,
+        _x_main_module_186,
+        _x_main_module_185,
+        _x_main_module_184);
+    auto _x_main_module_322 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_321);
+    auto _x_main_module_323 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_322,
+        _x_main_module_183);
+    auto _x_main_module_324 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_323,
+        _x_main_module_182,
+        _x_main_module_181,
+        _x_main_module_180,
+        _x_main_module_179);
+    auto _x_main_module_325 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_324, _x_main_module_316);
+    auto _x_main_module_326 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_325);
+    auto _x_main_module_327 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_326,
+        _x_main_module_178);
+    auto _x_main_module_328 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_327,
+        _x_main_module_177,
+        _x_main_module_176,
+        _x_main_module_175,
+        _x_main_module_174);
+    auto _x_main_module_329 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_328);
+    auto _x_main_module_330 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_329,
+        _x_main_module_173);
+    auto _x_main_module_331 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_330,
+        _x_main_module_172,
+        _x_main_module_171,
+        _x_main_module_170,
+        _x_main_module_169);
+    auto _x_main_module_332 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_331);
+    auto _x_main_module_333 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_332,
+        _x_main_module_168);
+    auto _x_main_module_334 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_333,
+        _x_main_module_167,
+        _x_main_module_166,
+        _x_main_module_165,
+        _x_main_module_164);
+    auto _x_main_module_335 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_334, _x_main_module_326);
+    auto _x_main_module_336 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_335);
+    auto _x_main_module_337 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_336,
+        _x_main_module_163);
+    auto _x_main_module_338 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_337,
+        _x_main_module_162,
+        _x_main_module_161,
+        _x_main_module_160,
+        _x_main_module_159);
+    auto _x_main_module_339 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_338);
+    auto _x_main_module_340 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_339,
+        _x_main_module_158);
+    auto _x_main_module_341 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_340,
+        _x_main_module_157,
+        _x_main_module_156,
+        _x_main_module_155,
+        _x_main_module_154);
+    auto _x_main_module_342 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_341);
+    auto _x_main_module_343 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_342,
+        _x_main_module_153);
+    auto _x_main_module_344 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_343,
+        _x_main_module_152,
+        _x_main_module_151,
+        _x_main_module_150,
+        _x_main_module_149);
+    auto _x_main_module_345 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_344, _x_main_module_336);
+    auto _x_main_module_346 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_345);
+    auto _x_main_module_347 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_346,
+        _x_main_module_148);
+    auto _x_main_module_348 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_347,
+        _x_main_module_147,
+        _x_main_module_146,
+        _x_main_module_145,
+        _x_main_module_144);
+    auto _x_main_module_349 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_348);
+    auto _x_main_module_350 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_349,
+        _x_main_module_143);
+    auto _x_main_module_351 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_350,
+        _x_main_module_142,
+        _x_main_module_141,
+        _x_main_module_140,
+        _x_main_module_139);
+    auto _x_main_module_352 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_351);
+    auto _x_main_module_353 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_352,
+        _x_main_module_138);
+    auto _x_main_module_354 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_353,
+        _x_main_module_137,
+        _x_main_module_136,
+        _x_main_module_135,
+        _x_main_module_134);
+    auto _x_main_module_355 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_346,
+        _x_main_module_133);
+    auto _x_main_module_356 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_355,
+        _x_main_module_132,
+        _x_main_module_131,
+        _x_main_module_130,
+        _x_main_module_129);
+    auto _x_main_module_357 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_354, _x_main_module_356);
+    auto _x_main_module_358 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_357);
+    auto _x_main_module_359 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_358,
+        _x_main_module_128);
+    auto _x_main_module_360 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_359,
+        _x_main_module_127,
+        _x_main_module_126,
+        _x_main_module_125,
+        _x_main_module_124);
+    auto _x_main_module_361 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_360);
+    auto _x_main_module_362 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_361,
+        _x_main_module_123);
+    auto _x_main_module_363 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_362,
+        _x_main_module_122,
+        _x_main_module_121,
+        _x_main_module_120,
+        _x_main_module_119);
+    auto _x_main_module_364 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_363);
+    auto _x_main_module_365 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_364,
+        _x_main_module_118);
+    auto _x_main_module_366 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_365,
+        _x_main_module_117,
+        _x_main_module_116,
+        _x_main_module_115,
+        _x_main_module_114);
+    auto _x_main_module_367 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_366, _x_main_module_358);
+    auto _x_main_module_368 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_367);
+    auto _x_main_module_369 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_368,
+        _x_main_module_113);
+    auto _x_main_module_370 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_369,
+        _x_main_module_112,
+        _x_main_module_111,
+        _x_main_module_110,
+        _x_main_module_109);
+    auto _x_main_module_371 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_370);
+    auto _x_main_module_372 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_371,
+        _x_main_module_108);
+    auto _x_main_module_373 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_372,
+        _x_main_module_107,
+        _x_main_module_106,
+        _x_main_module_105,
+        _x_main_module_104);
+    auto _x_main_module_374 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_373);
+    auto _x_main_module_375 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_374,
+        _x_main_module_103);
+    auto _x_main_module_376 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_375,
+        _x_main_module_102,
+        _x_main_module_101,
+        _x_main_module_100,
+        _x_main_module_99);
+    auto _x_main_module_377 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_376, _x_main_module_368);
+    auto _x_main_module_378 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_377);
+    auto _x_main_module_379 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_378,
+        _x_main_module_98);
+    auto _x_main_module_380 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_379,
+        _x_main_module_97,
+        _x_main_module_96,
+        _x_main_module_95,
+        _x_main_module_94);
+    auto _x_main_module_381 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_380);
+    auto _x_main_module_382 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_381,
+        _x_main_module_93);
+    auto _x_main_module_383 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_382,
+        _x_main_module_92,
+        _x_main_module_91,
+        _x_main_module_90,
+        _x_main_module_89);
+    auto _x_main_module_384 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_383);
+    auto _x_main_module_385 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_384,
+        _x_main_module_88);
+    auto _x_main_module_386 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_385,
+        _x_main_module_87,
+        _x_main_module_86,
+        _x_main_module_85,
+        _x_main_module_84);
+    auto _x_main_module_387 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_386, _x_main_module_378);
+    auto _x_main_module_388 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_387);
+    auto _x_main_module_389 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_388,
+        _x_main_module_83);
+    auto _x_main_module_390 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_389,
+        _x_main_module_82,
+        _x_main_module_81,
+        _x_main_module_80,
+        _x_main_module_79);
+    auto _x_main_module_391 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_390);
+    auto _x_main_module_392 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_391,
+        _x_main_module_78);
+    auto _x_main_module_393 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_392,
+        _x_main_module_77,
+        _x_main_module_76,
+        _x_main_module_75,
+        _x_main_module_74);
+    auto _x_main_module_394 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_393);
+    auto _x_main_module_395 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_394,
+        _x_main_module_73);
+    auto _x_main_module_396 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_395,
+        _x_main_module_72,
+        _x_main_module_71,
+        _x_main_module_70,
+        _x_main_module_69);
+    auto _x_main_module_397 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_396, _x_main_module_388);
+    auto _x_main_module_398 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_397);
+    auto _x_main_module_399 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_398,
+        _x_main_module_68);
+    auto _x_main_module_400 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_399,
+        _x_main_module_67,
+        _x_main_module_66,
+        _x_main_module_65,
+        _x_main_module_64);
+    auto _x_main_module_401 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_400);
+    auto _x_main_module_402 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_401,
+        _x_main_module_63);
+    auto _x_main_module_403 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_402,
+        _x_main_module_62,
+        _x_main_module_61,
+        _x_main_module_60,
+        _x_main_module_59);
+    auto _x_main_module_404 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_403);
+    auto _x_main_module_405 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_404,
+        _x_main_module_58);
+    auto _x_main_module_406 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_405,
+        _x_main_module_57,
+        _x_main_module_56,
+        _x_main_module_55,
+        _x_main_module_54);
+    auto _x_main_module_407 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_406, _x_main_module_398);
+    auto _x_main_module_408 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_407);
+    auto _x_main_module_409 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_408,
+        _x_main_module_53);
+    auto _x_main_module_410 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_409,
+        _x_main_module_52,
+        _x_main_module_51,
+        _x_main_module_50,
+        _x_main_module_49);
+    auto _x_main_module_411 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_410);
+    auto _x_main_module_412 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_411,
+        _x_main_module_48);
+    auto _x_main_module_413 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_412,
+        _x_main_module_47,
+        _x_main_module_46,
+        _x_main_module_45,
+        _x_main_module_44);
+    auto _x_main_module_414 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_413);
+    auto _x_main_module_415 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_414,
+        _x_main_module_43);
+    auto _x_main_module_416 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_415,
+        _x_main_module_42,
+        _x_main_module_41,
+        _x_main_module_40,
+        _x_main_module_39);
+    auto _x_main_module_417 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_408,
+        _x_main_module_38);
+    auto _x_main_module_418 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_417,
+        _x_main_module_37,
+        _x_main_module_36,
+        _x_main_module_35,
+        _x_main_module_34);
+    auto _x_main_module_419 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_416, _x_main_module_418);
+    auto _x_main_module_420 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_419);
+    auto _x_main_module_421 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_420,
+        _x_main_module_33);
+    auto _x_main_module_422 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_421,
+        _x_main_module_32,
+        _x_main_module_31,
+        _x_main_module_30,
+        _x_main_module_29);
+    auto _x_main_module_423 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_422);
+    auto _x_main_module_424 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_423,
+        _x_main_module_28);
+    auto _x_main_module_425 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_424,
+        _x_main_module_27,
+        _x_main_module_26,
+        _x_main_module_25,
+        _x_main_module_24);
+    auto _x_main_module_426 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_425);
+    auto _x_main_module_427 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_426,
+        _x_main_module_23);
+    auto _x_main_module_428 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_427,
+        _x_main_module_22,
+        _x_main_module_21,
+        _x_main_module_20,
+        _x_main_module_19);
+    auto _x_main_module_429 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_428, _x_main_module_420);
+    auto _x_main_module_430 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_429);
+    auto _x_main_module_431 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_430,
+        _x_main_module_18);
+    auto _x_main_module_432 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_431,
+        _x_main_module_17,
+        _x_main_module_16,
+        _x_main_module_15,
+        _x_main_module_14);
+    auto _x_main_module_433 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_432);
+    auto _x_main_module_434 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_433,
+        _x_main_module_13);
+    auto _x_main_module_435 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_434,
+        _x_main_module_12,
+        _x_main_module_11,
+        _x_main_module_10,
+        _x_main_module_9);
+    auto _x_main_module_436 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_435);
+    auto _x_main_module_437 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        _x_main_module_436,
+        _x_main_module_8);
+    auto _x_main_module_438 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        _x_main_module_437,
+        _x_main_module_7,
+        _x_main_module_6,
+        _x_main_module_5,
+        _x_main_module_4);
+    auto _x_main_module_439 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_438, _x_main_module_430);
+    auto _x_main_module_440 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_439);
+    auto _x_main_module_441 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[7,7],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[0,0,0,0],\"stride\":[1,1]}")),
+        _x_main_module_440);
+    auto _x_main_module_442 = mmain->add_instruction(
+        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")),
+        _x_main_module_441);
+    auto _x_main_module_443 = mmain->add_instruction(
+        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
+        _x_main_module_3);
+    auto _x_main_module_444 =
+        mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_442, _x_main_module_443);
+    auto _x_main_module_445 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        _x_main_module_2);
+    auto _x_main_module_446 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        _x_main_module_0);
+    auto _x_main_module_447 =
+        mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_445, _x_main_module_446);
+    auto _x_main_module_448 =
+        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_444, _x_main_module_447);
+    mmain->add_return({_x_main_module_448});
 
     return p;
 }

--- a/src/driver/resnet50.cpp
+++ b/src/driver/resnet50.cpp
@@ -32,458 +32,1446 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program resnet50(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-migraphx::module_ref mmain = p.get_main_module();
-auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
-auto x_main_module_2 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
-auto x_main_module_3 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
-auto x_main_module_4 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 3)));
-auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 4));
-auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 5));
-auto x_main_module_7 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 6)));
-auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 7));
-auto x_main_module_9 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 8)));
-auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 9));
-auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 10));
-auto x_main_module_12 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 11)));
-auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 12));
-auto x_main_module_14 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 13)));
-auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 14));
-auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 15));
-auto x_main_module_17 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 16)));
-auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 17));
-auto x_main_module_19 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 18)));
-auto x_main_module_20 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 19));
-auto x_main_module_21 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 20));
-auto x_main_module_22 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 21)));
-auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 22));
-auto x_main_module_24 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 23)));
-auto x_main_module_25 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 24));
-auto x_main_module_26 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 25));
-auto x_main_module_27 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 26)));
-auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 27));
-auto x_main_module_29 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 28)));
-auto x_main_module_30 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 29));
-auto x_main_module_31 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 30));
-auto x_main_module_32 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 31)));
-auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 32));
-auto x_main_module_34 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 33)));
-auto x_main_module_35 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 34));
-auto x_main_module_36 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 35));
-auto x_main_module_37 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 36)));
-auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 1024, 1, 1}}, 37));
-auto x_main_module_39 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 38)));
-auto x_main_module_40 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 39));
-auto x_main_module_41 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 40));
-auto x_main_module_42 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 41)));
-auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 42));
-auto x_main_module_44 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 43)));
-auto x_main_module_45 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 44));
-auto x_main_module_46 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 45));
-auto x_main_module_47 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 46)));
-auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 47));
-auto x_main_module_49 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 48)));
-auto x_main_module_50 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 49));
-auto x_main_module_51 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 50));
-auto x_main_module_52 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 51)));
-auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 1024, 1, 1}}, 52));
-auto x_main_module_54 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 53)));
-auto x_main_module_55 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 54));
-auto x_main_module_56 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 55));
-auto x_main_module_57 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 56));
-auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 57));
-auto x_main_module_59 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 58)));
-auto x_main_module_60 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 59));
-auto x_main_module_61 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 60));
-auto x_main_module_62 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 61)));
-auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 62));
-auto x_main_module_64 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 63)));
-auto x_main_module_65 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 64));
-auto x_main_module_66 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 65));
-auto x_main_module_67 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 66)));
-auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 67));
-auto x_main_module_69 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 68)));
-auto x_main_module_70 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 69));
-auto x_main_module_71 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 70));
-auto x_main_module_72 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 71));
-auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 72));
-auto x_main_module_74 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 73)));
-auto x_main_module_75 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 74));
-auto x_main_module_76 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 75));
-auto x_main_module_77 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 76)));
-auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 77));
-auto x_main_module_79 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 78)));
-auto x_main_module_80 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 79));
-auto x_main_module_81 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 80));
-auto x_main_module_82 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 81)));
-auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 82));
-auto x_main_module_84 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 83)));
-auto x_main_module_85 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 84));
-auto x_main_module_86 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 85));
-auto x_main_module_87 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 86));
-auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 87));
-auto x_main_module_89 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 88)));
-auto x_main_module_90 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 89));
-auto x_main_module_91 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 90));
-auto x_main_module_92 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 91)));
-auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 92));
-auto x_main_module_94 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 93)));
-auto x_main_module_95 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 94));
-auto x_main_module_96 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 95));
-auto x_main_module_97 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 96)));
-auto x_main_module_98 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 97));
-auto x_main_module_99 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 98)));
-auto x_main_module_100 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 99));
-auto x_main_module_101 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 100));
-auto x_main_module_102 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 101));
-auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 102));
-auto x_main_module_104 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 103)));
-auto x_main_module_105 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 104));
-auto x_main_module_106 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 105));
-auto x_main_module_107 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 106)));
-auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 107));
-auto x_main_module_109 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 108)));
-auto x_main_module_110 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 109));
-auto x_main_module_111 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 110));
-auto x_main_module_112 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 111)));
-auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 112));
-auto x_main_module_114 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 113)));
-auto x_main_module_115 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 114));
-auto x_main_module_116 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 115));
-auto x_main_module_117 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 116));
-auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 117));
-auto x_main_module_119 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 118)));
-auto x_main_module_120 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 119));
-auto x_main_module_121 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 120));
-auto x_main_module_122 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 121)));
-auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 122));
-auto x_main_module_124 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 123)));
-auto x_main_module_125 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 124));
-auto x_main_module_126 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 125));
-auto x_main_module_127 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 126)));
-auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 127));
-auto x_main_module_129 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 128)));
-auto x_main_module_130 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 129));
-auto x_main_module_131 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 130));
-auto x_main_module_132 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 131));
-auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 512, 1, 1}}, 132));
-auto x_main_module_134 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 133)));
-auto x_main_module_135 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 134));
-auto x_main_module_136 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 135));
-auto x_main_module_137 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 136));
-auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 137));
-auto x_main_module_139 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 138)));
-auto x_main_module_140 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 139));
-auto x_main_module_141 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 140));
-auto x_main_module_142 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 141)));
-auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 142));
-auto x_main_module_144 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 143)));
-auto x_main_module_145 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 144));
-auto x_main_module_146 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 145));
-auto x_main_module_147 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 146)));
-auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 512, 1, 1}}, 147));
-auto x_main_module_149 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 148)));
-auto x_main_module_150 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 149));
-auto x_main_module_151 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 150));
-auto x_main_module_152 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 151));
-auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 152));
-auto x_main_module_154 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 153)));
-auto x_main_module_155 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 154));
-auto x_main_module_156 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 155));
-auto x_main_module_157 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 156)));
-auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 157));
-auto x_main_module_159 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 158)));
-auto x_main_module_160 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 159));
-auto x_main_module_161 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 160));
-auto x_main_module_162 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 161)));
-auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 162));
-auto x_main_module_164 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 163)));
-auto x_main_module_165 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 164));
-auto x_main_module_166 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 165));
-auto x_main_module_167 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 166));
-auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 167));
-auto x_main_module_169 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 168)));
-auto x_main_module_170 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 169));
-auto x_main_module_171 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 170));
-auto x_main_module_172 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 171)));
-auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 172));
-auto x_main_module_174 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 173)));
-auto x_main_module_175 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 174));
-auto x_main_module_176 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 175));
-auto x_main_module_177 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 176)));
-auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 177));
-auto x_main_module_179 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 178)));
-auto x_main_module_180 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 179));
-auto x_main_module_181 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 180));
-auto x_main_module_182 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 181));
-auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 182));
-auto x_main_module_184 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 183)));
-auto x_main_module_185 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 184));
-auto x_main_module_186 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 185));
-auto x_main_module_187 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 186)));
-auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 187));
-auto x_main_module_189 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 188)));
-auto x_main_module_190 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 189));
-auto x_main_module_191 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 190));
-auto x_main_module_192 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 191)));
-auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 192));
-auto x_main_module_194 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 193)));
-auto x_main_module_195 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 194));
-auto x_main_module_196 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 195));
-auto x_main_module_197 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 196));
-auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 256, 1, 1}}, 197));
-auto x_main_module_199 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 198)));
-auto x_main_module_200 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 199));
-auto x_main_module_201 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 200));
-auto x_main_module_202 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 201));
-auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 202));
-auto x_main_module_204 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 203)));
-auto x_main_module_205 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 204));
-auto x_main_module_206 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 205));
-auto x_main_module_207 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 206)));
-auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 207));
-auto x_main_module_209 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 208)));
-auto x_main_module_210 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 209));
-auto x_main_module_211 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 210));
-auto x_main_module_212 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 211)));
-auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 256, 1, 1}}, 212));
-auto x_main_module_214 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 213)));
-auto x_main_module_215 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 214));
-auto x_main_module_216 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 215));
-auto x_main_module_217 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 216));
-auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 217));
-auto x_main_module_219 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 218)));
-auto x_main_module_220 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 219));
-auto x_main_module_221 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 220));
-auto x_main_module_222 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 221)));
-auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 222));
-auto x_main_module_224 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 223)));
-auto x_main_module_225 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 224));
-auto x_main_module_226 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 225));
-auto x_main_module_227 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 226)));
-auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 227));
-auto x_main_module_229 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 228)));
-auto x_main_module_230 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 229));
-auto x_main_module_231 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 230));
-auto x_main_module_232 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 231));
-auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 232));
-auto x_main_module_234 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 233)));
-auto x_main_module_235 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 234));
-auto x_main_module_236 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 235));
-auto x_main_module_237 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 236)));
-auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 237));
-auto x_main_module_239 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 238)));
-auto x_main_module_240 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 239));
-auto x_main_module_241 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 240));
-auto x_main_module_242 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 241)));
-auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 242));
-auto x_main_module_244 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 243)));
-auto x_main_module_245 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 244));
-auto x_main_module_246 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 245));
-auto x_main_module_247 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 246));
-auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 247));
-auto x_main_module_249 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 248)));
-auto x_main_module_250 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 249));
-auto x_main_module_251 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 250));
-auto x_main_module_252 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 251));
-auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 252));
-auto x_main_module_254 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 253)));
-auto x_main_module_255 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 254));
-auto x_main_module_256 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 255));
-auto x_main_module_257 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 256)));
-auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 257));
-auto x_main_module_259 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 258)));
-auto x_main_module_260 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 259));
-auto x_main_module_261 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 260));
-auto x_main_module_262 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 261)));
-auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 1, 1}}, 262));
-auto x_main_module_264 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 263)));
-auto x_main_module_265 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 264));
-auto x_main_module_266 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 265));
-auto x_main_module_267 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 266)));
-auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 3, 7, 7}}, 267));
-auto x_main_module_269 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,3,3,3],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_0, x_main_module_268);
-auto x_main_module_270 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_269, x_main_module_267, x_main_module_266, x_main_module_265, x_main_module_264);
-auto x_main_module_271 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_270);
-auto x_main_module_272 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[1,1,1,1],stride:[2,2]}"), x_main_module_271);
-auto x_main_module_273 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_272, x_main_module_263);
-auto x_main_module_274 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_273, x_main_module_262, x_main_module_261, x_main_module_260, x_main_module_259);
-auto x_main_module_275 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_274);
-auto x_main_module_276 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_275, x_main_module_258);
-auto x_main_module_277 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_276, x_main_module_257, x_main_module_256, x_main_module_255, x_main_module_254);
-auto x_main_module_278 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_277);
-auto x_main_module_279 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_278, x_main_module_253);
-auto x_main_module_280 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_279, x_main_module_252, x_main_module_251, x_main_module_250, x_main_module_249);
-auto x_main_module_281 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_272, x_main_module_248);
-auto x_main_module_282 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_281, x_main_module_247, x_main_module_246, x_main_module_245, x_main_module_244);
-auto x_main_module_283 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_280, x_main_module_282);
-auto x_main_module_284 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_283);
-auto x_main_module_285 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_284, x_main_module_243);
-auto x_main_module_286 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_285, x_main_module_242, x_main_module_241, x_main_module_240, x_main_module_239);
-auto x_main_module_287 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_286);
-auto x_main_module_288 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_287, x_main_module_238);
-auto x_main_module_289 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_288, x_main_module_237, x_main_module_236, x_main_module_235, x_main_module_234);
-auto x_main_module_290 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_289);
-auto x_main_module_291 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_290, x_main_module_233);
-auto x_main_module_292 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_291, x_main_module_232, x_main_module_231, x_main_module_230, x_main_module_229);
-auto x_main_module_293 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_292, x_main_module_284);
-auto x_main_module_294 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_293);
-auto x_main_module_295 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_294, x_main_module_228);
-auto x_main_module_296 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_295, x_main_module_227, x_main_module_226, x_main_module_225, x_main_module_224);
-auto x_main_module_297 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_296);
-auto x_main_module_298 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_297, x_main_module_223);
-auto x_main_module_299 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_298, x_main_module_222, x_main_module_221, x_main_module_220, x_main_module_219);
-auto x_main_module_300 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_299);
-auto x_main_module_301 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_300, x_main_module_218);
-auto x_main_module_302 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_301, x_main_module_217, x_main_module_216, x_main_module_215, x_main_module_214);
-auto x_main_module_303 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_302, x_main_module_294);
-auto x_main_module_304 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_303);
-auto x_main_module_305 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_304, x_main_module_213);
-auto x_main_module_306 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_305, x_main_module_212, x_main_module_211, x_main_module_210, x_main_module_209);
-auto x_main_module_307 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_306);
-auto x_main_module_308 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_307, x_main_module_208);
-auto x_main_module_309 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_308, x_main_module_207, x_main_module_206, x_main_module_205, x_main_module_204);
-auto x_main_module_310 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_309);
-auto x_main_module_311 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_310, x_main_module_203);
-auto x_main_module_312 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_311, x_main_module_202, x_main_module_201, x_main_module_200, x_main_module_199);
-auto x_main_module_313 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_304, x_main_module_198);
-auto x_main_module_314 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_313, x_main_module_197, x_main_module_196, x_main_module_195, x_main_module_194);
-auto x_main_module_315 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_312, x_main_module_314);
-auto x_main_module_316 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_315);
-auto x_main_module_317 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_316, x_main_module_193);
-auto x_main_module_318 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_317, x_main_module_192, x_main_module_191, x_main_module_190, x_main_module_189);
-auto x_main_module_319 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_318);
-auto x_main_module_320 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_319, x_main_module_188);
-auto x_main_module_321 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_320, x_main_module_187, x_main_module_186, x_main_module_185, x_main_module_184);
-auto x_main_module_322 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_321);
-auto x_main_module_323 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_322, x_main_module_183);
-auto x_main_module_324 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_323, x_main_module_182, x_main_module_181, x_main_module_180, x_main_module_179);
-auto x_main_module_325 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_324, x_main_module_316);
-auto x_main_module_326 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_325);
-auto x_main_module_327 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_326, x_main_module_178);
-auto x_main_module_328 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_327, x_main_module_177, x_main_module_176, x_main_module_175, x_main_module_174);
-auto x_main_module_329 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_328);
-auto x_main_module_330 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_329, x_main_module_173);
-auto x_main_module_331 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_330, x_main_module_172, x_main_module_171, x_main_module_170, x_main_module_169);
-auto x_main_module_332 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_331);
-auto x_main_module_333 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_332, x_main_module_168);
-auto x_main_module_334 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_333, x_main_module_167, x_main_module_166, x_main_module_165, x_main_module_164);
-auto x_main_module_335 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_334, x_main_module_326);
-auto x_main_module_336 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_335);
-auto x_main_module_337 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_336, x_main_module_163);
-auto x_main_module_338 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_337, x_main_module_162, x_main_module_161, x_main_module_160, x_main_module_159);
-auto x_main_module_339 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_338);
-auto x_main_module_340 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_339, x_main_module_158);
-auto x_main_module_341 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_340, x_main_module_157, x_main_module_156, x_main_module_155, x_main_module_154);
-auto x_main_module_342 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_341);
-auto x_main_module_343 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_342, x_main_module_153);
-auto x_main_module_344 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_343, x_main_module_152, x_main_module_151, x_main_module_150, x_main_module_149);
-auto x_main_module_345 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_344, x_main_module_336);
-auto x_main_module_346 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_345);
-auto x_main_module_347 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_346, x_main_module_148);
-auto x_main_module_348 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_347, x_main_module_147, x_main_module_146, x_main_module_145, x_main_module_144);
-auto x_main_module_349 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_348);
-auto x_main_module_350 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_349, x_main_module_143);
-auto x_main_module_351 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_350, x_main_module_142, x_main_module_141, x_main_module_140, x_main_module_139);
-auto x_main_module_352 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_351);
-auto x_main_module_353 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_352, x_main_module_138);
-auto x_main_module_354 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_353, x_main_module_137, x_main_module_136, x_main_module_135, x_main_module_134);
-auto x_main_module_355 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_346, x_main_module_133);
-auto x_main_module_356 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_355, x_main_module_132, x_main_module_131, x_main_module_130, x_main_module_129);
-auto x_main_module_357 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_354, x_main_module_356);
-auto x_main_module_358 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_357);
-auto x_main_module_359 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_358, x_main_module_128);
-auto x_main_module_360 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_359, x_main_module_127, x_main_module_126, x_main_module_125, x_main_module_124);
-auto x_main_module_361 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_360);
-auto x_main_module_362 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_361, x_main_module_123);
-auto x_main_module_363 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_362, x_main_module_122, x_main_module_121, x_main_module_120, x_main_module_119);
-auto x_main_module_364 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_363);
-auto x_main_module_365 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_364, x_main_module_118);
-auto x_main_module_366 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_365, x_main_module_117, x_main_module_116, x_main_module_115, x_main_module_114);
-auto x_main_module_367 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_366, x_main_module_358);
-auto x_main_module_368 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_367);
-auto x_main_module_369 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_368, x_main_module_113);
-auto x_main_module_370 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_369, x_main_module_112, x_main_module_111, x_main_module_110, x_main_module_109);
-auto x_main_module_371 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_370);
-auto x_main_module_372 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_371, x_main_module_108);
-auto x_main_module_373 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_372, x_main_module_107, x_main_module_106, x_main_module_105, x_main_module_104);
-auto x_main_module_374 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_373);
-auto x_main_module_375 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_374, x_main_module_103);
-auto x_main_module_376 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_375, x_main_module_102, x_main_module_101, x_main_module_100, x_main_module_99);
-auto x_main_module_377 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_376, x_main_module_368);
-auto x_main_module_378 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_377);
-auto x_main_module_379 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_378, x_main_module_98);
-auto x_main_module_380 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_379, x_main_module_97, x_main_module_96, x_main_module_95, x_main_module_94);
-auto x_main_module_381 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_380);
-auto x_main_module_382 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_381, x_main_module_93);
-auto x_main_module_383 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_382, x_main_module_92, x_main_module_91, x_main_module_90, x_main_module_89);
-auto x_main_module_384 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_383);
-auto x_main_module_385 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_384, x_main_module_88);
-auto x_main_module_386 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_385, x_main_module_87, x_main_module_86, x_main_module_85, x_main_module_84);
-auto x_main_module_387 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_386, x_main_module_378);
-auto x_main_module_388 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_387);
-auto x_main_module_389 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_388, x_main_module_83);
-auto x_main_module_390 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_389, x_main_module_82, x_main_module_81, x_main_module_80, x_main_module_79);
-auto x_main_module_391 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_390);
-auto x_main_module_392 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_391, x_main_module_78);
-auto x_main_module_393 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_392, x_main_module_77, x_main_module_76, x_main_module_75, x_main_module_74);
-auto x_main_module_394 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_393);
-auto x_main_module_395 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_394, x_main_module_73);
-auto x_main_module_396 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_395, x_main_module_72, x_main_module_71, x_main_module_70, x_main_module_69);
-auto x_main_module_397 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_396, x_main_module_388);
-auto x_main_module_398 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_397);
-auto x_main_module_399 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_398, x_main_module_68);
-auto x_main_module_400 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_399, x_main_module_67, x_main_module_66, x_main_module_65, x_main_module_64);
-auto x_main_module_401 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_400);
-auto x_main_module_402 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_401, x_main_module_63);
-auto x_main_module_403 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_402, x_main_module_62, x_main_module_61, x_main_module_60, x_main_module_59);
-auto x_main_module_404 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_403);
-auto x_main_module_405 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_404, x_main_module_58);
-auto x_main_module_406 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_405, x_main_module_57, x_main_module_56, x_main_module_55, x_main_module_54);
-auto x_main_module_407 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_406, x_main_module_398);
-auto x_main_module_408 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_407);
-auto x_main_module_409 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_408, x_main_module_53);
-auto x_main_module_410 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_409, x_main_module_52, x_main_module_51, x_main_module_50, x_main_module_49);
-auto x_main_module_411 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_410);
-auto x_main_module_412 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_411, x_main_module_48);
-auto x_main_module_413 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_412, x_main_module_47, x_main_module_46, x_main_module_45, x_main_module_44);
-auto x_main_module_414 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_413);
-auto x_main_module_415 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_414, x_main_module_43);
-auto x_main_module_416 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_415, x_main_module_42, x_main_module_41, x_main_module_40, x_main_module_39);
-auto x_main_module_417 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_408, x_main_module_38);
-auto x_main_module_418 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_417, x_main_module_37, x_main_module_36, x_main_module_35, x_main_module_34);
-auto x_main_module_419 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_416, x_main_module_418);
-auto x_main_module_420 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_419);
-auto x_main_module_421 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_420, x_main_module_33);
-auto x_main_module_422 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_421, x_main_module_32, x_main_module_31, x_main_module_30, x_main_module_29);
-auto x_main_module_423 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_422);
-auto x_main_module_424 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_423, x_main_module_28);
-auto x_main_module_425 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_424, x_main_module_27, x_main_module_26, x_main_module_25, x_main_module_24);
-auto x_main_module_426 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_425);
-auto x_main_module_427 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_426, x_main_module_23);
-auto x_main_module_428 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_427, x_main_module_22, x_main_module_21, x_main_module_20, x_main_module_19);
-auto x_main_module_429 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_428, x_main_module_420);
-auto x_main_module_430 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_429);
-auto x_main_module_431 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_430, x_main_module_18);
-auto x_main_module_432 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_431, x_main_module_17, x_main_module_16, x_main_module_15, x_main_module_14);
-auto x_main_module_433 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_432);
-auto x_main_module_434 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_433, x_main_module_13);
-auto x_main_module_435 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_434, x_main_module_12, x_main_module_11, x_main_module_10, x_main_module_9);
-auto x_main_module_436 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_435);
-auto x_main_module_437 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_436, x_main_module_8);
-auto x_main_module_438 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_437, x_main_module_7, x_main_module_6, x_main_module_5, x_main_module_4);
-auto x_main_module_439 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_438, x_main_module_430);
-auto x_main_module_440 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_439);
-auto x_main_module_441 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[7,7],lp_order:2,mode:0,padding:[0,0,0,0],stride:[1,1]}"), x_main_module_440);
-auto x_main_module_442 = mmain->add_instruction(migraphx::make_json_op("flatten", "{axis:1}"), x_main_module_441);
-auto x_main_module_443 = mmain->add_instruction(migraphx::make_json_op("transpose", "{permutation:[1,0]}"), x_main_module_3);
-auto x_main_module_444 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_442, x_main_module_443);
-auto x_main_module_445 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_2);
-auto x_main_module_446 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_0);
-auto x_main_module_447 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_445, x_main_module_446);
-auto x_main_module_448 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_444, x_main_module_447);
-mmain->add_return({x_main_module_448});
-
+    migraphx::module_ref mmain = p.get_main_module();
+    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+    auto x_0                   = mmain->add_parameter(
+        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
+    auto x_main_module_2 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
+    auto x_main_module_3 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
+    auto x_main_module_4 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 3)));
+    auto x_main_module_5 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 4));
+    auto x_main_module_6 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 5));
+    auto x_main_module_7  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 6)));
+    auto x_main_module_8  = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 7));
+    auto x_main_module_9  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 8)));
+    auto x_main_module_10 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 9));
+    auto x_main_module_11 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 10));
+    auto x_main_module_12 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 11)));
+    auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 12));
+    auto x_main_module_14 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 13)));
+    auto x_main_module_15 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 14));
+    auto x_main_module_16 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 15));
+    auto x_main_module_17 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 16)));
+    auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 17));
+    auto x_main_module_19 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 18)));
+    auto x_main_module_20 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 19));
+    auto x_main_module_21 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 20));
+    auto x_main_module_22 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 21)));
+    auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 22));
+    auto x_main_module_24 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 23)));
+    auto x_main_module_25 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 24));
+    auto x_main_module_26 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 25));
+    auto x_main_module_27 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 26)));
+    auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 27));
+    auto x_main_module_29 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 28)));
+    auto x_main_module_30 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 29));
+    auto x_main_module_31 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 30));
+    auto x_main_module_32 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 31)));
+    auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 32));
+    auto x_main_module_34 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 33)));
+    auto x_main_module_35 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 34));
+    auto x_main_module_36 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 35));
+    auto x_main_module_37 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 36)));
+    auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {2048, 1024, 1, 1}}, 37));
+    auto x_main_module_39 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 38)));
+    auto x_main_module_40 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 39));
+    auto x_main_module_41 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 40));
+    auto x_main_module_42 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 41)));
+    auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 42));
+    auto x_main_module_44 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 43)));
+    auto x_main_module_45 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 44));
+    auto x_main_module_46 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 45));
+    auto x_main_module_47 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 46)));
+    auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 47));
+    auto x_main_module_49 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 48)));
+    auto x_main_module_50 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 49));
+    auto x_main_module_51 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 50));
+    auto x_main_module_52 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 51)));
+    auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 1024, 1, 1}}, 52));
+    auto x_main_module_54 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 53)));
+    auto x_main_module_55 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 54));
+    auto x_main_module_56 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 55));
+    auto x_main_module_57 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 56));
+    auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 57));
+    auto x_main_module_59 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 58)));
+    auto x_main_module_60 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 59));
+    auto x_main_module_61 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 60));
+    auto x_main_module_62 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 61)));
+    auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 62));
+    auto x_main_module_64 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 63)));
+    auto x_main_module_65 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 64));
+    auto x_main_module_66 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 65));
+    auto x_main_module_67 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 66)));
+    auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 67));
+    auto x_main_module_69 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 68)));
+    auto x_main_module_70 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 69));
+    auto x_main_module_71 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 70));
+    auto x_main_module_72 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 71));
+    auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 72));
+    auto x_main_module_74 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 73)));
+    auto x_main_module_75 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 74));
+    auto x_main_module_76 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 75));
+    auto x_main_module_77 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 76)));
+    auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 77));
+    auto x_main_module_79 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 78)));
+    auto x_main_module_80 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 79));
+    auto x_main_module_81 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 80));
+    auto x_main_module_82 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 81)));
+    auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 82));
+    auto x_main_module_84 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 83)));
+    auto x_main_module_85 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 84));
+    auto x_main_module_86 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 85));
+    auto x_main_module_87 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 86));
+    auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 87));
+    auto x_main_module_89 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 88)));
+    auto x_main_module_90 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 89));
+    auto x_main_module_91 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 90));
+    auto x_main_module_92 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 91)));
+    auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 92));
+    auto x_main_module_94 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 93)));
+    auto x_main_module_95 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 94));
+    auto x_main_module_96 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 95));
+    auto x_main_module_97  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 96)));
+    auto x_main_module_98  = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 97));
+    auto x_main_module_99  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 98)));
+    auto x_main_module_100 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 99));
+    auto x_main_module_101 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 100));
+    auto x_main_module_102 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 101));
+    auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 102));
+    auto x_main_module_104 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 103)));
+    auto x_main_module_105 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 104));
+    auto x_main_module_106 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 105));
+    auto x_main_module_107 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 106)));
+    auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 107));
+    auto x_main_module_109 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 108)));
+    auto x_main_module_110 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 109));
+    auto x_main_module_111 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 110));
+    auto x_main_module_112 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 111)));
+    auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 112));
+    auto x_main_module_114 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 113)));
+    auto x_main_module_115 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 114));
+    auto x_main_module_116 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 115));
+    auto x_main_module_117 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 116));
+    auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 117));
+    auto x_main_module_119 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 118)));
+    auto x_main_module_120 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 119));
+    auto x_main_module_121 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 120));
+    auto x_main_module_122 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 121)));
+    auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 122));
+    auto x_main_module_124 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 123)));
+    auto x_main_module_125 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 124));
+    auto x_main_module_126 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 125));
+    auto x_main_module_127 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 126)));
+    auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 127));
+    auto x_main_module_129 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 128)));
+    auto x_main_module_130 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 129));
+    auto x_main_module_131 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 130));
+    auto x_main_module_132 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 131));
+    auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 512, 1, 1}}, 132));
+    auto x_main_module_134 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 133)));
+    auto x_main_module_135 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 134));
+    auto x_main_module_136 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 135));
+    auto x_main_module_137 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 136));
+    auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 137));
+    auto x_main_module_139 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 138)));
+    auto x_main_module_140 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 139));
+    auto x_main_module_141 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 140));
+    auto x_main_module_142 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 141)));
+    auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 142));
+    auto x_main_module_144 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 143)));
+    auto x_main_module_145 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 144));
+    auto x_main_module_146 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 145));
+    auto x_main_module_147 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 146)));
+    auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 512, 1, 1}}, 147));
+    auto x_main_module_149 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 148)));
+    auto x_main_module_150 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 149));
+    auto x_main_module_151 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 150));
+    auto x_main_module_152 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 151));
+    auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 152));
+    auto x_main_module_154 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 153)));
+    auto x_main_module_155 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 154));
+    auto x_main_module_156 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 155));
+    auto x_main_module_157 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 156)));
+    auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 157));
+    auto x_main_module_159 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 158)));
+    auto x_main_module_160 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 159));
+    auto x_main_module_161 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 160));
+    auto x_main_module_162 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 161)));
+    auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 162));
+    auto x_main_module_164 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 163)));
+    auto x_main_module_165 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 164));
+    auto x_main_module_166 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 165));
+    auto x_main_module_167 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 166));
+    auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 167));
+    auto x_main_module_169 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 168)));
+    auto x_main_module_170 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 169));
+    auto x_main_module_171 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 170));
+    auto x_main_module_172 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 171)));
+    auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 172));
+    auto x_main_module_174 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 173)));
+    auto x_main_module_175 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 174));
+    auto x_main_module_176 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 175));
+    auto x_main_module_177 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 176)));
+    auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 177));
+    auto x_main_module_179 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 178)));
+    auto x_main_module_180 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 179));
+    auto x_main_module_181 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 180));
+    auto x_main_module_182 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 181));
+    auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 182));
+    auto x_main_module_184 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 183)));
+    auto x_main_module_185 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 184));
+    auto x_main_module_186 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 185));
+    auto x_main_module_187 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 186)));
+    auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 187));
+    auto x_main_module_189 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 188)));
+    auto x_main_module_190 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 189));
+    auto x_main_module_191 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 190));
+    auto x_main_module_192 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 191)));
+    auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 192));
+    auto x_main_module_194 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 193)));
+    auto x_main_module_195 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 194));
+    auto x_main_module_196 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 195));
+    auto x_main_module_197 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 196));
+    auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 256, 1, 1}}, 197));
+    auto x_main_module_199 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 198)));
+    auto x_main_module_200 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 199));
+    auto x_main_module_201 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 200));
+    auto x_main_module_202 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 201));
+    auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 202));
+    auto x_main_module_204 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 203)));
+    auto x_main_module_205 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 204));
+    auto x_main_module_206 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 205));
+    auto x_main_module_207 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 206)));
+    auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 207));
+    auto x_main_module_209 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 208)));
+    auto x_main_module_210 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 209));
+    auto x_main_module_211 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 210));
+    auto x_main_module_212 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 211)));
+    auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 256, 1, 1}}, 212));
+    auto x_main_module_214 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 213)));
+    auto x_main_module_215 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 214));
+    auto x_main_module_216 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 215));
+    auto x_main_module_217 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 216));
+    auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 217));
+    auto x_main_module_219 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 218)));
+    auto x_main_module_220 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 219));
+    auto x_main_module_221 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 220));
+    auto x_main_module_222 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 221)));
+    auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 222));
+    auto x_main_module_224 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 223)));
+    auto x_main_module_225 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 224));
+    auto x_main_module_226 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 225));
+    auto x_main_module_227 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 226)));
+    auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 227));
+    auto x_main_module_229 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 228)));
+    auto x_main_module_230 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 229));
+    auto x_main_module_231 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 230));
+    auto x_main_module_232 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 231));
+    auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 232));
+    auto x_main_module_234 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 233)));
+    auto x_main_module_235 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 234));
+    auto x_main_module_236 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 235));
+    auto x_main_module_237 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 236)));
+    auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 237));
+    auto x_main_module_239 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 238)));
+    auto x_main_module_240 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 239));
+    auto x_main_module_241 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 240));
+    auto x_main_module_242 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 241)));
+    auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 242));
+    auto x_main_module_244 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 243)));
+    auto x_main_module_245 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 244));
+    auto x_main_module_246 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 245));
+    auto x_main_module_247 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 246));
+    auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 247));
+    auto x_main_module_249 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 248)));
+    auto x_main_module_250 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 249));
+    auto x_main_module_251 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 250));
+    auto x_main_module_252 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 251));
+    auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 252));
+    auto x_main_module_254 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 253)));
+    auto x_main_module_255 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 254));
+    auto x_main_module_256 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 255));
+    auto x_main_module_257 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 256)));
+    auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 257));
+    auto x_main_module_259 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 258)));
+    auto x_main_module_260 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 259));
+    auto x_main_module_261 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 260));
+    auto x_main_module_262 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 261)));
+    auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 64, 1, 1}}, 262));
+    auto x_main_module_264 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 263)));
+    auto x_main_module_265 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 264));
+    auto x_main_module_266 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 265));
+    auto x_main_module_267 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 266)));
+    auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 3, 7, 7}}, 267));
+    auto x_main_module_269 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[3,3,3,3],padding_mode:0,stride:[2,"
+                               "2],use_dynamic_same_auto_pad:0}"),
+        x_0,
+        x_main_module_268);
+    auto x_main_module_270 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_269,
+        x_main_module_267,
+        x_main_module_266,
+        x_main_module_265,
+        x_main_module_264);
+    auto x_main_module_271 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_270);
+    auto x_main_module_272 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[1,1,1,1],stride:[2,2]}"),
+        x_main_module_271);
+    auto x_main_module_273 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_272,
+        x_main_module_263);
+    auto x_main_module_274 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_273,
+        x_main_module_262,
+        x_main_module_261,
+        x_main_module_260,
+        x_main_module_259);
+    auto x_main_module_275 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_274);
+    auto x_main_module_276 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_275,
+        x_main_module_258);
+    auto x_main_module_277 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_276,
+        x_main_module_257,
+        x_main_module_256,
+        x_main_module_255,
+        x_main_module_254);
+    auto x_main_module_278 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_277);
+    auto x_main_module_279 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_278,
+        x_main_module_253);
+    auto x_main_module_280 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_279,
+        x_main_module_252,
+        x_main_module_251,
+        x_main_module_250,
+        x_main_module_249);
+    auto x_main_module_281 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_272,
+        x_main_module_248);
+    auto x_main_module_282 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_281,
+        x_main_module_247,
+        x_main_module_246,
+        x_main_module_245,
+        x_main_module_244);
+    auto x_main_module_283 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_280, x_main_module_282);
+    auto x_main_module_284 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_283);
+    auto x_main_module_285 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_284,
+        x_main_module_243);
+    auto x_main_module_286 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_285,
+        x_main_module_242,
+        x_main_module_241,
+        x_main_module_240,
+        x_main_module_239);
+    auto x_main_module_287 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_286);
+    auto x_main_module_288 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_287,
+        x_main_module_238);
+    auto x_main_module_289 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_288,
+        x_main_module_237,
+        x_main_module_236,
+        x_main_module_235,
+        x_main_module_234);
+    auto x_main_module_290 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_289);
+    auto x_main_module_291 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_290,
+        x_main_module_233);
+    auto x_main_module_292 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_291,
+        x_main_module_232,
+        x_main_module_231,
+        x_main_module_230,
+        x_main_module_229);
+    auto x_main_module_293 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_292, x_main_module_284);
+    auto x_main_module_294 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_293);
+    auto x_main_module_295 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_294,
+        x_main_module_228);
+    auto x_main_module_296 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_295,
+        x_main_module_227,
+        x_main_module_226,
+        x_main_module_225,
+        x_main_module_224);
+    auto x_main_module_297 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_296);
+    auto x_main_module_298 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_297,
+        x_main_module_223);
+    auto x_main_module_299 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_298,
+        x_main_module_222,
+        x_main_module_221,
+        x_main_module_220,
+        x_main_module_219);
+    auto x_main_module_300 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_299);
+    auto x_main_module_301 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_300,
+        x_main_module_218);
+    auto x_main_module_302 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_301,
+        x_main_module_217,
+        x_main_module_216,
+        x_main_module_215,
+        x_main_module_214);
+    auto x_main_module_303 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_302, x_main_module_294);
+    auto x_main_module_304 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_303);
+    auto x_main_module_305 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_304,
+        x_main_module_213);
+    auto x_main_module_306 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_305,
+        x_main_module_212,
+        x_main_module_211,
+        x_main_module_210,
+        x_main_module_209);
+    auto x_main_module_307 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_306);
+    auto x_main_module_308 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[2,"
+                               "2],use_dynamic_same_auto_pad:0}"),
+        x_main_module_307,
+        x_main_module_208);
+    auto x_main_module_309 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_308,
+        x_main_module_207,
+        x_main_module_206,
+        x_main_module_205,
+        x_main_module_204);
+    auto x_main_module_310 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_309);
+    auto x_main_module_311 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_310,
+        x_main_module_203);
+    auto x_main_module_312 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_311,
+        x_main_module_202,
+        x_main_module_201,
+        x_main_module_200,
+        x_main_module_199);
+    auto x_main_module_313 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,"
+                               "2],use_dynamic_same_auto_pad:0}"),
+        x_main_module_304,
+        x_main_module_198);
+    auto x_main_module_314 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_313,
+        x_main_module_197,
+        x_main_module_196,
+        x_main_module_195,
+        x_main_module_194);
+    auto x_main_module_315 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_312, x_main_module_314);
+    auto x_main_module_316 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_315);
+    auto x_main_module_317 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_316,
+        x_main_module_193);
+    auto x_main_module_318 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_317,
+        x_main_module_192,
+        x_main_module_191,
+        x_main_module_190,
+        x_main_module_189);
+    auto x_main_module_319 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_318);
+    auto x_main_module_320 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_319,
+        x_main_module_188);
+    auto x_main_module_321 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_320,
+        x_main_module_187,
+        x_main_module_186,
+        x_main_module_185,
+        x_main_module_184);
+    auto x_main_module_322 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_321);
+    auto x_main_module_323 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_322,
+        x_main_module_183);
+    auto x_main_module_324 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_323,
+        x_main_module_182,
+        x_main_module_181,
+        x_main_module_180,
+        x_main_module_179);
+    auto x_main_module_325 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_324, x_main_module_316);
+    auto x_main_module_326 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_325);
+    auto x_main_module_327 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_326,
+        x_main_module_178);
+    auto x_main_module_328 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_327,
+        x_main_module_177,
+        x_main_module_176,
+        x_main_module_175,
+        x_main_module_174);
+    auto x_main_module_329 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_328);
+    auto x_main_module_330 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_329,
+        x_main_module_173);
+    auto x_main_module_331 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_330,
+        x_main_module_172,
+        x_main_module_171,
+        x_main_module_170,
+        x_main_module_169);
+    auto x_main_module_332 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_331);
+    auto x_main_module_333 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_332,
+        x_main_module_168);
+    auto x_main_module_334 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_333,
+        x_main_module_167,
+        x_main_module_166,
+        x_main_module_165,
+        x_main_module_164);
+    auto x_main_module_335 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_334, x_main_module_326);
+    auto x_main_module_336 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_335);
+    auto x_main_module_337 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_336,
+        x_main_module_163);
+    auto x_main_module_338 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_337,
+        x_main_module_162,
+        x_main_module_161,
+        x_main_module_160,
+        x_main_module_159);
+    auto x_main_module_339 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_338);
+    auto x_main_module_340 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_339,
+        x_main_module_158);
+    auto x_main_module_341 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_340,
+        x_main_module_157,
+        x_main_module_156,
+        x_main_module_155,
+        x_main_module_154);
+    auto x_main_module_342 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_341);
+    auto x_main_module_343 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_342,
+        x_main_module_153);
+    auto x_main_module_344 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_343,
+        x_main_module_152,
+        x_main_module_151,
+        x_main_module_150,
+        x_main_module_149);
+    auto x_main_module_345 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_344, x_main_module_336);
+    auto x_main_module_346 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_345);
+    auto x_main_module_347 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_346,
+        x_main_module_148);
+    auto x_main_module_348 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_347,
+        x_main_module_147,
+        x_main_module_146,
+        x_main_module_145,
+        x_main_module_144);
+    auto x_main_module_349 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_348);
+    auto x_main_module_350 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[2,"
+                               "2],use_dynamic_same_auto_pad:0}"),
+        x_main_module_349,
+        x_main_module_143);
+    auto x_main_module_351 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_350,
+        x_main_module_142,
+        x_main_module_141,
+        x_main_module_140,
+        x_main_module_139);
+    auto x_main_module_352 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_351);
+    auto x_main_module_353 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_352,
+        x_main_module_138);
+    auto x_main_module_354 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_353,
+        x_main_module_137,
+        x_main_module_136,
+        x_main_module_135,
+        x_main_module_134);
+    auto x_main_module_355 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,"
+                               "2],use_dynamic_same_auto_pad:0}"),
+        x_main_module_346,
+        x_main_module_133);
+    auto x_main_module_356 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_355,
+        x_main_module_132,
+        x_main_module_131,
+        x_main_module_130,
+        x_main_module_129);
+    auto x_main_module_357 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_354, x_main_module_356);
+    auto x_main_module_358 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_357);
+    auto x_main_module_359 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_358,
+        x_main_module_128);
+    auto x_main_module_360 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_359,
+        x_main_module_127,
+        x_main_module_126,
+        x_main_module_125,
+        x_main_module_124);
+    auto x_main_module_361 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_360);
+    auto x_main_module_362 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_361,
+        x_main_module_123);
+    auto x_main_module_363 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_362,
+        x_main_module_122,
+        x_main_module_121,
+        x_main_module_120,
+        x_main_module_119);
+    auto x_main_module_364 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_363);
+    auto x_main_module_365 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_364,
+        x_main_module_118);
+    auto x_main_module_366 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_365,
+        x_main_module_117,
+        x_main_module_116,
+        x_main_module_115,
+        x_main_module_114);
+    auto x_main_module_367 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_366, x_main_module_358);
+    auto x_main_module_368 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_367);
+    auto x_main_module_369 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_368,
+        x_main_module_113);
+    auto x_main_module_370 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_369,
+        x_main_module_112,
+        x_main_module_111,
+        x_main_module_110,
+        x_main_module_109);
+    auto x_main_module_371 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_370);
+    auto x_main_module_372 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_371,
+        x_main_module_108);
+    auto x_main_module_373 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_372,
+        x_main_module_107,
+        x_main_module_106,
+        x_main_module_105,
+        x_main_module_104);
+    auto x_main_module_374 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_373);
+    auto x_main_module_375 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_374,
+        x_main_module_103);
+    auto x_main_module_376 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_375,
+        x_main_module_102,
+        x_main_module_101,
+        x_main_module_100,
+        x_main_module_99);
+    auto x_main_module_377 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_376, x_main_module_368);
+    auto x_main_module_378 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_377);
+    auto x_main_module_379 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_378,
+        x_main_module_98);
+    auto x_main_module_380 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_379,
+        x_main_module_97,
+        x_main_module_96,
+        x_main_module_95,
+        x_main_module_94);
+    auto x_main_module_381 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_380);
+    auto x_main_module_382 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_381,
+        x_main_module_93);
+    auto x_main_module_383 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_382,
+        x_main_module_92,
+        x_main_module_91,
+        x_main_module_90,
+        x_main_module_89);
+    auto x_main_module_384 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_383);
+    auto x_main_module_385 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_384,
+        x_main_module_88);
+    auto x_main_module_386 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_385,
+        x_main_module_87,
+        x_main_module_86,
+        x_main_module_85,
+        x_main_module_84);
+    auto x_main_module_387 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_386, x_main_module_378);
+    auto x_main_module_388 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_387);
+    auto x_main_module_389 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_388,
+        x_main_module_83);
+    auto x_main_module_390 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_389,
+        x_main_module_82,
+        x_main_module_81,
+        x_main_module_80,
+        x_main_module_79);
+    auto x_main_module_391 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_390);
+    auto x_main_module_392 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_391,
+        x_main_module_78);
+    auto x_main_module_393 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_392,
+        x_main_module_77,
+        x_main_module_76,
+        x_main_module_75,
+        x_main_module_74);
+    auto x_main_module_394 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_393);
+    auto x_main_module_395 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_394,
+        x_main_module_73);
+    auto x_main_module_396 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_395,
+        x_main_module_72,
+        x_main_module_71,
+        x_main_module_70,
+        x_main_module_69);
+    auto x_main_module_397 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_396, x_main_module_388);
+    auto x_main_module_398 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_397);
+    auto x_main_module_399 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_398,
+        x_main_module_68);
+    auto x_main_module_400 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_399,
+        x_main_module_67,
+        x_main_module_66,
+        x_main_module_65,
+        x_main_module_64);
+    auto x_main_module_401 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_400);
+    auto x_main_module_402 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_401,
+        x_main_module_63);
+    auto x_main_module_403 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_402,
+        x_main_module_62,
+        x_main_module_61,
+        x_main_module_60,
+        x_main_module_59);
+    auto x_main_module_404 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_403);
+    auto x_main_module_405 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_404,
+        x_main_module_58);
+    auto x_main_module_406 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_405,
+        x_main_module_57,
+        x_main_module_56,
+        x_main_module_55,
+        x_main_module_54);
+    auto x_main_module_407 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_406, x_main_module_398);
+    auto x_main_module_408 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_407);
+    auto x_main_module_409 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_408,
+        x_main_module_53);
+    auto x_main_module_410 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_409,
+        x_main_module_52,
+        x_main_module_51,
+        x_main_module_50,
+        x_main_module_49);
+    auto x_main_module_411 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_410);
+    auto x_main_module_412 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[2,"
+                               "2],use_dynamic_same_auto_pad:0}"),
+        x_main_module_411,
+        x_main_module_48);
+    auto x_main_module_413 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_412,
+        x_main_module_47,
+        x_main_module_46,
+        x_main_module_45,
+        x_main_module_44);
+    auto x_main_module_414 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_413);
+    auto x_main_module_415 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_414,
+        x_main_module_43);
+    auto x_main_module_416 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_415,
+        x_main_module_42,
+        x_main_module_41,
+        x_main_module_40,
+        x_main_module_39);
+    auto x_main_module_417 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,"
+                               "2],use_dynamic_same_auto_pad:0}"),
+        x_main_module_408,
+        x_main_module_38);
+    auto x_main_module_418 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_417,
+        x_main_module_37,
+        x_main_module_36,
+        x_main_module_35,
+        x_main_module_34);
+    auto x_main_module_419 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_416, x_main_module_418);
+    auto x_main_module_420 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_419);
+    auto x_main_module_421 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_420,
+        x_main_module_33);
+    auto x_main_module_422 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_421,
+        x_main_module_32,
+        x_main_module_31,
+        x_main_module_30,
+        x_main_module_29);
+    auto x_main_module_423 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_422);
+    auto x_main_module_424 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_423,
+        x_main_module_28);
+    auto x_main_module_425 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_424,
+        x_main_module_27,
+        x_main_module_26,
+        x_main_module_25,
+        x_main_module_24);
+    auto x_main_module_426 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_425);
+    auto x_main_module_427 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_426,
+        x_main_module_23);
+    auto x_main_module_428 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_427,
+        x_main_module_22,
+        x_main_module_21,
+        x_main_module_20,
+        x_main_module_19);
+    auto x_main_module_429 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_428, x_main_module_420);
+    auto x_main_module_430 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_429);
+    auto x_main_module_431 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_430,
+        x_main_module_18);
+    auto x_main_module_432 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_431,
+        x_main_module_17,
+        x_main_module_16,
+        x_main_module_15,
+        x_main_module_14);
+    auto x_main_module_433 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_432);
+    auto x_main_module_434 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_433,
+        x_main_module_13);
+    auto x_main_module_435 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_434,
+        x_main_module_12,
+        x_main_module_11,
+        x_main_module_10,
+        x_main_module_9);
+    auto x_main_module_436 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_435);
+    auto x_main_module_437 = mmain->add_instruction(
+        migraphx::make_json_op("convolution",
+                               "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,"
+                               "1],use_dynamic_same_auto_pad:0}"),
+        x_main_module_436,
+        x_main_module_8);
+    auto x_main_module_438 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "batch_norm_inference",
+            "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"),
+        x_main_module_437,
+        x_main_module_7,
+        x_main_module_6,
+        x_main_module_5,
+        x_main_module_4);
+    auto x_main_module_439 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_438, x_main_module_430);
+    auto x_main_module_440 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_439);
+    auto x_main_module_441 = mmain->add_instruction(
+        migraphx::make_json_op(
+            "pooling",
+            "{ceil_mode:0,lengths:[7,7],lp_order:2,mode:0,padding:[0,0,0,0],stride:[1,1]}"),
+        x_main_module_440);
+    auto x_main_module_442 =
+        mmain->add_instruction(migraphx::make_json_op("flatten", "{axis:1}"), x_main_module_441);
+    auto x_main_module_443 = mmain->add_instruction(
+        migraphx::make_json_op("transpose", "{permutation:[1,0]}"), x_main_module_3);
+    auto x_main_module_444 =
+        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_442, x_main_module_443);
+    auto x_main_module_445 = mmain->add_instruction(
+        migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_2);
+    auto x_main_module_446 = mmain->add_instruction(
+        migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_0);
+    auto x_main_module_447 =
+        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_445, x_main_module_446);
+    auto x_main_module_448 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_444, x_main_module_447);
+    mmain->add_return({x_main_module_448});
 
     return p;
 }

--- a/src/driver/resnet50.cpp
+++ b/src/driver/resnet50.cpp
@@ -33,458 +33,1558 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program resnet50(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-migraphx::module_ref mmain = p.get_main_module();
-auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
-auto x_main_module_2 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
-auto x_main_module_3 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
-auto x_main_module_4 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 3)));
-auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 4));
-auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 5));
-auto x_main_module_7 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 6)));
-auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 7));
-auto x_main_module_9 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 8)));
-auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 9));
-auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 10));
-auto x_main_module_12 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 11)));
-auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 12));
-auto x_main_module_14 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 13)));
-auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 14));
-auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 15));
-auto x_main_module_17 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 16)));
-auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 17));
-auto x_main_module_19 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 18)));
-auto x_main_module_20 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 19));
-auto x_main_module_21 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 20));
-auto x_main_module_22 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 21)));
-auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 22));
-auto x_main_module_24 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 23)));
-auto x_main_module_25 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 24));
-auto x_main_module_26 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 25));
-auto x_main_module_27 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 26)));
-auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 27));
-auto x_main_module_29 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 28)));
-auto x_main_module_30 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 29));
-auto x_main_module_31 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 30));
-auto x_main_module_32 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 31)));
-auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 32));
-auto x_main_module_34 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 33)));
-auto x_main_module_35 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 34));
-auto x_main_module_36 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 35));
-auto x_main_module_37 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 36)));
-auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 1024, 1, 1}}, 37));
-auto x_main_module_39 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 38)));
-auto x_main_module_40 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 39));
-auto x_main_module_41 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 40));
-auto x_main_module_42 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 41)));
-auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 42));
-auto x_main_module_44 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 43)));
-auto x_main_module_45 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 44));
-auto x_main_module_46 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 45));
-auto x_main_module_47 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 46)));
-auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 47));
-auto x_main_module_49 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 48)));
-auto x_main_module_50 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 49));
-auto x_main_module_51 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 50));
-auto x_main_module_52 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 51)));
-auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 1024, 1, 1}}, 52));
-auto x_main_module_54 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 53)));
-auto x_main_module_55 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 54));
-auto x_main_module_56 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 55));
-auto x_main_module_57 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 56));
-auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 57));
-auto x_main_module_59 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 58)));
-auto x_main_module_60 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 59));
-auto x_main_module_61 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 60));
-auto x_main_module_62 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 61)));
-auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 62));
-auto x_main_module_64 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 63)));
-auto x_main_module_65 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 64));
-auto x_main_module_66 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 65));
-auto x_main_module_67 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 66)));
-auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 67));
-auto x_main_module_69 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 68)));
-auto x_main_module_70 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 69));
-auto x_main_module_71 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 70));
-auto x_main_module_72 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 71));
-auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 72));
-auto x_main_module_74 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 73)));
-auto x_main_module_75 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 74));
-auto x_main_module_76 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 75));
-auto x_main_module_77 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 76)));
-auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 77));
-auto x_main_module_79 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 78)));
-auto x_main_module_80 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 79));
-auto x_main_module_81 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 80));
-auto x_main_module_82 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 81)));
-auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 82));
-auto x_main_module_84 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 83)));
-auto x_main_module_85 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 84));
-auto x_main_module_86 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 85));
-auto x_main_module_87 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 86));
-auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 87));
-auto x_main_module_89 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 88)));
-auto x_main_module_90 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 89));
-auto x_main_module_91 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 90));
-auto x_main_module_92 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 91)));
-auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 92));
-auto x_main_module_94 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 93)));
-auto x_main_module_95 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 94));
-auto x_main_module_96 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 95));
-auto x_main_module_97 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 96)));
-auto x_main_module_98 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 97));
-auto x_main_module_99 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 98)));
-auto x_main_module_100 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 99));
-auto x_main_module_101 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 100));
-auto x_main_module_102 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 101));
-auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 102));
-auto x_main_module_104 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 103)));
-auto x_main_module_105 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 104));
-auto x_main_module_106 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 105));
-auto x_main_module_107 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 106)));
-auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 107));
-auto x_main_module_109 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 108)));
-auto x_main_module_110 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 109));
-auto x_main_module_111 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 110));
-auto x_main_module_112 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 111)));
-auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 112));
-auto x_main_module_114 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 113)));
-auto x_main_module_115 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 114));
-auto x_main_module_116 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 115));
-auto x_main_module_117 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 116));
-auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 117));
-auto x_main_module_119 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 118)));
-auto x_main_module_120 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 119));
-auto x_main_module_121 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 120));
-auto x_main_module_122 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 121)));
-auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 122));
-auto x_main_module_124 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 123)));
-auto x_main_module_125 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 124));
-auto x_main_module_126 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 125));
-auto x_main_module_127 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 126)));
-auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 127));
-auto x_main_module_129 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 128)));
-auto x_main_module_130 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 129));
-auto x_main_module_131 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 130));
-auto x_main_module_132 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 131));
-auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 512, 1, 1}}, 132));
-auto x_main_module_134 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 133)));
-auto x_main_module_135 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 134));
-auto x_main_module_136 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 135));
-auto x_main_module_137 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 136));
-auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 137));
-auto x_main_module_139 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 138)));
-auto x_main_module_140 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 139));
-auto x_main_module_141 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 140));
-auto x_main_module_142 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 141)));
-auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 142));
-auto x_main_module_144 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 143)));
-auto x_main_module_145 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 144));
-auto x_main_module_146 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 145));
-auto x_main_module_147 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 146)));
-auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 512, 1, 1}}, 147));
-auto x_main_module_149 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 148)));
-auto x_main_module_150 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 149));
-auto x_main_module_151 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 150));
-auto x_main_module_152 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 151));
-auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 152));
-auto x_main_module_154 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 153)));
-auto x_main_module_155 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 154));
-auto x_main_module_156 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 155));
-auto x_main_module_157 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 156)));
-auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 157));
-auto x_main_module_159 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 158)));
-auto x_main_module_160 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 159));
-auto x_main_module_161 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 160));
-auto x_main_module_162 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 161)));
-auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 162));
-auto x_main_module_164 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 163)));
-auto x_main_module_165 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 164));
-auto x_main_module_166 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 165));
-auto x_main_module_167 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 166));
-auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 167));
-auto x_main_module_169 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 168)));
-auto x_main_module_170 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 169));
-auto x_main_module_171 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 170));
-auto x_main_module_172 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 171)));
-auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 172));
-auto x_main_module_174 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 173)));
-auto x_main_module_175 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 174));
-auto x_main_module_176 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 175));
-auto x_main_module_177 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 176)));
-auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 177));
-auto x_main_module_179 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 178)));
-auto x_main_module_180 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 179));
-auto x_main_module_181 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 180));
-auto x_main_module_182 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 181));
-auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 182));
-auto x_main_module_184 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 183)));
-auto x_main_module_185 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 184));
-auto x_main_module_186 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 185));
-auto x_main_module_187 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 186)));
-auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 187));
-auto x_main_module_189 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 188)));
-auto x_main_module_190 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 189));
-auto x_main_module_191 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 190));
-auto x_main_module_192 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 191)));
-auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 192));
-auto x_main_module_194 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 193)));
-auto x_main_module_195 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 194));
-auto x_main_module_196 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 195));
-auto x_main_module_197 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 196));
-auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 256, 1, 1}}, 197));
-auto x_main_module_199 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 198)));
-auto x_main_module_200 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 199));
-auto x_main_module_201 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 200));
-auto x_main_module_202 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 201));
-auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 202));
-auto x_main_module_204 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 203)));
-auto x_main_module_205 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 204));
-auto x_main_module_206 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 205));
-auto x_main_module_207 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 206)));
-auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 207));
-auto x_main_module_209 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 208)));
-auto x_main_module_210 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 209));
-auto x_main_module_211 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 210));
-auto x_main_module_212 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 211)));
-auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 256, 1, 1}}, 212));
-auto x_main_module_214 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 213)));
-auto x_main_module_215 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 214));
-auto x_main_module_216 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 215));
-auto x_main_module_217 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 216));
-auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 217));
-auto x_main_module_219 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 218)));
-auto x_main_module_220 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 219));
-auto x_main_module_221 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 220));
-auto x_main_module_222 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 221)));
-auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 222));
-auto x_main_module_224 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 223)));
-auto x_main_module_225 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 224));
-auto x_main_module_226 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 225));
-auto x_main_module_227 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 226)));
-auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 227));
-auto x_main_module_229 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 228)));
-auto x_main_module_230 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 229));
-auto x_main_module_231 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 230));
-auto x_main_module_232 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 231));
-auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 232));
-auto x_main_module_234 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 233)));
-auto x_main_module_235 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 234));
-auto x_main_module_236 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 235));
-auto x_main_module_237 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 236)));
-auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 237));
-auto x_main_module_239 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 238)));
-auto x_main_module_240 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 239));
-auto x_main_module_241 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 240));
-auto x_main_module_242 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 241)));
-auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 242));
-auto x_main_module_244 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 243)));
-auto x_main_module_245 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 244));
-auto x_main_module_246 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 245));
-auto x_main_module_247 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 246));
-auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 247));
-auto x_main_module_249 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 248)));
-auto x_main_module_250 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 249));
-auto x_main_module_251 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 250));
-auto x_main_module_252 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 251));
-auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 252));
-auto x_main_module_254 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 253)));
-auto x_main_module_255 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 254));
-auto x_main_module_256 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 255));
-auto x_main_module_257 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 256)));
-auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 257));
-auto x_main_module_259 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 258)));
-auto x_main_module_260 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 259));
-auto x_main_module_261 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 260));
-auto x_main_module_262 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 261)));
-auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 1, 1}}, 262));
-auto x_main_module_264 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 263)));
-auto x_main_module_265 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 264));
-auto x_main_module_266 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 265));
-auto x_main_module_267 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 266)));
-auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 3, 7, 7}}, 267));
-auto x_main_module_269 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,3,3,3],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_0, x_main_module_268);
-auto x_main_module_270 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_269, x_main_module_267, x_main_module_266, x_main_module_265, x_main_module_264);
-auto x_main_module_271 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_270);
-auto x_main_module_272 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[1,1,1,1],\"stride\":[2,2]}")), x_main_module_271);
-auto x_main_module_273 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_272, x_main_module_263);
-auto x_main_module_274 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_273, x_main_module_262, x_main_module_261, x_main_module_260, x_main_module_259);
-auto x_main_module_275 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_274);
-auto x_main_module_276 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_275, x_main_module_258);
-auto x_main_module_277 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_276, x_main_module_257, x_main_module_256, x_main_module_255, x_main_module_254);
-auto x_main_module_278 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_277);
-auto x_main_module_279 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_278, x_main_module_253);
-auto x_main_module_280 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_279, x_main_module_252, x_main_module_251, x_main_module_250, x_main_module_249);
-auto x_main_module_281 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_272, x_main_module_248);
-auto x_main_module_282 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_281, x_main_module_247, x_main_module_246, x_main_module_245, x_main_module_244);
-auto x_main_module_283 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_280, x_main_module_282);
-auto x_main_module_284 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_283);
-auto x_main_module_285 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_284, x_main_module_243);
-auto x_main_module_286 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_285, x_main_module_242, x_main_module_241, x_main_module_240, x_main_module_239);
-auto x_main_module_287 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_286);
-auto x_main_module_288 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_287, x_main_module_238);
-auto x_main_module_289 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_288, x_main_module_237, x_main_module_236, x_main_module_235, x_main_module_234);
-auto x_main_module_290 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_289);
-auto x_main_module_291 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_290, x_main_module_233);
-auto x_main_module_292 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_291, x_main_module_232, x_main_module_231, x_main_module_230, x_main_module_229);
-auto x_main_module_293 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_292, x_main_module_284);
-auto x_main_module_294 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_293);
-auto x_main_module_295 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_294, x_main_module_228);
-auto x_main_module_296 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_295, x_main_module_227, x_main_module_226, x_main_module_225, x_main_module_224);
-auto x_main_module_297 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_296);
-auto x_main_module_298 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_297, x_main_module_223);
-auto x_main_module_299 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_298, x_main_module_222, x_main_module_221, x_main_module_220, x_main_module_219);
-auto x_main_module_300 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_299);
-auto x_main_module_301 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_300, x_main_module_218);
-auto x_main_module_302 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_301, x_main_module_217, x_main_module_216, x_main_module_215, x_main_module_214);
-auto x_main_module_303 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_302, x_main_module_294);
-auto x_main_module_304 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_303);
-auto x_main_module_305 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_304, x_main_module_213);
-auto x_main_module_306 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_305, x_main_module_212, x_main_module_211, x_main_module_210, x_main_module_209);
-auto x_main_module_307 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_306);
-auto x_main_module_308 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_307, x_main_module_208);
-auto x_main_module_309 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_308, x_main_module_207, x_main_module_206, x_main_module_205, x_main_module_204);
-auto x_main_module_310 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_309);
-auto x_main_module_311 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_310, x_main_module_203);
-auto x_main_module_312 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_311, x_main_module_202, x_main_module_201, x_main_module_200, x_main_module_199);
-auto x_main_module_313 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_304, x_main_module_198);
-auto x_main_module_314 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_313, x_main_module_197, x_main_module_196, x_main_module_195, x_main_module_194);
-auto x_main_module_315 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_312, x_main_module_314);
-auto x_main_module_316 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_315);
-auto x_main_module_317 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_316, x_main_module_193);
-auto x_main_module_318 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_317, x_main_module_192, x_main_module_191, x_main_module_190, x_main_module_189);
-auto x_main_module_319 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_318);
-auto x_main_module_320 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_319, x_main_module_188);
-auto x_main_module_321 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_320, x_main_module_187, x_main_module_186, x_main_module_185, x_main_module_184);
-auto x_main_module_322 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_321);
-auto x_main_module_323 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_322, x_main_module_183);
-auto x_main_module_324 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_323, x_main_module_182, x_main_module_181, x_main_module_180, x_main_module_179);
-auto x_main_module_325 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_324, x_main_module_316);
-auto x_main_module_326 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_325);
-auto x_main_module_327 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_326, x_main_module_178);
-auto x_main_module_328 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_327, x_main_module_177, x_main_module_176, x_main_module_175, x_main_module_174);
-auto x_main_module_329 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_328);
-auto x_main_module_330 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_329, x_main_module_173);
-auto x_main_module_331 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_330, x_main_module_172, x_main_module_171, x_main_module_170, x_main_module_169);
-auto x_main_module_332 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_331);
-auto x_main_module_333 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_332, x_main_module_168);
-auto x_main_module_334 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_333, x_main_module_167, x_main_module_166, x_main_module_165, x_main_module_164);
-auto x_main_module_335 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_334, x_main_module_326);
-auto x_main_module_336 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_335);
-auto x_main_module_337 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_336, x_main_module_163);
-auto x_main_module_338 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_337, x_main_module_162, x_main_module_161, x_main_module_160, x_main_module_159);
-auto x_main_module_339 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_338);
-auto x_main_module_340 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_339, x_main_module_158);
-auto x_main_module_341 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_340, x_main_module_157, x_main_module_156, x_main_module_155, x_main_module_154);
-auto x_main_module_342 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_341);
-auto x_main_module_343 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_342, x_main_module_153);
-auto x_main_module_344 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_343, x_main_module_152, x_main_module_151, x_main_module_150, x_main_module_149);
-auto x_main_module_345 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_344, x_main_module_336);
-auto x_main_module_346 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_345);
-auto x_main_module_347 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_346, x_main_module_148);
-auto x_main_module_348 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_347, x_main_module_147, x_main_module_146, x_main_module_145, x_main_module_144);
-auto x_main_module_349 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_348);
-auto x_main_module_350 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_349, x_main_module_143);
-auto x_main_module_351 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_350, x_main_module_142, x_main_module_141, x_main_module_140, x_main_module_139);
-auto x_main_module_352 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_351);
-auto x_main_module_353 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_352, x_main_module_138);
-auto x_main_module_354 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_353, x_main_module_137, x_main_module_136, x_main_module_135, x_main_module_134);
-auto x_main_module_355 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_346, x_main_module_133);
-auto x_main_module_356 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_355, x_main_module_132, x_main_module_131, x_main_module_130, x_main_module_129);
-auto x_main_module_357 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_354, x_main_module_356);
-auto x_main_module_358 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_357);
-auto x_main_module_359 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_358, x_main_module_128);
-auto x_main_module_360 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_359, x_main_module_127, x_main_module_126, x_main_module_125, x_main_module_124);
-auto x_main_module_361 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_360);
-auto x_main_module_362 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_361, x_main_module_123);
-auto x_main_module_363 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_362, x_main_module_122, x_main_module_121, x_main_module_120, x_main_module_119);
-auto x_main_module_364 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_363);
-auto x_main_module_365 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_364, x_main_module_118);
-auto x_main_module_366 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_365, x_main_module_117, x_main_module_116, x_main_module_115, x_main_module_114);
-auto x_main_module_367 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_366, x_main_module_358);
-auto x_main_module_368 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_367);
-auto x_main_module_369 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_368, x_main_module_113);
-auto x_main_module_370 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_369, x_main_module_112, x_main_module_111, x_main_module_110, x_main_module_109);
-auto x_main_module_371 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_370);
-auto x_main_module_372 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_371, x_main_module_108);
-auto x_main_module_373 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_372, x_main_module_107, x_main_module_106, x_main_module_105, x_main_module_104);
-auto x_main_module_374 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_373);
-auto x_main_module_375 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_374, x_main_module_103);
-auto x_main_module_376 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_375, x_main_module_102, x_main_module_101, x_main_module_100, x_main_module_99);
-auto x_main_module_377 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_376, x_main_module_368);
-auto x_main_module_378 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_377);
-auto x_main_module_379 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_378, x_main_module_98);
-auto x_main_module_380 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_379, x_main_module_97, x_main_module_96, x_main_module_95, x_main_module_94);
-auto x_main_module_381 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_380);
-auto x_main_module_382 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_381, x_main_module_93);
-auto x_main_module_383 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_382, x_main_module_92, x_main_module_91, x_main_module_90, x_main_module_89);
-auto x_main_module_384 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_383);
-auto x_main_module_385 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_384, x_main_module_88);
-auto x_main_module_386 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_385, x_main_module_87, x_main_module_86, x_main_module_85, x_main_module_84);
-auto x_main_module_387 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_386, x_main_module_378);
-auto x_main_module_388 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_387);
-auto x_main_module_389 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_388, x_main_module_83);
-auto x_main_module_390 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_389, x_main_module_82, x_main_module_81, x_main_module_80, x_main_module_79);
-auto x_main_module_391 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_390);
-auto x_main_module_392 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_391, x_main_module_78);
-auto x_main_module_393 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_392, x_main_module_77, x_main_module_76, x_main_module_75, x_main_module_74);
-auto x_main_module_394 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_393);
-auto x_main_module_395 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_394, x_main_module_73);
-auto x_main_module_396 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_395, x_main_module_72, x_main_module_71, x_main_module_70, x_main_module_69);
-auto x_main_module_397 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_396, x_main_module_388);
-auto x_main_module_398 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_397);
-auto x_main_module_399 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_398, x_main_module_68);
-auto x_main_module_400 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_399, x_main_module_67, x_main_module_66, x_main_module_65, x_main_module_64);
-auto x_main_module_401 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_400);
-auto x_main_module_402 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_401, x_main_module_63);
-auto x_main_module_403 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_402, x_main_module_62, x_main_module_61, x_main_module_60, x_main_module_59);
-auto x_main_module_404 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_403);
-auto x_main_module_405 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_404, x_main_module_58);
-auto x_main_module_406 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_405, x_main_module_57, x_main_module_56, x_main_module_55, x_main_module_54);
-auto x_main_module_407 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_406, x_main_module_398);
-auto x_main_module_408 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_407);
-auto x_main_module_409 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_408, x_main_module_53);
-auto x_main_module_410 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_409, x_main_module_52, x_main_module_51, x_main_module_50, x_main_module_49);
-auto x_main_module_411 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_410);
-auto x_main_module_412 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_411, x_main_module_48);
-auto x_main_module_413 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_412, x_main_module_47, x_main_module_46, x_main_module_45, x_main_module_44);
-auto x_main_module_414 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_413);
-auto x_main_module_415 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_414, x_main_module_43);
-auto x_main_module_416 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_415, x_main_module_42, x_main_module_41, x_main_module_40, x_main_module_39);
-auto x_main_module_417 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_408, x_main_module_38);
-auto x_main_module_418 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_417, x_main_module_37, x_main_module_36, x_main_module_35, x_main_module_34);
-auto x_main_module_419 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_416, x_main_module_418);
-auto x_main_module_420 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_419);
-auto x_main_module_421 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_420, x_main_module_33);
-auto x_main_module_422 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_421, x_main_module_32, x_main_module_31, x_main_module_30, x_main_module_29);
-auto x_main_module_423 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_422);
-auto x_main_module_424 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_423, x_main_module_28);
-auto x_main_module_425 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_424, x_main_module_27, x_main_module_26, x_main_module_25, x_main_module_24);
-auto x_main_module_426 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_425);
-auto x_main_module_427 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_426, x_main_module_23);
-auto x_main_module_428 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_427, x_main_module_22, x_main_module_21, x_main_module_20, x_main_module_19);
-auto x_main_module_429 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_428, x_main_module_420);
-auto x_main_module_430 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_429);
-auto x_main_module_431 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_430, x_main_module_18);
-auto x_main_module_432 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_431, x_main_module_17, x_main_module_16, x_main_module_15, x_main_module_14);
-auto x_main_module_433 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_432);
-auto x_main_module_434 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_433, x_main_module_13);
-auto x_main_module_435 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_434, x_main_module_12, x_main_module_11, x_main_module_10, x_main_module_9);
-auto x_main_module_436 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_435);
-auto x_main_module_437 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_436, x_main_module_8);
-auto x_main_module_438 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_437, x_main_module_7, x_main_module_6, x_main_module_5, x_main_module_4);
-auto x_main_module_439 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_438, x_main_module_430);
-auto x_main_module_440 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_439);
-auto x_main_module_441 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[7,7],\"lp_order\":2,\"mode\":0,\"padding\":[0,0,0,0],\"stride\":[1,1]}")), x_main_module_440);
-auto x_main_module_442 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), x_main_module_441);
-auto x_main_module_443 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_3);
-auto x_main_module_444 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_442, x_main_module_443);
-auto x_main_module_445 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_2);
-auto x_main_module_446 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_0);
-auto x_main_module_447 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_445, x_main_module_446);
-auto x_main_module_448 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_444, x_main_module_447);
-mmain->add_return({x_main_module_448});
-
+    migraphx::module_ref mmain = p.get_main_module();
+    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+    auto x_0                   = mmain->add_parameter(
+        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
+    auto x_main_module_2 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
+    auto x_main_module_3 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
+    auto x_main_module_4 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 3)));
+    auto x_main_module_5 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 4));
+    auto x_main_module_6 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 5));
+    auto x_main_module_7  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 6)));
+    auto x_main_module_8  = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 7));
+    auto x_main_module_9  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 8)));
+    auto x_main_module_10 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 9));
+    auto x_main_module_11 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 10));
+    auto x_main_module_12 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 11)));
+    auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 12));
+    auto x_main_module_14 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 13)));
+    auto x_main_module_15 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 14));
+    auto x_main_module_16 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 15));
+    auto x_main_module_17 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 16)));
+    auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 17));
+    auto x_main_module_19 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 18)));
+    auto x_main_module_20 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 19));
+    auto x_main_module_21 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 20));
+    auto x_main_module_22 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 21)));
+    auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 22));
+    auto x_main_module_24 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 23)));
+    auto x_main_module_25 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 24));
+    auto x_main_module_26 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 25));
+    auto x_main_module_27 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 26)));
+    auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 27));
+    auto x_main_module_29 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 28)));
+    auto x_main_module_30 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 29));
+    auto x_main_module_31 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 30));
+    auto x_main_module_32 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 31)));
+    auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 32));
+    auto x_main_module_34 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 33)));
+    auto x_main_module_35 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 34));
+    auto x_main_module_36 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 35));
+    auto x_main_module_37 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 36)));
+    auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {2048, 1024, 1, 1}}, 37));
+    auto x_main_module_39 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 38)));
+    auto x_main_module_40 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 39));
+    auto x_main_module_41 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 40));
+    auto x_main_module_42 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 41)));
+    auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 42));
+    auto x_main_module_44 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 43)));
+    auto x_main_module_45 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 44));
+    auto x_main_module_46 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 45));
+    auto x_main_module_47 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 46)));
+    auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 47));
+    auto x_main_module_49 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 48)));
+    auto x_main_module_50 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 49));
+    auto x_main_module_51 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 50));
+    auto x_main_module_52 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 51)));
+    auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 1024, 1, 1}}, 52));
+    auto x_main_module_54 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 53)));
+    auto x_main_module_55 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 54));
+    auto x_main_module_56 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 55));
+    auto x_main_module_57 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 56));
+    auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 57));
+    auto x_main_module_59 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 58)));
+    auto x_main_module_60 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 59));
+    auto x_main_module_61 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 60));
+    auto x_main_module_62 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 61)));
+    auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 62));
+    auto x_main_module_64 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 63)));
+    auto x_main_module_65 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 64));
+    auto x_main_module_66 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 65));
+    auto x_main_module_67 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 66)));
+    auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 67));
+    auto x_main_module_69 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 68)));
+    auto x_main_module_70 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 69));
+    auto x_main_module_71 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 70));
+    auto x_main_module_72 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 71));
+    auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 72));
+    auto x_main_module_74 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 73)));
+    auto x_main_module_75 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 74));
+    auto x_main_module_76 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 75));
+    auto x_main_module_77 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 76)));
+    auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 77));
+    auto x_main_module_79 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 78)));
+    auto x_main_module_80 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 79));
+    auto x_main_module_81 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 80));
+    auto x_main_module_82 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 81)));
+    auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 82));
+    auto x_main_module_84 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 83)));
+    auto x_main_module_85 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 84));
+    auto x_main_module_86 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 85));
+    auto x_main_module_87 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 86));
+    auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 87));
+    auto x_main_module_89 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 88)));
+    auto x_main_module_90 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 89));
+    auto x_main_module_91 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 90));
+    auto x_main_module_92 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 91)));
+    auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 92));
+    auto x_main_module_94 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 93)));
+    auto x_main_module_95 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 94));
+    auto x_main_module_96 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 95));
+    auto x_main_module_97  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 96)));
+    auto x_main_module_98  = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 97));
+    auto x_main_module_99  = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 98)));
+    auto x_main_module_100 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 99));
+    auto x_main_module_101 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 100));
+    auto x_main_module_102 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 101));
+    auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 102));
+    auto x_main_module_104 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 103)));
+    auto x_main_module_105 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 104));
+    auto x_main_module_106 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 105));
+    auto x_main_module_107 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 106)));
+    auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 107));
+    auto x_main_module_109 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 108)));
+    auto x_main_module_110 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 109));
+    auto x_main_module_111 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 110));
+    auto x_main_module_112 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 111)));
+    auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 112));
+    auto x_main_module_114 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 113)));
+    auto x_main_module_115 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 114));
+    auto x_main_module_116 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 115));
+    auto x_main_module_117 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 116));
+    auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 117));
+    auto x_main_module_119 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 118)));
+    auto x_main_module_120 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 119));
+    auto x_main_module_121 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 120));
+    auto x_main_module_122 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 121)));
+    auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 122));
+    auto x_main_module_124 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 123)));
+    auto x_main_module_125 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 124));
+    auto x_main_module_126 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 125));
+    auto x_main_module_127 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 126)));
+    auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 127));
+    auto x_main_module_129 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 128)));
+    auto x_main_module_130 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 129));
+    auto x_main_module_131 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 130));
+    auto x_main_module_132 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 131));
+    auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 512, 1, 1}}, 132));
+    auto x_main_module_134 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 133)));
+    auto x_main_module_135 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 134));
+    auto x_main_module_136 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 135));
+    auto x_main_module_137 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 136));
+    auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 137));
+    auto x_main_module_139 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 138)));
+    auto x_main_module_140 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 139));
+    auto x_main_module_141 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 140));
+    auto x_main_module_142 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 141)));
+    auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 142));
+    auto x_main_module_144 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 143)));
+    auto x_main_module_145 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 144));
+    auto x_main_module_146 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 145));
+    auto x_main_module_147 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 146)));
+    auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 512, 1, 1}}, 147));
+    auto x_main_module_149 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 148)));
+    auto x_main_module_150 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 149));
+    auto x_main_module_151 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 150));
+    auto x_main_module_152 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 151));
+    auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 152));
+    auto x_main_module_154 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 153)));
+    auto x_main_module_155 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 154));
+    auto x_main_module_156 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 155));
+    auto x_main_module_157 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 156)));
+    auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 157));
+    auto x_main_module_159 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 158)));
+    auto x_main_module_160 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 159));
+    auto x_main_module_161 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 160));
+    auto x_main_module_162 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 161)));
+    auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 162));
+    auto x_main_module_164 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 163)));
+    auto x_main_module_165 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 164));
+    auto x_main_module_166 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 165));
+    auto x_main_module_167 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 166));
+    auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 167));
+    auto x_main_module_169 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 168)));
+    auto x_main_module_170 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 169));
+    auto x_main_module_171 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 170));
+    auto x_main_module_172 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 171)));
+    auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 172));
+    auto x_main_module_174 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 173)));
+    auto x_main_module_175 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 174));
+    auto x_main_module_176 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 175));
+    auto x_main_module_177 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 176)));
+    auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 177));
+    auto x_main_module_179 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 178)));
+    auto x_main_module_180 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 179));
+    auto x_main_module_181 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 180));
+    auto x_main_module_182 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 181));
+    auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 182));
+    auto x_main_module_184 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 183)));
+    auto x_main_module_185 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 184));
+    auto x_main_module_186 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 185));
+    auto x_main_module_187 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 186)));
+    auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 187));
+    auto x_main_module_189 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 188)));
+    auto x_main_module_190 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 189));
+    auto x_main_module_191 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 190));
+    auto x_main_module_192 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 191)));
+    auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 192));
+    auto x_main_module_194 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 193)));
+    auto x_main_module_195 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 194));
+    auto x_main_module_196 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 195));
+    auto x_main_module_197 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 196));
+    auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 256, 1, 1}}, 197));
+    auto x_main_module_199 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 198)));
+    auto x_main_module_200 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 199));
+    auto x_main_module_201 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 200));
+    auto x_main_module_202 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 201));
+    auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 202));
+    auto x_main_module_204 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 203)));
+    auto x_main_module_205 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 204));
+    auto x_main_module_206 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 205));
+    auto x_main_module_207 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 206)));
+    auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 207));
+    auto x_main_module_209 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 208)));
+    auto x_main_module_210 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 209));
+    auto x_main_module_211 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 210));
+    auto x_main_module_212 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 211)));
+    auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {128, 256, 1, 1}}, 212));
+    auto x_main_module_214 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 213)));
+    auto x_main_module_215 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 214));
+    auto x_main_module_216 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 215));
+    auto x_main_module_217 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 216));
+    auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 217));
+    auto x_main_module_219 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 218)));
+    auto x_main_module_220 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 219));
+    auto x_main_module_221 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 220));
+    auto x_main_module_222 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 221)));
+    auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 222));
+    auto x_main_module_224 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 223)));
+    auto x_main_module_225 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 224));
+    auto x_main_module_226 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 225));
+    auto x_main_module_227 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 226)));
+    auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 227));
+    auto x_main_module_229 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 228)));
+    auto x_main_module_230 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 229));
+    auto x_main_module_231 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 230));
+    auto x_main_module_232 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 231));
+    auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 232));
+    auto x_main_module_234 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 233)));
+    auto x_main_module_235 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 234));
+    auto x_main_module_236 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 235));
+    auto x_main_module_237 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 236)));
+    auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 237));
+    auto x_main_module_239 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 238)));
+    auto x_main_module_240 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 239));
+    auto x_main_module_241 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 240));
+    auto x_main_module_242 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 241)));
+    auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 242));
+    auto x_main_module_244 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 243)));
+    auto x_main_module_245 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 244));
+    auto x_main_module_246 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 245));
+    auto x_main_module_247 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 246));
+    auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 247));
+    auto x_main_module_249 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 248)));
+    auto x_main_module_250 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 249));
+    auto x_main_module_251 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 250));
+    auto x_main_module_252 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 251));
+    auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 252));
+    auto x_main_module_254 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 253)));
+    auto x_main_module_255 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 254));
+    auto x_main_module_256 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 255));
+    auto x_main_module_257 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 256)));
+    auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 257));
+    auto x_main_module_259 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 258)));
+    auto x_main_module_260 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 259));
+    auto x_main_module_261 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 260));
+    auto x_main_module_262 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 261)));
+    auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 64, 1, 1}}, 262));
+    auto x_main_module_264 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 263)));
+    auto x_main_module_265 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 264));
+    auto x_main_module_266 = mmain->add_literal(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 265));
+    auto x_main_module_267 = mmain->add_literal(migraphx::abs(
+        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 266)));
+    auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(
+        migraphx::shape{migraphx::shape::float_type, {64, 3, 7, 7}}, 267));
+    auto x_main_module_269 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,3,3,3],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_0,
+        x_main_module_268);
+    auto x_main_module_270 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_269,
+        x_main_module_267,
+        x_main_module_266,
+        x_main_module_265,
+        x_main_module_264);
+    auto x_main_module_271 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_270);
+    auto x_main_module_272 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
+                                       "1,\"padding\":[1,1,1,1],\"stride\":[2,2]}")),
+        x_main_module_271);
+    auto x_main_module_273 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_272,
+        x_main_module_263);
+    auto x_main_module_274 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_273,
+        x_main_module_262,
+        x_main_module_261,
+        x_main_module_260,
+        x_main_module_259);
+    auto x_main_module_275 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_274);
+    auto x_main_module_276 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_275,
+        x_main_module_258);
+    auto x_main_module_277 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_276,
+        x_main_module_257,
+        x_main_module_256,
+        x_main_module_255,
+        x_main_module_254);
+    auto x_main_module_278 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_277);
+    auto x_main_module_279 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_278,
+        x_main_module_253);
+    auto x_main_module_280 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_279,
+        x_main_module_252,
+        x_main_module_251,
+        x_main_module_250,
+        x_main_module_249);
+    auto x_main_module_281 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_272,
+        x_main_module_248);
+    auto x_main_module_282 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_281,
+        x_main_module_247,
+        x_main_module_246,
+        x_main_module_245,
+        x_main_module_244);
+    auto x_main_module_283 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_280, x_main_module_282);
+    auto x_main_module_284 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_283);
+    auto x_main_module_285 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_284,
+        x_main_module_243);
+    auto x_main_module_286 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_285,
+        x_main_module_242,
+        x_main_module_241,
+        x_main_module_240,
+        x_main_module_239);
+    auto x_main_module_287 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_286);
+    auto x_main_module_288 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_287,
+        x_main_module_238);
+    auto x_main_module_289 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_288,
+        x_main_module_237,
+        x_main_module_236,
+        x_main_module_235,
+        x_main_module_234);
+    auto x_main_module_290 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_289);
+    auto x_main_module_291 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_290,
+        x_main_module_233);
+    auto x_main_module_292 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_291,
+        x_main_module_232,
+        x_main_module_231,
+        x_main_module_230,
+        x_main_module_229);
+    auto x_main_module_293 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_292, x_main_module_284);
+    auto x_main_module_294 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_293);
+    auto x_main_module_295 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_294,
+        x_main_module_228);
+    auto x_main_module_296 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_295,
+        x_main_module_227,
+        x_main_module_226,
+        x_main_module_225,
+        x_main_module_224);
+    auto x_main_module_297 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_296);
+    auto x_main_module_298 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_297,
+        x_main_module_223);
+    auto x_main_module_299 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_298,
+        x_main_module_222,
+        x_main_module_221,
+        x_main_module_220,
+        x_main_module_219);
+    auto x_main_module_300 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_299);
+    auto x_main_module_301 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_300,
+        x_main_module_218);
+    auto x_main_module_302 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_301,
+        x_main_module_217,
+        x_main_module_216,
+        x_main_module_215,
+        x_main_module_214);
+    auto x_main_module_303 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_302, x_main_module_294);
+    auto x_main_module_304 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_303);
+    auto x_main_module_305 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_304,
+        x_main_module_213);
+    auto x_main_module_306 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_305,
+        x_main_module_212,
+        x_main_module_211,
+        x_main_module_210,
+        x_main_module_209);
+    auto x_main_module_307 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_306);
+    auto x_main_module_308 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_307,
+        x_main_module_208);
+    auto x_main_module_309 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_308,
+        x_main_module_207,
+        x_main_module_206,
+        x_main_module_205,
+        x_main_module_204);
+    auto x_main_module_310 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_309);
+    auto x_main_module_311 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_310,
+        x_main_module_203);
+    auto x_main_module_312 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_311,
+        x_main_module_202,
+        x_main_module_201,
+        x_main_module_200,
+        x_main_module_199);
+    auto x_main_module_313 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_304,
+        x_main_module_198);
+    auto x_main_module_314 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_313,
+        x_main_module_197,
+        x_main_module_196,
+        x_main_module_195,
+        x_main_module_194);
+    auto x_main_module_315 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_312, x_main_module_314);
+    auto x_main_module_316 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_315);
+    auto x_main_module_317 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_316,
+        x_main_module_193);
+    auto x_main_module_318 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_317,
+        x_main_module_192,
+        x_main_module_191,
+        x_main_module_190,
+        x_main_module_189);
+    auto x_main_module_319 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_318);
+    auto x_main_module_320 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_319,
+        x_main_module_188);
+    auto x_main_module_321 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_320,
+        x_main_module_187,
+        x_main_module_186,
+        x_main_module_185,
+        x_main_module_184);
+    auto x_main_module_322 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_321);
+    auto x_main_module_323 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_322,
+        x_main_module_183);
+    auto x_main_module_324 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_323,
+        x_main_module_182,
+        x_main_module_181,
+        x_main_module_180,
+        x_main_module_179);
+    auto x_main_module_325 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_324, x_main_module_316);
+    auto x_main_module_326 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_325);
+    auto x_main_module_327 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_326,
+        x_main_module_178);
+    auto x_main_module_328 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_327,
+        x_main_module_177,
+        x_main_module_176,
+        x_main_module_175,
+        x_main_module_174);
+    auto x_main_module_329 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_328);
+    auto x_main_module_330 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_329,
+        x_main_module_173);
+    auto x_main_module_331 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_330,
+        x_main_module_172,
+        x_main_module_171,
+        x_main_module_170,
+        x_main_module_169);
+    auto x_main_module_332 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_331);
+    auto x_main_module_333 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_332,
+        x_main_module_168);
+    auto x_main_module_334 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_333,
+        x_main_module_167,
+        x_main_module_166,
+        x_main_module_165,
+        x_main_module_164);
+    auto x_main_module_335 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_334, x_main_module_326);
+    auto x_main_module_336 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_335);
+    auto x_main_module_337 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_336,
+        x_main_module_163);
+    auto x_main_module_338 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_337,
+        x_main_module_162,
+        x_main_module_161,
+        x_main_module_160,
+        x_main_module_159);
+    auto x_main_module_339 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_338);
+    auto x_main_module_340 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_339,
+        x_main_module_158);
+    auto x_main_module_341 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_340,
+        x_main_module_157,
+        x_main_module_156,
+        x_main_module_155,
+        x_main_module_154);
+    auto x_main_module_342 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_341);
+    auto x_main_module_343 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_342,
+        x_main_module_153);
+    auto x_main_module_344 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_343,
+        x_main_module_152,
+        x_main_module_151,
+        x_main_module_150,
+        x_main_module_149);
+    auto x_main_module_345 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_344, x_main_module_336);
+    auto x_main_module_346 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_345);
+    auto x_main_module_347 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_346,
+        x_main_module_148);
+    auto x_main_module_348 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_347,
+        x_main_module_147,
+        x_main_module_146,
+        x_main_module_145,
+        x_main_module_144);
+    auto x_main_module_349 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_348);
+    auto x_main_module_350 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_349,
+        x_main_module_143);
+    auto x_main_module_351 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_350,
+        x_main_module_142,
+        x_main_module_141,
+        x_main_module_140,
+        x_main_module_139);
+    auto x_main_module_352 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_351);
+    auto x_main_module_353 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_352,
+        x_main_module_138);
+    auto x_main_module_354 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_353,
+        x_main_module_137,
+        x_main_module_136,
+        x_main_module_135,
+        x_main_module_134);
+    auto x_main_module_355 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_346,
+        x_main_module_133);
+    auto x_main_module_356 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_355,
+        x_main_module_132,
+        x_main_module_131,
+        x_main_module_130,
+        x_main_module_129);
+    auto x_main_module_357 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_354, x_main_module_356);
+    auto x_main_module_358 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_357);
+    auto x_main_module_359 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_358,
+        x_main_module_128);
+    auto x_main_module_360 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_359,
+        x_main_module_127,
+        x_main_module_126,
+        x_main_module_125,
+        x_main_module_124);
+    auto x_main_module_361 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_360);
+    auto x_main_module_362 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_361,
+        x_main_module_123);
+    auto x_main_module_363 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_362,
+        x_main_module_122,
+        x_main_module_121,
+        x_main_module_120,
+        x_main_module_119);
+    auto x_main_module_364 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_363);
+    auto x_main_module_365 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_364,
+        x_main_module_118);
+    auto x_main_module_366 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_365,
+        x_main_module_117,
+        x_main_module_116,
+        x_main_module_115,
+        x_main_module_114);
+    auto x_main_module_367 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_366, x_main_module_358);
+    auto x_main_module_368 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_367);
+    auto x_main_module_369 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_368,
+        x_main_module_113);
+    auto x_main_module_370 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_369,
+        x_main_module_112,
+        x_main_module_111,
+        x_main_module_110,
+        x_main_module_109);
+    auto x_main_module_371 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_370);
+    auto x_main_module_372 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_371,
+        x_main_module_108);
+    auto x_main_module_373 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_372,
+        x_main_module_107,
+        x_main_module_106,
+        x_main_module_105,
+        x_main_module_104);
+    auto x_main_module_374 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_373);
+    auto x_main_module_375 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_374,
+        x_main_module_103);
+    auto x_main_module_376 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_375,
+        x_main_module_102,
+        x_main_module_101,
+        x_main_module_100,
+        x_main_module_99);
+    auto x_main_module_377 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_376, x_main_module_368);
+    auto x_main_module_378 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_377);
+    auto x_main_module_379 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_378,
+        x_main_module_98);
+    auto x_main_module_380 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_379,
+        x_main_module_97,
+        x_main_module_96,
+        x_main_module_95,
+        x_main_module_94);
+    auto x_main_module_381 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_380);
+    auto x_main_module_382 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_381,
+        x_main_module_93);
+    auto x_main_module_383 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_382,
+        x_main_module_92,
+        x_main_module_91,
+        x_main_module_90,
+        x_main_module_89);
+    auto x_main_module_384 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_383);
+    auto x_main_module_385 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_384,
+        x_main_module_88);
+    auto x_main_module_386 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_385,
+        x_main_module_87,
+        x_main_module_86,
+        x_main_module_85,
+        x_main_module_84);
+    auto x_main_module_387 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_386, x_main_module_378);
+    auto x_main_module_388 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_387);
+    auto x_main_module_389 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_388,
+        x_main_module_83);
+    auto x_main_module_390 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_389,
+        x_main_module_82,
+        x_main_module_81,
+        x_main_module_80,
+        x_main_module_79);
+    auto x_main_module_391 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_390);
+    auto x_main_module_392 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_391,
+        x_main_module_78);
+    auto x_main_module_393 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_392,
+        x_main_module_77,
+        x_main_module_76,
+        x_main_module_75,
+        x_main_module_74);
+    auto x_main_module_394 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_393);
+    auto x_main_module_395 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_394,
+        x_main_module_73);
+    auto x_main_module_396 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_395,
+        x_main_module_72,
+        x_main_module_71,
+        x_main_module_70,
+        x_main_module_69);
+    auto x_main_module_397 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_396, x_main_module_388);
+    auto x_main_module_398 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_397);
+    auto x_main_module_399 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_398,
+        x_main_module_68);
+    auto x_main_module_400 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_399,
+        x_main_module_67,
+        x_main_module_66,
+        x_main_module_65,
+        x_main_module_64);
+    auto x_main_module_401 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_400);
+    auto x_main_module_402 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_401,
+        x_main_module_63);
+    auto x_main_module_403 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_402,
+        x_main_module_62,
+        x_main_module_61,
+        x_main_module_60,
+        x_main_module_59);
+    auto x_main_module_404 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_403);
+    auto x_main_module_405 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_404,
+        x_main_module_58);
+    auto x_main_module_406 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_405,
+        x_main_module_57,
+        x_main_module_56,
+        x_main_module_55,
+        x_main_module_54);
+    auto x_main_module_407 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_406, x_main_module_398);
+    auto x_main_module_408 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_407);
+    auto x_main_module_409 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_408,
+        x_main_module_53);
+    auto x_main_module_410 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_409,
+        x_main_module_52,
+        x_main_module_51,
+        x_main_module_50,
+        x_main_module_49);
+    auto x_main_module_411 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_410);
+    auto x_main_module_412 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_411,
+        x_main_module_48);
+    auto x_main_module_413 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_412,
+        x_main_module_47,
+        x_main_module_46,
+        x_main_module_45,
+        x_main_module_44);
+    auto x_main_module_414 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_413);
+    auto x_main_module_415 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_414,
+        x_main_module_43);
+    auto x_main_module_416 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_415,
+        x_main_module_42,
+        x_main_module_41,
+        x_main_module_40,
+        x_main_module_39);
+    auto x_main_module_417 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_408,
+        x_main_module_38);
+    auto x_main_module_418 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_417,
+        x_main_module_37,
+        x_main_module_36,
+        x_main_module_35,
+        x_main_module_34);
+    auto x_main_module_419 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_416, x_main_module_418);
+    auto x_main_module_420 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_419);
+    auto x_main_module_421 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_420,
+        x_main_module_33);
+    auto x_main_module_422 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_421,
+        x_main_module_32,
+        x_main_module_31,
+        x_main_module_30,
+        x_main_module_29);
+    auto x_main_module_423 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_422);
+    auto x_main_module_424 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_423,
+        x_main_module_28);
+    auto x_main_module_425 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_424,
+        x_main_module_27,
+        x_main_module_26,
+        x_main_module_25,
+        x_main_module_24);
+    auto x_main_module_426 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_425);
+    auto x_main_module_427 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_426,
+        x_main_module_23);
+    auto x_main_module_428 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_427,
+        x_main_module_22,
+        x_main_module_21,
+        x_main_module_20,
+        x_main_module_19);
+    auto x_main_module_429 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_428, x_main_module_420);
+    auto x_main_module_430 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_429);
+    auto x_main_module_431 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_430,
+        x_main_module_18);
+    auto x_main_module_432 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_431,
+        x_main_module_17,
+        x_main_module_16,
+        x_main_module_15,
+        x_main_module_14);
+    auto x_main_module_433 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_432);
+    auto x_main_module_434 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_433,
+        x_main_module_13);
+    auto x_main_module_435 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_434,
+        x_main_module_12,
+        x_main_module_11,
+        x_main_module_10,
+        x_main_module_9);
+    auto x_main_module_436 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_435);
+    auto x_main_module_437 = mmain->add_instruction(
+        migraphx::make_op("convolution",
+                          migraphx::from_json_string(
+                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
+                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
+        x_main_module_436,
+        x_main_module_8);
+    auto x_main_module_438 = mmain->add_instruction(
+        migraphx::make_op(
+            "batch_norm_inference",
+            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
+                                       "\"momentum\":0.8999999761581421}")),
+        x_main_module_437,
+        x_main_module_7,
+        x_main_module_6,
+        x_main_module_5,
+        x_main_module_4);
+    auto x_main_module_439 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_438, x_main_module_430);
+    auto x_main_module_440 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_439);
+    auto x_main_module_441 = mmain->add_instruction(
+        migraphx::make_op(
+            "pooling",
+            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[7,7],\"lp_order\":2,\"mode\":"
+                                       "0,\"padding\":[0,0,0,0],\"stride\":[1,1]}")),
+        x_main_module_440);
+    auto x_main_module_442 = mmain->add_instruction(
+        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")),
+        x_main_module_441);
+    auto x_main_module_443 = mmain->add_instruction(
+        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
+        x_main_module_3);
+    auto x_main_module_444 =
+        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_442, x_main_module_443);
+    auto x_main_module_445 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        x_main_module_2);
+    auto x_main_module_446 = mmain->add_instruction(
+        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
+        x_main_module_0);
+    auto x_main_module_447 =
+        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_445, x_main_module_446);
+    auto x_main_module_448 =
+        mmain->add_instruction(migraphx::make_op("add"), x_main_module_444, x_main_module_447);
+    mmain->add_return({x_main_module_448});
 
     return p;
 }

--- a/src/driver/resnet50.cpp
+++ b/src/driver/resnet50.cpp
@@ -33,1558 +33,458 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program resnet50(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-    migraphx::module_ref mmain = p.get_main_module();
-    auto _x_main_module_0      = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-    auto _x_0                  = mmain->add_parameter(
-        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
-    auto _x_main_module_2 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
-    auto _x_main_module_3 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
-    auto _x_main_module_4 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 3)));
-    auto _x_main_module_5 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 4));
-    auto _x_main_module_6 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 5));
-    auto _x_main_module_7  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 6)));
-    auto _x_main_module_8  = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 7));
-    auto _x_main_module_9  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 8)));
-    auto _x_main_module_10 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 9));
-    auto _x_main_module_11 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 10));
-    auto _x_main_module_12 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 11)));
-    auto _x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 12));
-    auto _x_main_module_14 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 13)));
-    auto _x_main_module_15 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 14));
-    auto _x_main_module_16 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 15));
-    auto _x_main_module_17 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 16)));
-    auto _x_main_module_18 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 17));
-    auto _x_main_module_19 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 18)));
-    auto _x_main_module_20 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 19));
-    auto _x_main_module_21 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 20));
-    auto _x_main_module_22 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 21)));
-    auto _x_main_module_23 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 22));
-    auto _x_main_module_24 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 23)));
-    auto _x_main_module_25 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 24));
-    auto _x_main_module_26 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 25));
-    auto _x_main_module_27 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 26)));
-    auto _x_main_module_28 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 27));
-    auto _x_main_module_29 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 28)));
-    auto _x_main_module_30 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 29));
-    auto _x_main_module_31 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 30));
-    auto _x_main_module_32 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 31)));
-    auto _x_main_module_33 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 32));
-    auto _x_main_module_34 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 33)));
-    auto _x_main_module_35 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 34));
-    auto _x_main_module_36 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 35));
-    auto _x_main_module_37 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 36)));
-    auto _x_main_module_38 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {2048, 1024, 1, 1}}, 37));
-    auto _x_main_module_39 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 38)));
-    auto _x_main_module_40 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 39));
-    auto _x_main_module_41 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 40));
-    auto _x_main_module_42 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 41)));
-    auto _x_main_module_43 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 42));
-    auto _x_main_module_44 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 43)));
-    auto _x_main_module_45 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 44));
-    auto _x_main_module_46 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 45));
-    auto _x_main_module_47 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 46)));
-    auto _x_main_module_48 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 47));
-    auto _x_main_module_49 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 48)));
-    auto _x_main_module_50 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 49));
-    auto _x_main_module_51 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 50));
-    auto _x_main_module_52 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 51)));
-    auto _x_main_module_53 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 1024, 1, 1}}, 52));
-    auto _x_main_module_54 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 53)));
-    auto _x_main_module_55 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 54));
-    auto _x_main_module_56 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 55));
-    auto _x_main_module_57 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 56));
-    auto _x_main_module_58 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 57));
-    auto _x_main_module_59 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 58)));
-    auto _x_main_module_60 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 59));
-    auto _x_main_module_61 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 60));
-    auto _x_main_module_62 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 61)));
-    auto _x_main_module_63 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 62));
-    auto _x_main_module_64 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 63)));
-    auto _x_main_module_65 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 64));
-    auto _x_main_module_66 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 65));
-    auto _x_main_module_67 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 66)));
-    auto _x_main_module_68 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 67));
-    auto _x_main_module_69 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 68)));
-    auto _x_main_module_70 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 69));
-    auto _x_main_module_71 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 70));
-    auto _x_main_module_72 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 71));
-    auto _x_main_module_73 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 72));
-    auto _x_main_module_74 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 73)));
-    auto _x_main_module_75 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 74));
-    auto _x_main_module_76 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 75));
-    auto _x_main_module_77 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 76)));
-    auto _x_main_module_78 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 77));
-    auto _x_main_module_79 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 78)));
-    auto _x_main_module_80 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 79));
-    auto _x_main_module_81 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 80));
-    auto _x_main_module_82 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 81)));
-    auto _x_main_module_83 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 82));
-    auto _x_main_module_84 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 83)));
-    auto _x_main_module_85 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 84));
-    auto _x_main_module_86 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 85));
-    auto _x_main_module_87 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 86));
-    auto _x_main_module_88 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 87));
-    auto _x_main_module_89 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 88)));
-    auto _x_main_module_90 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 89));
-    auto _x_main_module_91 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 90));
-    auto _x_main_module_92 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 91)));
-    auto _x_main_module_93 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 92));
-    auto _x_main_module_94 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 93)));
-    auto _x_main_module_95 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 94));
-    auto _x_main_module_96 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 95));
-    auto _x_main_module_97  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 96)));
-    auto _x_main_module_98  = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 97));
-    auto _x_main_module_99  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 98)));
-    auto _x_main_module_100 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 99));
-    auto _x_main_module_101 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 100));
-    auto _x_main_module_102 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 101));
-    auto _x_main_module_103 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 102));
-    auto _x_main_module_104 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 103)));
-    auto _x_main_module_105 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 104));
-    auto _x_main_module_106 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 105));
-    auto _x_main_module_107 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 106)));
-    auto _x_main_module_108 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 107));
-    auto _x_main_module_109 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 108)));
-    auto _x_main_module_110 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 109));
-    auto _x_main_module_111 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 110));
-    auto _x_main_module_112 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 111)));
-    auto _x_main_module_113 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 112));
-    auto _x_main_module_114 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 113)));
-    auto _x_main_module_115 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 114));
-    auto _x_main_module_116 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 115));
-    auto _x_main_module_117 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 116));
-    auto _x_main_module_118 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 117));
-    auto _x_main_module_119 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 118)));
-    auto _x_main_module_120 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 119));
-    auto _x_main_module_121 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 120));
-    auto _x_main_module_122 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 121)));
-    auto _x_main_module_123 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 122));
-    auto _x_main_module_124 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 123)));
-    auto _x_main_module_125 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 124));
-    auto _x_main_module_126 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 125));
-    auto _x_main_module_127 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 126)));
-    auto _x_main_module_128 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 127));
-    auto _x_main_module_129 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 128)));
-    auto _x_main_module_130 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 129));
-    auto _x_main_module_131 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 130));
-    auto _x_main_module_132 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 131));
-    auto _x_main_module_133 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 512, 1, 1}}, 132));
-    auto _x_main_module_134 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 133)));
-    auto _x_main_module_135 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 134));
-    auto _x_main_module_136 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 135));
-    auto _x_main_module_137 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 136));
-    auto _x_main_module_138 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 137));
-    auto _x_main_module_139 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 138)));
-    auto _x_main_module_140 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 139));
-    auto _x_main_module_141 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 140));
-    auto _x_main_module_142 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 141)));
-    auto _x_main_module_143 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 142));
-    auto _x_main_module_144 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 143)));
-    auto _x_main_module_145 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 144));
-    auto _x_main_module_146 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 145));
-    auto _x_main_module_147 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 146)));
-    auto _x_main_module_148 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 512, 1, 1}}, 147));
-    auto _x_main_module_149 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 148)));
-    auto _x_main_module_150 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 149));
-    auto _x_main_module_151 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 150));
-    auto _x_main_module_152 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 151));
-    auto _x_main_module_153 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 152));
-    auto _x_main_module_154 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 153)));
-    auto _x_main_module_155 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 154));
-    auto _x_main_module_156 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 155));
-    auto _x_main_module_157 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 156)));
-    auto _x_main_module_158 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 157));
-    auto _x_main_module_159 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 158)));
-    auto _x_main_module_160 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 159));
-    auto _x_main_module_161 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 160));
-    auto _x_main_module_162 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 161)));
-    auto _x_main_module_163 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 162));
-    auto _x_main_module_164 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 163)));
-    auto _x_main_module_165 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 164));
-    auto _x_main_module_166 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 165));
-    auto _x_main_module_167 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 166));
-    auto _x_main_module_168 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 167));
-    auto _x_main_module_169 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 168)));
-    auto _x_main_module_170 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 169));
-    auto _x_main_module_171 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 170));
-    auto _x_main_module_172 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 171)));
-    auto _x_main_module_173 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 172));
-    auto _x_main_module_174 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 173)));
-    auto _x_main_module_175 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 174));
-    auto _x_main_module_176 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 175));
-    auto _x_main_module_177 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 176)));
-    auto _x_main_module_178 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 177));
-    auto _x_main_module_179 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 178)));
-    auto _x_main_module_180 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 179));
-    auto _x_main_module_181 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 180));
-    auto _x_main_module_182 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 181));
-    auto _x_main_module_183 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 182));
-    auto _x_main_module_184 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 183)));
-    auto _x_main_module_185 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 184));
-    auto _x_main_module_186 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 185));
-    auto _x_main_module_187 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 186)));
-    auto _x_main_module_188 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 187));
-    auto _x_main_module_189 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 188)));
-    auto _x_main_module_190 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 189));
-    auto _x_main_module_191 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 190));
-    auto _x_main_module_192 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 191)));
-    auto _x_main_module_193 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 192));
-    auto _x_main_module_194 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 193)));
-    auto _x_main_module_195 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 194));
-    auto _x_main_module_196 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 195));
-    auto _x_main_module_197 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 196));
-    auto _x_main_module_198 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 256, 1, 1}}, 197));
-    auto _x_main_module_199 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 198)));
-    auto _x_main_module_200 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 199));
-    auto _x_main_module_201 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 200));
-    auto _x_main_module_202 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 201));
-    auto _x_main_module_203 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 202));
-    auto _x_main_module_204 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 203)));
-    auto _x_main_module_205 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 204));
-    auto _x_main_module_206 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 205));
-    auto _x_main_module_207 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 206)));
-    auto _x_main_module_208 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 207));
-    auto _x_main_module_209 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 208)));
-    auto _x_main_module_210 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 209));
-    auto _x_main_module_211 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 210));
-    auto _x_main_module_212 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 211)));
-    auto _x_main_module_213 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 256, 1, 1}}, 212));
-    auto _x_main_module_214 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 213)));
-    auto _x_main_module_215 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 214));
-    auto _x_main_module_216 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 215));
-    auto _x_main_module_217 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 216));
-    auto _x_main_module_218 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 217));
-    auto _x_main_module_219 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 218)));
-    auto _x_main_module_220 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 219));
-    auto _x_main_module_221 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 220));
-    auto _x_main_module_222 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 221)));
-    auto _x_main_module_223 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 222));
-    auto _x_main_module_224 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 223)));
-    auto _x_main_module_225 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 224));
-    auto _x_main_module_226 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 225));
-    auto _x_main_module_227 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 226)));
-    auto _x_main_module_228 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 227));
-    auto _x_main_module_229 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 228)));
-    auto _x_main_module_230 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 229));
-    auto _x_main_module_231 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 230));
-    auto _x_main_module_232 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 231));
-    auto _x_main_module_233 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 232));
-    auto _x_main_module_234 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 233)));
-    auto _x_main_module_235 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 234));
-    auto _x_main_module_236 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 235));
-    auto _x_main_module_237 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 236)));
-    auto _x_main_module_238 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 237));
-    auto _x_main_module_239 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 238)));
-    auto _x_main_module_240 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 239));
-    auto _x_main_module_241 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 240));
-    auto _x_main_module_242 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 241)));
-    auto _x_main_module_243 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 242));
-    auto _x_main_module_244 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 243)));
-    auto _x_main_module_245 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 244));
-    auto _x_main_module_246 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 245));
-    auto _x_main_module_247 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 246));
-    auto _x_main_module_248 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 247));
-    auto _x_main_module_249 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 248)));
-    auto _x_main_module_250 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 249));
-    auto _x_main_module_251 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 250));
-    auto _x_main_module_252 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 251));
-    auto _x_main_module_253 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 252));
-    auto _x_main_module_254 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 253)));
-    auto _x_main_module_255 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 254));
-    auto _x_main_module_256 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 255));
-    auto _x_main_module_257 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 256)));
-    auto _x_main_module_258 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 257));
-    auto _x_main_module_259 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 258)));
-    auto _x_main_module_260 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 259));
-    auto _x_main_module_261 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 260));
-    auto _x_main_module_262 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 261)));
-    auto _x_main_module_263 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 64, 1, 1}}, 262));
-    auto _x_main_module_264 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 263)));
-    auto _x_main_module_265 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 264));
-    auto _x_main_module_266 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 265));
-    auto _x_main_module_267 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 266)));
-    auto _x_main_module_268 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 3, 7, 7}}, 267));
-    auto _x_main_module_269 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,3,3,3],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        _x_0,
-        _x_main_module_268);
-    auto _x_main_module_270 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_269,
-        _x_main_module_267,
-        _x_main_module_266,
-        _x_main_module_265,
-        _x_main_module_264);
-    auto _x_main_module_271 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_270);
-    auto _x_main_module_272 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[1,1,1,1],\"stride\":[2,2]}")),
-        _x_main_module_271);
-    auto _x_main_module_273 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_272,
-        _x_main_module_263);
-    auto _x_main_module_274 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_273,
-        _x_main_module_262,
-        _x_main_module_261,
-        _x_main_module_260,
-        _x_main_module_259);
-    auto _x_main_module_275 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_274);
-    auto _x_main_module_276 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_275,
-        _x_main_module_258);
-    auto _x_main_module_277 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_276,
-        _x_main_module_257,
-        _x_main_module_256,
-        _x_main_module_255,
-        _x_main_module_254);
-    auto _x_main_module_278 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_277);
-    auto _x_main_module_279 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_278,
-        _x_main_module_253);
-    auto _x_main_module_280 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_279,
-        _x_main_module_252,
-        _x_main_module_251,
-        _x_main_module_250,
-        _x_main_module_249);
-    auto _x_main_module_281 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_272,
-        _x_main_module_248);
-    auto _x_main_module_282 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_281,
-        _x_main_module_247,
-        _x_main_module_246,
-        _x_main_module_245,
-        _x_main_module_244);
-    auto _x_main_module_283 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_280, _x_main_module_282);
-    auto _x_main_module_284 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_283);
-    auto _x_main_module_285 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_284,
-        _x_main_module_243);
-    auto _x_main_module_286 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_285,
-        _x_main_module_242,
-        _x_main_module_241,
-        _x_main_module_240,
-        _x_main_module_239);
-    auto _x_main_module_287 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_286);
-    auto _x_main_module_288 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_287,
-        _x_main_module_238);
-    auto _x_main_module_289 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_288,
-        _x_main_module_237,
-        _x_main_module_236,
-        _x_main_module_235,
-        _x_main_module_234);
-    auto _x_main_module_290 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_289);
-    auto _x_main_module_291 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_290,
-        _x_main_module_233);
-    auto _x_main_module_292 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_291,
-        _x_main_module_232,
-        _x_main_module_231,
-        _x_main_module_230,
-        _x_main_module_229);
-    auto _x_main_module_293 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_292, _x_main_module_284);
-    auto _x_main_module_294 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_293);
-    auto _x_main_module_295 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_294,
-        _x_main_module_228);
-    auto _x_main_module_296 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_295,
-        _x_main_module_227,
-        _x_main_module_226,
-        _x_main_module_225,
-        _x_main_module_224);
-    auto _x_main_module_297 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_296);
-    auto _x_main_module_298 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_297,
-        _x_main_module_223);
-    auto _x_main_module_299 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_298,
-        _x_main_module_222,
-        _x_main_module_221,
-        _x_main_module_220,
-        _x_main_module_219);
-    auto _x_main_module_300 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_299);
-    auto _x_main_module_301 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_300,
-        _x_main_module_218);
-    auto _x_main_module_302 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_301,
-        _x_main_module_217,
-        _x_main_module_216,
-        _x_main_module_215,
-        _x_main_module_214);
-    auto _x_main_module_303 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_302, _x_main_module_294);
-    auto _x_main_module_304 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_303);
-    auto _x_main_module_305 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_304,
-        _x_main_module_213);
-    auto _x_main_module_306 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_305,
-        _x_main_module_212,
-        _x_main_module_211,
-        _x_main_module_210,
-        _x_main_module_209);
-    auto _x_main_module_307 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_306);
-    auto _x_main_module_308 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_307,
-        _x_main_module_208);
-    auto _x_main_module_309 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_308,
-        _x_main_module_207,
-        _x_main_module_206,
-        _x_main_module_205,
-        _x_main_module_204);
-    auto _x_main_module_310 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_309);
-    auto _x_main_module_311 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_310,
-        _x_main_module_203);
-    auto _x_main_module_312 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_311,
-        _x_main_module_202,
-        _x_main_module_201,
-        _x_main_module_200,
-        _x_main_module_199);
-    auto _x_main_module_313 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_304,
-        _x_main_module_198);
-    auto _x_main_module_314 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_313,
-        _x_main_module_197,
-        _x_main_module_196,
-        _x_main_module_195,
-        _x_main_module_194);
-    auto _x_main_module_315 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_312, _x_main_module_314);
-    auto _x_main_module_316 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_315);
-    auto _x_main_module_317 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_316,
-        _x_main_module_193);
-    auto _x_main_module_318 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_317,
-        _x_main_module_192,
-        _x_main_module_191,
-        _x_main_module_190,
-        _x_main_module_189);
-    auto _x_main_module_319 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_318);
-    auto _x_main_module_320 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_319,
-        _x_main_module_188);
-    auto _x_main_module_321 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_320,
-        _x_main_module_187,
-        _x_main_module_186,
-        _x_main_module_185,
-        _x_main_module_184);
-    auto _x_main_module_322 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_321);
-    auto _x_main_module_323 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_322,
-        _x_main_module_183);
-    auto _x_main_module_324 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_323,
-        _x_main_module_182,
-        _x_main_module_181,
-        _x_main_module_180,
-        _x_main_module_179);
-    auto _x_main_module_325 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_324, _x_main_module_316);
-    auto _x_main_module_326 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_325);
-    auto _x_main_module_327 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_326,
-        _x_main_module_178);
-    auto _x_main_module_328 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_327,
-        _x_main_module_177,
-        _x_main_module_176,
-        _x_main_module_175,
-        _x_main_module_174);
-    auto _x_main_module_329 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_328);
-    auto _x_main_module_330 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_329,
-        _x_main_module_173);
-    auto _x_main_module_331 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_330,
-        _x_main_module_172,
-        _x_main_module_171,
-        _x_main_module_170,
-        _x_main_module_169);
-    auto _x_main_module_332 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_331);
-    auto _x_main_module_333 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_332,
-        _x_main_module_168);
-    auto _x_main_module_334 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_333,
-        _x_main_module_167,
-        _x_main_module_166,
-        _x_main_module_165,
-        _x_main_module_164);
-    auto _x_main_module_335 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_334, _x_main_module_326);
-    auto _x_main_module_336 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_335);
-    auto _x_main_module_337 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_336,
-        _x_main_module_163);
-    auto _x_main_module_338 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_337,
-        _x_main_module_162,
-        _x_main_module_161,
-        _x_main_module_160,
-        _x_main_module_159);
-    auto _x_main_module_339 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_338);
-    auto _x_main_module_340 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_339,
-        _x_main_module_158);
-    auto _x_main_module_341 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_340,
-        _x_main_module_157,
-        _x_main_module_156,
-        _x_main_module_155,
-        _x_main_module_154);
-    auto _x_main_module_342 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_341);
-    auto _x_main_module_343 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_342,
-        _x_main_module_153);
-    auto _x_main_module_344 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_343,
-        _x_main_module_152,
-        _x_main_module_151,
-        _x_main_module_150,
-        _x_main_module_149);
-    auto _x_main_module_345 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_344, _x_main_module_336);
-    auto _x_main_module_346 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_345);
-    auto _x_main_module_347 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_346,
-        _x_main_module_148);
-    auto _x_main_module_348 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_347,
-        _x_main_module_147,
-        _x_main_module_146,
-        _x_main_module_145,
-        _x_main_module_144);
-    auto _x_main_module_349 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_348);
-    auto _x_main_module_350 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_349,
-        _x_main_module_143);
-    auto _x_main_module_351 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_350,
-        _x_main_module_142,
-        _x_main_module_141,
-        _x_main_module_140,
-        _x_main_module_139);
-    auto _x_main_module_352 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_351);
-    auto _x_main_module_353 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_352,
-        _x_main_module_138);
-    auto _x_main_module_354 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_353,
-        _x_main_module_137,
-        _x_main_module_136,
-        _x_main_module_135,
-        _x_main_module_134);
-    auto _x_main_module_355 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_346,
-        _x_main_module_133);
-    auto _x_main_module_356 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_355,
-        _x_main_module_132,
-        _x_main_module_131,
-        _x_main_module_130,
-        _x_main_module_129);
-    auto _x_main_module_357 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_354, _x_main_module_356);
-    auto _x_main_module_358 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_357);
-    auto _x_main_module_359 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_358,
-        _x_main_module_128);
-    auto _x_main_module_360 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_359,
-        _x_main_module_127,
-        _x_main_module_126,
-        _x_main_module_125,
-        _x_main_module_124);
-    auto _x_main_module_361 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_360);
-    auto _x_main_module_362 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_361,
-        _x_main_module_123);
-    auto _x_main_module_363 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_362,
-        _x_main_module_122,
-        _x_main_module_121,
-        _x_main_module_120,
-        _x_main_module_119);
-    auto _x_main_module_364 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_363);
-    auto _x_main_module_365 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_364,
-        _x_main_module_118);
-    auto _x_main_module_366 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_365,
-        _x_main_module_117,
-        _x_main_module_116,
-        _x_main_module_115,
-        _x_main_module_114);
-    auto _x_main_module_367 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_366, _x_main_module_358);
-    auto _x_main_module_368 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_367);
-    auto _x_main_module_369 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_368,
-        _x_main_module_113);
-    auto _x_main_module_370 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_369,
-        _x_main_module_112,
-        _x_main_module_111,
-        _x_main_module_110,
-        _x_main_module_109);
-    auto _x_main_module_371 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_370);
-    auto _x_main_module_372 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_371,
-        _x_main_module_108);
-    auto _x_main_module_373 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_372,
-        _x_main_module_107,
-        _x_main_module_106,
-        _x_main_module_105,
-        _x_main_module_104);
-    auto _x_main_module_374 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_373);
-    auto _x_main_module_375 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_374,
-        _x_main_module_103);
-    auto _x_main_module_376 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_375,
-        _x_main_module_102,
-        _x_main_module_101,
-        _x_main_module_100,
-        _x_main_module_99);
-    auto _x_main_module_377 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_376, _x_main_module_368);
-    auto _x_main_module_378 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_377);
-    auto _x_main_module_379 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_378,
-        _x_main_module_98);
-    auto _x_main_module_380 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_379,
-        _x_main_module_97,
-        _x_main_module_96,
-        _x_main_module_95,
-        _x_main_module_94);
-    auto _x_main_module_381 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_380);
-    auto _x_main_module_382 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_381,
-        _x_main_module_93);
-    auto _x_main_module_383 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_382,
-        _x_main_module_92,
-        _x_main_module_91,
-        _x_main_module_90,
-        _x_main_module_89);
-    auto _x_main_module_384 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_383);
-    auto _x_main_module_385 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_384,
-        _x_main_module_88);
-    auto _x_main_module_386 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_385,
-        _x_main_module_87,
-        _x_main_module_86,
-        _x_main_module_85,
-        _x_main_module_84);
-    auto _x_main_module_387 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_386, _x_main_module_378);
-    auto _x_main_module_388 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_387);
-    auto _x_main_module_389 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_388,
-        _x_main_module_83);
-    auto _x_main_module_390 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_389,
-        _x_main_module_82,
-        _x_main_module_81,
-        _x_main_module_80,
-        _x_main_module_79);
-    auto _x_main_module_391 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_390);
-    auto _x_main_module_392 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_391,
-        _x_main_module_78);
-    auto _x_main_module_393 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_392,
-        _x_main_module_77,
-        _x_main_module_76,
-        _x_main_module_75,
-        _x_main_module_74);
-    auto _x_main_module_394 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_393);
-    auto _x_main_module_395 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_394,
-        _x_main_module_73);
-    auto _x_main_module_396 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_395,
-        _x_main_module_72,
-        _x_main_module_71,
-        _x_main_module_70,
-        _x_main_module_69);
-    auto _x_main_module_397 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_396, _x_main_module_388);
-    auto _x_main_module_398 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_397);
-    auto _x_main_module_399 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_398,
-        _x_main_module_68);
-    auto _x_main_module_400 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_399,
-        _x_main_module_67,
-        _x_main_module_66,
-        _x_main_module_65,
-        _x_main_module_64);
-    auto _x_main_module_401 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_400);
-    auto _x_main_module_402 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_401,
-        _x_main_module_63);
-    auto _x_main_module_403 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_402,
-        _x_main_module_62,
-        _x_main_module_61,
-        _x_main_module_60,
-        _x_main_module_59);
-    auto _x_main_module_404 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_403);
-    auto _x_main_module_405 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_404,
-        _x_main_module_58);
-    auto _x_main_module_406 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_405,
-        _x_main_module_57,
-        _x_main_module_56,
-        _x_main_module_55,
-        _x_main_module_54);
-    auto _x_main_module_407 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_406, _x_main_module_398);
-    auto _x_main_module_408 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_407);
-    auto _x_main_module_409 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_408,
-        _x_main_module_53);
-    auto _x_main_module_410 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_409,
-        _x_main_module_52,
-        _x_main_module_51,
-        _x_main_module_50,
-        _x_main_module_49);
-    auto _x_main_module_411 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_410);
-    auto _x_main_module_412 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_411,
-        _x_main_module_48);
-    auto _x_main_module_413 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_412,
-        _x_main_module_47,
-        _x_main_module_46,
-        _x_main_module_45,
-        _x_main_module_44);
-    auto _x_main_module_414 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_413);
-    auto _x_main_module_415 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_414,
-        _x_main_module_43);
-    auto _x_main_module_416 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_415,
-        _x_main_module_42,
-        _x_main_module_41,
-        _x_main_module_40,
-        _x_main_module_39);
-    auto _x_main_module_417 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_408,
-        _x_main_module_38);
-    auto _x_main_module_418 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_417,
-        _x_main_module_37,
-        _x_main_module_36,
-        _x_main_module_35,
-        _x_main_module_34);
-    auto _x_main_module_419 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_416, _x_main_module_418);
-    auto _x_main_module_420 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_419);
-    auto _x_main_module_421 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_420,
-        _x_main_module_33);
-    auto _x_main_module_422 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_421,
-        _x_main_module_32,
-        _x_main_module_31,
-        _x_main_module_30,
-        _x_main_module_29);
-    auto _x_main_module_423 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_422);
-    auto _x_main_module_424 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_423,
-        _x_main_module_28);
-    auto _x_main_module_425 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_424,
-        _x_main_module_27,
-        _x_main_module_26,
-        _x_main_module_25,
-        _x_main_module_24);
-    auto _x_main_module_426 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_425);
-    auto _x_main_module_427 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_426,
-        _x_main_module_23);
-    auto _x_main_module_428 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_427,
-        _x_main_module_22,
-        _x_main_module_21,
-        _x_main_module_20,
-        _x_main_module_19);
-    auto _x_main_module_429 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_428, _x_main_module_420);
-    auto _x_main_module_430 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_429);
-    auto _x_main_module_431 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_430,
-        _x_main_module_18);
-    auto _x_main_module_432 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_431,
-        _x_main_module_17,
-        _x_main_module_16,
-        _x_main_module_15,
-        _x_main_module_14);
-    auto _x_main_module_433 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_432);
-    auto _x_main_module_434 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_433,
-        _x_main_module_13);
-    auto _x_main_module_435 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_434,
-        _x_main_module_12,
-        _x_main_module_11,
-        _x_main_module_10,
-        _x_main_module_9);
-    auto _x_main_module_436 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_435);
-    auto _x_main_module_437 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        _x_main_module_436,
-        _x_main_module_8);
-    auto _x_main_module_438 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        _x_main_module_437,
-        _x_main_module_7,
-        _x_main_module_6,
-        _x_main_module_5,
-        _x_main_module_4);
-    auto _x_main_module_439 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_438, _x_main_module_430);
-    auto _x_main_module_440 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_439);
-    auto _x_main_module_441 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[7,7],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[0,0,0,0],\"stride\":[1,1]}")),
-        _x_main_module_440);
-    auto _x_main_module_442 = mmain->add_instruction(
-        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")),
-        _x_main_module_441);
-    auto _x_main_module_443 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
-        _x_main_module_3);
-    auto _x_main_module_444 =
-        mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_442, _x_main_module_443);
-    auto _x_main_module_445 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        _x_main_module_2);
-    auto _x_main_module_446 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        _x_main_module_0);
-    auto _x_main_module_447 =
-        mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_445, _x_main_module_446);
-    auto _x_main_module_448 =
-        mmain->add_instruction(migraphx::make_op("add"), _x_main_module_444, _x_main_module_447);
-    mmain->add_return({_x_main_module_448});
+migraphx::module_ref mmain = p.get_main_module();
+auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
+auto x_main_module_2 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
+auto x_main_module_3 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
+auto x_main_module_4 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 3)));
+auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 4));
+auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 5));
+auto x_main_module_7 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 6)));
+auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 7));
+auto x_main_module_9 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 8)));
+auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 9));
+auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 10));
+auto x_main_module_12 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 11)));
+auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 12));
+auto x_main_module_14 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 13)));
+auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 14));
+auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 15));
+auto x_main_module_17 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 16)));
+auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 17));
+auto x_main_module_19 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 18)));
+auto x_main_module_20 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 19));
+auto x_main_module_21 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 20));
+auto x_main_module_22 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 21)));
+auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 22));
+auto x_main_module_24 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 23)));
+auto x_main_module_25 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 24));
+auto x_main_module_26 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 25));
+auto x_main_module_27 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 26)));
+auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 27));
+auto x_main_module_29 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 28)));
+auto x_main_module_30 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 29));
+auto x_main_module_31 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 30));
+auto x_main_module_32 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 31)));
+auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 32));
+auto x_main_module_34 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 33)));
+auto x_main_module_35 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 34));
+auto x_main_module_36 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 35));
+auto x_main_module_37 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 36)));
+auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 1024, 1, 1}}, 37));
+auto x_main_module_39 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 38)));
+auto x_main_module_40 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 39));
+auto x_main_module_41 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 40));
+auto x_main_module_42 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 41)));
+auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 42));
+auto x_main_module_44 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 43)));
+auto x_main_module_45 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 44));
+auto x_main_module_46 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 45));
+auto x_main_module_47 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 46)));
+auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 47));
+auto x_main_module_49 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 48)));
+auto x_main_module_50 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 49));
+auto x_main_module_51 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 50));
+auto x_main_module_52 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 51)));
+auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 1024, 1, 1}}, 52));
+auto x_main_module_54 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 53)));
+auto x_main_module_55 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 54));
+auto x_main_module_56 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 55));
+auto x_main_module_57 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 56));
+auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 57));
+auto x_main_module_59 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 58)));
+auto x_main_module_60 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 59));
+auto x_main_module_61 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 60));
+auto x_main_module_62 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 61)));
+auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 62));
+auto x_main_module_64 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 63)));
+auto x_main_module_65 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 64));
+auto x_main_module_66 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 65));
+auto x_main_module_67 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 66)));
+auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 67));
+auto x_main_module_69 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 68)));
+auto x_main_module_70 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 69));
+auto x_main_module_71 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 70));
+auto x_main_module_72 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 71));
+auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 72));
+auto x_main_module_74 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 73)));
+auto x_main_module_75 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 74));
+auto x_main_module_76 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 75));
+auto x_main_module_77 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 76)));
+auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 77));
+auto x_main_module_79 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 78)));
+auto x_main_module_80 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 79));
+auto x_main_module_81 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 80));
+auto x_main_module_82 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 81)));
+auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 82));
+auto x_main_module_84 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 83)));
+auto x_main_module_85 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 84));
+auto x_main_module_86 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 85));
+auto x_main_module_87 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 86));
+auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 87));
+auto x_main_module_89 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 88)));
+auto x_main_module_90 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 89));
+auto x_main_module_91 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 90));
+auto x_main_module_92 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 91)));
+auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 92));
+auto x_main_module_94 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 93)));
+auto x_main_module_95 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 94));
+auto x_main_module_96 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 95));
+auto x_main_module_97 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 96)));
+auto x_main_module_98 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 97));
+auto x_main_module_99 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 98)));
+auto x_main_module_100 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 99));
+auto x_main_module_101 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 100));
+auto x_main_module_102 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 101));
+auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 102));
+auto x_main_module_104 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 103)));
+auto x_main_module_105 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 104));
+auto x_main_module_106 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 105));
+auto x_main_module_107 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 106)));
+auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 107));
+auto x_main_module_109 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 108)));
+auto x_main_module_110 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 109));
+auto x_main_module_111 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 110));
+auto x_main_module_112 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 111)));
+auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 112));
+auto x_main_module_114 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 113)));
+auto x_main_module_115 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 114));
+auto x_main_module_116 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 115));
+auto x_main_module_117 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 116));
+auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 117));
+auto x_main_module_119 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 118)));
+auto x_main_module_120 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 119));
+auto x_main_module_121 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 120));
+auto x_main_module_122 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 121)));
+auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 122));
+auto x_main_module_124 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 123)));
+auto x_main_module_125 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 124));
+auto x_main_module_126 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 125));
+auto x_main_module_127 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 126)));
+auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 127));
+auto x_main_module_129 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 128)));
+auto x_main_module_130 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 129));
+auto x_main_module_131 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 130));
+auto x_main_module_132 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 131));
+auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 512, 1, 1}}, 132));
+auto x_main_module_134 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 133)));
+auto x_main_module_135 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 134));
+auto x_main_module_136 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 135));
+auto x_main_module_137 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 136));
+auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 137));
+auto x_main_module_139 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 138)));
+auto x_main_module_140 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 139));
+auto x_main_module_141 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 140));
+auto x_main_module_142 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 141)));
+auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 142));
+auto x_main_module_144 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 143)));
+auto x_main_module_145 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 144));
+auto x_main_module_146 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 145));
+auto x_main_module_147 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 146)));
+auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 512, 1, 1}}, 147));
+auto x_main_module_149 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 148)));
+auto x_main_module_150 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 149));
+auto x_main_module_151 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 150));
+auto x_main_module_152 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 151));
+auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 152));
+auto x_main_module_154 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 153)));
+auto x_main_module_155 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 154));
+auto x_main_module_156 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 155));
+auto x_main_module_157 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 156)));
+auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 157));
+auto x_main_module_159 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 158)));
+auto x_main_module_160 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 159));
+auto x_main_module_161 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 160));
+auto x_main_module_162 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 161)));
+auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 162));
+auto x_main_module_164 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 163)));
+auto x_main_module_165 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 164));
+auto x_main_module_166 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 165));
+auto x_main_module_167 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 166));
+auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 167));
+auto x_main_module_169 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 168)));
+auto x_main_module_170 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 169));
+auto x_main_module_171 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 170));
+auto x_main_module_172 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 171)));
+auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 172));
+auto x_main_module_174 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 173)));
+auto x_main_module_175 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 174));
+auto x_main_module_176 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 175));
+auto x_main_module_177 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 176)));
+auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 177));
+auto x_main_module_179 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 178)));
+auto x_main_module_180 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 179));
+auto x_main_module_181 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 180));
+auto x_main_module_182 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 181));
+auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 182));
+auto x_main_module_184 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 183)));
+auto x_main_module_185 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 184));
+auto x_main_module_186 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 185));
+auto x_main_module_187 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 186)));
+auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 187));
+auto x_main_module_189 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 188)));
+auto x_main_module_190 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 189));
+auto x_main_module_191 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 190));
+auto x_main_module_192 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 191)));
+auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 192));
+auto x_main_module_194 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 193)));
+auto x_main_module_195 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 194));
+auto x_main_module_196 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 195));
+auto x_main_module_197 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 196));
+auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 256, 1, 1}}, 197));
+auto x_main_module_199 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 198)));
+auto x_main_module_200 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 199));
+auto x_main_module_201 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 200));
+auto x_main_module_202 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 201));
+auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 202));
+auto x_main_module_204 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 203)));
+auto x_main_module_205 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 204));
+auto x_main_module_206 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 205));
+auto x_main_module_207 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 206)));
+auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 207));
+auto x_main_module_209 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 208)));
+auto x_main_module_210 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 209));
+auto x_main_module_211 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 210));
+auto x_main_module_212 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 211)));
+auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 256, 1, 1}}, 212));
+auto x_main_module_214 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 213)));
+auto x_main_module_215 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 214));
+auto x_main_module_216 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 215));
+auto x_main_module_217 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 216));
+auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 217));
+auto x_main_module_219 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 218)));
+auto x_main_module_220 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 219));
+auto x_main_module_221 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 220));
+auto x_main_module_222 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 221)));
+auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 222));
+auto x_main_module_224 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 223)));
+auto x_main_module_225 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 224));
+auto x_main_module_226 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 225));
+auto x_main_module_227 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 226)));
+auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 227));
+auto x_main_module_229 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 228)));
+auto x_main_module_230 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 229));
+auto x_main_module_231 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 230));
+auto x_main_module_232 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 231));
+auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 232));
+auto x_main_module_234 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 233)));
+auto x_main_module_235 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 234));
+auto x_main_module_236 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 235));
+auto x_main_module_237 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 236)));
+auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 237));
+auto x_main_module_239 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 238)));
+auto x_main_module_240 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 239));
+auto x_main_module_241 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 240));
+auto x_main_module_242 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 241)));
+auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 242));
+auto x_main_module_244 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 243)));
+auto x_main_module_245 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 244));
+auto x_main_module_246 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 245));
+auto x_main_module_247 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 246));
+auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 247));
+auto x_main_module_249 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 248)));
+auto x_main_module_250 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 249));
+auto x_main_module_251 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 250));
+auto x_main_module_252 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 251));
+auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 252));
+auto x_main_module_254 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 253)));
+auto x_main_module_255 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 254));
+auto x_main_module_256 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 255));
+auto x_main_module_257 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 256)));
+auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 257));
+auto x_main_module_259 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 258)));
+auto x_main_module_260 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 259));
+auto x_main_module_261 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 260));
+auto x_main_module_262 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 261)));
+auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 1, 1}}, 262));
+auto x_main_module_264 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 263)));
+auto x_main_module_265 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 264));
+auto x_main_module_266 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 265));
+auto x_main_module_267 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 266)));
+auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 3, 7, 7}}, 267));
+auto x_main_module_269 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,3,3,3],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_0, x_main_module_268);
+auto x_main_module_270 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_269, x_main_module_267, x_main_module_266, x_main_module_265, x_main_module_264);
+auto x_main_module_271 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_270);
+auto x_main_module_272 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[1,1,1,1],\"stride\":[2,2]}")), x_main_module_271);
+auto x_main_module_273 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_272, x_main_module_263);
+auto x_main_module_274 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_273, x_main_module_262, x_main_module_261, x_main_module_260, x_main_module_259);
+auto x_main_module_275 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_274);
+auto x_main_module_276 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_275, x_main_module_258);
+auto x_main_module_277 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_276, x_main_module_257, x_main_module_256, x_main_module_255, x_main_module_254);
+auto x_main_module_278 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_277);
+auto x_main_module_279 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_278, x_main_module_253);
+auto x_main_module_280 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_279, x_main_module_252, x_main_module_251, x_main_module_250, x_main_module_249);
+auto x_main_module_281 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_272, x_main_module_248);
+auto x_main_module_282 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_281, x_main_module_247, x_main_module_246, x_main_module_245, x_main_module_244);
+auto x_main_module_283 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_280, x_main_module_282);
+auto x_main_module_284 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_283);
+auto x_main_module_285 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_284, x_main_module_243);
+auto x_main_module_286 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_285, x_main_module_242, x_main_module_241, x_main_module_240, x_main_module_239);
+auto x_main_module_287 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_286);
+auto x_main_module_288 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_287, x_main_module_238);
+auto x_main_module_289 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_288, x_main_module_237, x_main_module_236, x_main_module_235, x_main_module_234);
+auto x_main_module_290 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_289);
+auto x_main_module_291 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_290, x_main_module_233);
+auto x_main_module_292 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_291, x_main_module_232, x_main_module_231, x_main_module_230, x_main_module_229);
+auto x_main_module_293 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_292, x_main_module_284);
+auto x_main_module_294 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_293);
+auto x_main_module_295 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_294, x_main_module_228);
+auto x_main_module_296 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_295, x_main_module_227, x_main_module_226, x_main_module_225, x_main_module_224);
+auto x_main_module_297 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_296);
+auto x_main_module_298 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_297, x_main_module_223);
+auto x_main_module_299 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_298, x_main_module_222, x_main_module_221, x_main_module_220, x_main_module_219);
+auto x_main_module_300 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_299);
+auto x_main_module_301 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_300, x_main_module_218);
+auto x_main_module_302 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_301, x_main_module_217, x_main_module_216, x_main_module_215, x_main_module_214);
+auto x_main_module_303 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_302, x_main_module_294);
+auto x_main_module_304 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_303);
+auto x_main_module_305 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_304, x_main_module_213);
+auto x_main_module_306 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_305, x_main_module_212, x_main_module_211, x_main_module_210, x_main_module_209);
+auto x_main_module_307 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_306);
+auto x_main_module_308 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_307, x_main_module_208);
+auto x_main_module_309 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_308, x_main_module_207, x_main_module_206, x_main_module_205, x_main_module_204);
+auto x_main_module_310 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_309);
+auto x_main_module_311 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_310, x_main_module_203);
+auto x_main_module_312 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_311, x_main_module_202, x_main_module_201, x_main_module_200, x_main_module_199);
+auto x_main_module_313 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_304, x_main_module_198);
+auto x_main_module_314 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_313, x_main_module_197, x_main_module_196, x_main_module_195, x_main_module_194);
+auto x_main_module_315 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_312, x_main_module_314);
+auto x_main_module_316 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_315);
+auto x_main_module_317 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_316, x_main_module_193);
+auto x_main_module_318 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_317, x_main_module_192, x_main_module_191, x_main_module_190, x_main_module_189);
+auto x_main_module_319 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_318);
+auto x_main_module_320 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_319, x_main_module_188);
+auto x_main_module_321 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_320, x_main_module_187, x_main_module_186, x_main_module_185, x_main_module_184);
+auto x_main_module_322 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_321);
+auto x_main_module_323 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_322, x_main_module_183);
+auto x_main_module_324 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_323, x_main_module_182, x_main_module_181, x_main_module_180, x_main_module_179);
+auto x_main_module_325 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_324, x_main_module_316);
+auto x_main_module_326 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_325);
+auto x_main_module_327 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_326, x_main_module_178);
+auto x_main_module_328 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_327, x_main_module_177, x_main_module_176, x_main_module_175, x_main_module_174);
+auto x_main_module_329 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_328);
+auto x_main_module_330 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_329, x_main_module_173);
+auto x_main_module_331 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_330, x_main_module_172, x_main_module_171, x_main_module_170, x_main_module_169);
+auto x_main_module_332 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_331);
+auto x_main_module_333 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_332, x_main_module_168);
+auto x_main_module_334 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_333, x_main_module_167, x_main_module_166, x_main_module_165, x_main_module_164);
+auto x_main_module_335 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_334, x_main_module_326);
+auto x_main_module_336 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_335);
+auto x_main_module_337 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_336, x_main_module_163);
+auto x_main_module_338 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_337, x_main_module_162, x_main_module_161, x_main_module_160, x_main_module_159);
+auto x_main_module_339 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_338);
+auto x_main_module_340 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_339, x_main_module_158);
+auto x_main_module_341 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_340, x_main_module_157, x_main_module_156, x_main_module_155, x_main_module_154);
+auto x_main_module_342 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_341);
+auto x_main_module_343 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_342, x_main_module_153);
+auto x_main_module_344 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_343, x_main_module_152, x_main_module_151, x_main_module_150, x_main_module_149);
+auto x_main_module_345 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_344, x_main_module_336);
+auto x_main_module_346 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_345);
+auto x_main_module_347 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_346, x_main_module_148);
+auto x_main_module_348 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_347, x_main_module_147, x_main_module_146, x_main_module_145, x_main_module_144);
+auto x_main_module_349 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_348);
+auto x_main_module_350 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_349, x_main_module_143);
+auto x_main_module_351 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_350, x_main_module_142, x_main_module_141, x_main_module_140, x_main_module_139);
+auto x_main_module_352 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_351);
+auto x_main_module_353 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_352, x_main_module_138);
+auto x_main_module_354 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_353, x_main_module_137, x_main_module_136, x_main_module_135, x_main_module_134);
+auto x_main_module_355 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_346, x_main_module_133);
+auto x_main_module_356 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_355, x_main_module_132, x_main_module_131, x_main_module_130, x_main_module_129);
+auto x_main_module_357 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_354, x_main_module_356);
+auto x_main_module_358 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_357);
+auto x_main_module_359 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_358, x_main_module_128);
+auto x_main_module_360 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_359, x_main_module_127, x_main_module_126, x_main_module_125, x_main_module_124);
+auto x_main_module_361 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_360);
+auto x_main_module_362 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_361, x_main_module_123);
+auto x_main_module_363 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_362, x_main_module_122, x_main_module_121, x_main_module_120, x_main_module_119);
+auto x_main_module_364 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_363);
+auto x_main_module_365 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_364, x_main_module_118);
+auto x_main_module_366 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_365, x_main_module_117, x_main_module_116, x_main_module_115, x_main_module_114);
+auto x_main_module_367 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_366, x_main_module_358);
+auto x_main_module_368 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_367);
+auto x_main_module_369 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_368, x_main_module_113);
+auto x_main_module_370 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_369, x_main_module_112, x_main_module_111, x_main_module_110, x_main_module_109);
+auto x_main_module_371 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_370);
+auto x_main_module_372 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_371, x_main_module_108);
+auto x_main_module_373 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_372, x_main_module_107, x_main_module_106, x_main_module_105, x_main_module_104);
+auto x_main_module_374 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_373);
+auto x_main_module_375 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_374, x_main_module_103);
+auto x_main_module_376 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_375, x_main_module_102, x_main_module_101, x_main_module_100, x_main_module_99);
+auto x_main_module_377 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_376, x_main_module_368);
+auto x_main_module_378 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_377);
+auto x_main_module_379 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_378, x_main_module_98);
+auto x_main_module_380 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_379, x_main_module_97, x_main_module_96, x_main_module_95, x_main_module_94);
+auto x_main_module_381 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_380);
+auto x_main_module_382 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_381, x_main_module_93);
+auto x_main_module_383 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_382, x_main_module_92, x_main_module_91, x_main_module_90, x_main_module_89);
+auto x_main_module_384 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_383);
+auto x_main_module_385 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_384, x_main_module_88);
+auto x_main_module_386 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_385, x_main_module_87, x_main_module_86, x_main_module_85, x_main_module_84);
+auto x_main_module_387 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_386, x_main_module_378);
+auto x_main_module_388 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_387);
+auto x_main_module_389 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_388, x_main_module_83);
+auto x_main_module_390 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_389, x_main_module_82, x_main_module_81, x_main_module_80, x_main_module_79);
+auto x_main_module_391 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_390);
+auto x_main_module_392 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_391, x_main_module_78);
+auto x_main_module_393 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_392, x_main_module_77, x_main_module_76, x_main_module_75, x_main_module_74);
+auto x_main_module_394 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_393);
+auto x_main_module_395 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_394, x_main_module_73);
+auto x_main_module_396 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_395, x_main_module_72, x_main_module_71, x_main_module_70, x_main_module_69);
+auto x_main_module_397 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_396, x_main_module_388);
+auto x_main_module_398 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_397);
+auto x_main_module_399 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_398, x_main_module_68);
+auto x_main_module_400 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_399, x_main_module_67, x_main_module_66, x_main_module_65, x_main_module_64);
+auto x_main_module_401 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_400);
+auto x_main_module_402 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_401, x_main_module_63);
+auto x_main_module_403 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_402, x_main_module_62, x_main_module_61, x_main_module_60, x_main_module_59);
+auto x_main_module_404 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_403);
+auto x_main_module_405 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_404, x_main_module_58);
+auto x_main_module_406 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_405, x_main_module_57, x_main_module_56, x_main_module_55, x_main_module_54);
+auto x_main_module_407 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_406, x_main_module_398);
+auto x_main_module_408 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_407);
+auto x_main_module_409 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_408, x_main_module_53);
+auto x_main_module_410 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_409, x_main_module_52, x_main_module_51, x_main_module_50, x_main_module_49);
+auto x_main_module_411 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_410);
+auto x_main_module_412 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_411, x_main_module_48);
+auto x_main_module_413 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_412, x_main_module_47, x_main_module_46, x_main_module_45, x_main_module_44);
+auto x_main_module_414 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_413);
+auto x_main_module_415 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_414, x_main_module_43);
+auto x_main_module_416 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_415, x_main_module_42, x_main_module_41, x_main_module_40, x_main_module_39);
+auto x_main_module_417 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), x_main_module_408, x_main_module_38);
+auto x_main_module_418 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_417, x_main_module_37, x_main_module_36, x_main_module_35, x_main_module_34);
+auto x_main_module_419 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_416, x_main_module_418);
+auto x_main_module_420 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_419);
+auto x_main_module_421 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_420, x_main_module_33);
+auto x_main_module_422 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_421, x_main_module_32, x_main_module_31, x_main_module_30, x_main_module_29);
+auto x_main_module_423 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_422);
+auto x_main_module_424 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_423, x_main_module_28);
+auto x_main_module_425 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_424, x_main_module_27, x_main_module_26, x_main_module_25, x_main_module_24);
+auto x_main_module_426 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_425);
+auto x_main_module_427 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_426, x_main_module_23);
+auto x_main_module_428 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_427, x_main_module_22, x_main_module_21, x_main_module_20, x_main_module_19);
+auto x_main_module_429 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_428, x_main_module_420);
+auto x_main_module_430 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_429);
+auto x_main_module_431 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_430, x_main_module_18);
+auto x_main_module_432 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_431, x_main_module_17, x_main_module_16, x_main_module_15, x_main_module_14);
+auto x_main_module_433 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_432);
+auto x_main_module_434 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_433, x_main_module_13);
+auto x_main_module_435 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_434, x_main_module_12, x_main_module_11, x_main_module_10, x_main_module_9);
+auto x_main_module_436 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_435);
+auto x_main_module_437 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), x_main_module_436, x_main_module_8);
+auto x_main_module_438 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), x_main_module_437, x_main_module_7, x_main_module_6, x_main_module_5, x_main_module_4);
+auto x_main_module_439 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_438, x_main_module_430);
+auto x_main_module_440 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_439);
+auto x_main_module_441 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[7,7],\"lp_order\":2,\"mode\":0,\"padding\":[0,0,0,0],\"stride\":[1,1]}")), x_main_module_440);
+auto x_main_module_442 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), x_main_module_441);
+auto x_main_module_443 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), x_main_module_3);
+auto x_main_module_444 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_442, x_main_module_443);
+auto x_main_module_445 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_2);
+auto x_main_module_446 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), x_main_module_0);
+auto x_main_module_447 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_445, x_main_module_446);
+auto x_main_module_448 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_444, x_main_module_447);
+mmain->add_return({x_main_module_448});
+
 
     return p;
 }

--- a/src/driver/resnet50.cpp
+++ b/src/driver/resnet50.cpp
@@ -25,7 +25,6 @@
 #include <migraphx/make_op.hpp>
 #include <migraphx/program.hpp>
 #include <migraphx/generate.hpp>
-#include <migraphx/json.hpp>
 #include "models.hpp"
 namespace migraphx {
 namespace driver {
@@ -33,1558 +32,458 @@ inline namespace MIGRAPHX_INLINE_NS {
 migraphx::program resnet50(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-    migraphx::module_ref mmain = p.get_main_module();
-    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-    auto x_0                   = mmain->add_parameter(
-        "0", migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
-    auto x_main_module_2 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
-    auto x_main_module_3 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
-    auto x_main_module_4 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 3)));
-    auto x_main_module_5 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 4));
-    auto x_main_module_6 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 5));
-    auto x_main_module_7  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 6)));
-    auto x_main_module_8  = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 7));
-    auto x_main_module_9  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 8)));
-    auto x_main_module_10 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 9));
-    auto x_main_module_11 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 10));
-    auto x_main_module_12 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 11)));
-    auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 12));
-    auto x_main_module_14 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 13)));
-    auto x_main_module_15 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 14));
-    auto x_main_module_16 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 15));
-    auto x_main_module_17 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 16)));
-    auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 17));
-    auto x_main_module_19 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 18)));
-    auto x_main_module_20 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 19));
-    auto x_main_module_21 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 20));
-    auto x_main_module_22 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 21)));
-    auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 22));
-    auto x_main_module_24 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 23)));
-    auto x_main_module_25 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 24));
-    auto x_main_module_26 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 25));
-    auto x_main_module_27 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 26)));
-    auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 27));
-    auto x_main_module_29 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 28)));
-    auto x_main_module_30 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 29));
-    auto x_main_module_31 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 30));
-    auto x_main_module_32 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 31)));
-    auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 32));
-    auto x_main_module_34 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 33)));
-    auto x_main_module_35 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 34));
-    auto x_main_module_36 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 35));
-    auto x_main_module_37 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 36)));
-    auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {2048, 1024, 1, 1}}, 37));
-    auto x_main_module_39 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 38)));
-    auto x_main_module_40 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 39));
-    auto x_main_module_41 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 40));
-    auto x_main_module_42 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 41)));
-    auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 42));
-    auto x_main_module_44 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 43)));
-    auto x_main_module_45 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 44));
-    auto x_main_module_46 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 45));
-    auto x_main_module_47 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 46)));
-    auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 47));
-    auto x_main_module_49 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 48)));
-    auto x_main_module_50 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 49));
-    auto x_main_module_51 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 50));
-    auto x_main_module_52 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 51)));
-    auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 1024, 1, 1}}, 52));
-    auto x_main_module_54 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 53)));
-    auto x_main_module_55 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 54));
-    auto x_main_module_56 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 55));
-    auto x_main_module_57 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 56));
-    auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 57));
-    auto x_main_module_59 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 58)));
-    auto x_main_module_60 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 59));
-    auto x_main_module_61 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 60));
-    auto x_main_module_62 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 61)));
-    auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 62));
-    auto x_main_module_64 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 63)));
-    auto x_main_module_65 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 64));
-    auto x_main_module_66 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 65));
-    auto x_main_module_67 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 66)));
-    auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 67));
-    auto x_main_module_69 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 68)));
-    auto x_main_module_70 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 69));
-    auto x_main_module_71 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 70));
-    auto x_main_module_72 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 71));
-    auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 72));
-    auto x_main_module_74 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 73)));
-    auto x_main_module_75 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 74));
-    auto x_main_module_76 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 75));
-    auto x_main_module_77 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 76)));
-    auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 77));
-    auto x_main_module_79 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 78)));
-    auto x_main_module_80 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 79));
-    auto x_main_module_81 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 80));
-    auto x_main_module_82 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 81)));
-    auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 82));
-    auto x_main_module_84 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 83)));
-    auto x_main_module_85 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 84));
-    auto x_main_module_86 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 85));
-    auto x_main_module_87 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 86));
-    auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 87));
-    auto x_main_module_89 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 88)));
-    auto x_main_module_90 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 89));
-    auto x_main_module_91 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 90));
-    auto x_main_module_92 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 91)));
-    auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 92));
-    auto x_main_module_94 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 93)));
-    auto x_main_module_95 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 94));
-    auto x_main_module_96 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 95));
-    auto x_main_module_97  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 96)));
-    auto x_main_module_98  = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 97));
-    auto x_main_module_99  = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 98)));
-    auto x_main_module_100 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 99));
-    auto x_main_module_101 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 100));
-    auto x_main_module_102 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 101));
-    auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 102));
-    auto x_main_module_104 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 103)));
-    auto x_main_module_105 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 104));
-    auto x_main_module_106 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 105));
-    auto x_main_module_107 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 106)));
-    auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 107));
-    auto x_main_module_109 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 108)));
-    auto x_main_module_110 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 109));
-    auto x_main_module_111 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 110));
-    auto x_main_module_112 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 111)));
-    auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 112));
-    auto x_main_module_114 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 113)));
-    auto x_main_module_115 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 114));
-    auto x_main_module_116 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 115));
-    auto x_main_module_117 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 116));
-    auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 117));
-    auto x_main_module_119 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 118)));
-    auto x_main_module_120 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 119));
-    auto x_main_module_121 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 120));
-    auto x_main_module_122 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 121)));
-    auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 122));
-    auto x_main_module_124 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 123)));
-    auto x_main_module_125 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 124));
-    auto x_main_module_126 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 125));
-    auto x_main_module_127 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 126)));
-    auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 127));
-    auto x_main_module_129 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 128)));
-    auto x_main_module_130 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 129));
-    auto x_main_module_131 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 130));
-    auto x_main_module_132 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 131));
-    auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 512, 1, 1}}, 132));
-    auto x_main_module_134 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 133)));
-    auto x_main_module_135 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 134));
-    auto x_main_module_136 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 135));
-    auto x_main_module_137 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 136));
-    auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 137));
-    auto x_main_module_139 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 138)));
-    auto x_main_module_140 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 139));
-    auto x_main_module_141 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 140));
-    auto x_main_module_142 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 141)));
-    auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 142));
-    auto x_main_module_144 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 143)));
-    auto x_main_module_145 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 144));
-    auto x_main_module_146 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 145));
-    auto x_main_module_147 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 146)));
-    auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 512, 1, 1}}, 147));
-    auto x_main_module_149 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 148)));
-    auto x_main_module_150 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 149));
-    auto x_main_module_151 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 150));
-    auto x_main_module_152 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 151));
-    auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 152));
-    auto x_main_module_154 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 153)));
-    auto x_main_module_155 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 154));
-    auto x_main_module_156 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 155));
-    auto x_main_module_157 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 156)));
-    auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 157));
-    auto x_main_module_159 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 158)));
-    auto x_main_module_160 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 159));
-    auto x_main_module_161 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 160));
-    auto x_main_module_162 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 161)));
-    auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 162));
-    auto x_main_module_164 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 163)));
-    auto x_main_module_165 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 164));
-    auto x_main_module_166 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 165));
-    auto x_main_module_167 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 166));
-    auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 167));
-    auto x_main_module_169 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 168)));
-    auto x_main_module_170 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 169));
-    auto x_main_module_171 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 170));
-    auto x_main_module_172 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 171)));
-    auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 172));
-    auto x_main_module_174 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 173)));
-    auto x_main_module_175 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 174));
-    auto x_main_module_176 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 175));
-    auto x_main_module_177 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 176)));
-    auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 177));
-    auto x_main_module_179 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 178)));
-    auto x_main_module_180 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 179));
-    auto x_main_module_181 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 180));
-    auto x_main_module_182 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 181));
-    auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 182));
-    auto x_main_module_184 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 183)));
-    auto x_main_module_185 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 184));
-    auto x_main_module_186 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 185));
-    auto x_main_module_187 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 186)));
-    auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 187));
-    auto x_main_module_189 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 188)));
-    auto x_main_module_190 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 189));
-    auto x_main_module_191 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 190));
-    auto x_main_module_192 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 191)));
-    auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 192));
-    auto x_main_module_194 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 193)));
-    auto x_main_module_195 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 194));
-    auto x_main_module_196 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 195));
-    auto x_main_module_197 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 196));
-    auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 256, 1, 1}}, 197));
-    auto x_main_module_199 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 198)));
-    auto x_main_module_200 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 199));
-    auto x_main_module_201 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 200));
-    auto x_main_module_202 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 201));
-    auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 202));
-    auto x_main_module_204 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 203)));
-    auto x_main_module_205 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 204));
-    auto x_main_module_206 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 205));
-    auto x_main_module_207 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 206)));
-    auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 207));
-    auto x_main_module_209 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 208)));
-    auto x_main_module_210 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 209));
-    auto x_main_module_211 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 210));
-    auto x_main_module_212 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 211)));
-    auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 256, 1, 1}}, 212));
-    auto x_main_module_214 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 213)));
-    auto x_main_module_215 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 214));
-    auto x_main_module_216 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 215));
-    auto x_main_module_217 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 216));
-    auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 217));
-    auto x_main_module_219 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 218)));
-    auto x_main_module_220 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 219));
-    auto x_main_module_221 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 220));
-    auto x_main_module_222 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 221)));
-    auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 222));
-    auto x_main_module_224 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 223)));
-    auto x_main_module_225 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 224));
-    auto x_main_module_226 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 225));
-    auto x_main_module_227 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 226)));
-    auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 227));
-    auto x_main_module_229 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 228)));
-    auto x_main_module_230 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 229));
-    auto x_main_module_231 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 230));
-    auto x_main_module_232 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 231));
-    auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 232));
-    auto x_main_module_234 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 233)));
-    auto x_main_module_235 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 234));
-    auto x_main_module_236 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 235));
-    auto x_main_module_237 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 236)));
-    auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 237));
-    auto x_main_module_239 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 238)));
-    auto x_main_module_240 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 239));
-    auto x_main_module_241 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 240));
-    auto x_main_module_242 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 241)));
-    auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 242));
-    auto x_main_module_244 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 243)));
-    auto x_main_module_245 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 244));
-    auto x_main_module_246 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 245));
-    auto x_main_module_247 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 246));
-    auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 247));
-    auto x_main_module_249 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 248)));
-    auto x_main_module_250 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 249));
-    auto x_main_module_251 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 250));
-    auto x_main_module_252 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 251));
-    auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 252));
-    auto x_main_module_254 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 253)));
-    auto x_main_module_255 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 254));
-    auto x_main_module_256 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 255));
-    auto x_main_module_257 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 256)));
-    auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 257));
-    auto x_main_module_259 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 258)));
-    auto x_main_module_260 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 259));
-    auto x_main_module_261 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 260));
-    auto x_main_module_262 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 261)));
-    auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 64, 1, 1}}, 262));
-    auto x_main_module_264 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 263)));
-    auto x_main_module_265 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 264));
-    auto x_main_module_266 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 265));
-    auto x_main_module_267 = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 266)));
-    auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 3, 7, 7}}, 267));
-    auto x_main_module_269 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[3,3,3,3],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_0,
-        x_main_module_268); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_270 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_269,
-        x_main_module_267,
-        x_main_module_266,
-        x_main_module_265,
-        x_main_module_264); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_271 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_270);
-    auto x_main_module_272 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":"
-                                       "1,\"padding\":[1,1,1,1],\"stride\":[2,2]}")),
-        x_main_module_271); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_273 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_272,
-        x_main_module_263); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_274 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_273,
-        x_main_module_262,
-        x_main_module_261,
-        x_main_module_260,
-        x_main_module_259); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_275 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_274);
-    auto x_main_module_276 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_275,
-        x_main_module_258); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_277 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_276,
-        x_main_module_257,
-        x_main_module_256,
-        x_main_module_255,
-        x_main_module_254); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_278 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_277);
-    auto x_main_module_279 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_278,
-        x_main_module_253); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_280 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_279,
-        x_main_module_252,
-        x_main_module_251,
-        x_main_module_250,
-        x_main_module_249); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_281 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_272,
-        x_main_module_248); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_282 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_281,
-        x_main_module_247,
-        x_main_module_246,
-        x_main_module_245,
-        x_main_module_244); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_283 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_280, x_main_module_282);
-    auto x_main_module_284 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_283);
-    auto x_main_module_285 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_284,
-        x_main_module_243); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_286 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_285,
-        x_main_module_242,
-        x_main_module_241,
-        x_main_module_240,
-        x_main_module_239); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_287 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_286);
-    auto x_main_module_288 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_287,
-        x_main_module_238); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_289 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_288,
-        x_main_module_237,
-        x_main_module_236,
-        x_main_module_235,
-        x_main_module_234); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_290 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_289);
-    auto x_main_module_291 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_290,
-        x_main_module_233); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_292 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_291,
-        x_main_module_232,
-        x_main_module_231,
-        x_main_module_230,
-        x_main_module_229); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_293 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_292, x_main_module_284);
-    auto x_main_module_294 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_293);
-    auto x_main_module_295 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_294,
-        x_main_module_228); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_296 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_295,
-        x_main_module_227,
-        x_main_module_226,
-        x_main_module_225,
-        x_main_module_224); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_297 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_296);
-    auto x_main_module_298 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_297,
-        x_main_module_223); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_299 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_298,
-        x_main_module_222,
-        x_main_module_221,
-        x_main_module_220,
-        x_main_module_219); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_300 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_299);
-    auto x_main_module_301 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_300,
-        x_main_module_218); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_302 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_301,
-        x_main_module_217,
-        x_main_module_216,
-        x_main_module_215,
-        x_main_module_214); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_303 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_302, x_main_module_294);
-    auto x_main_module_304 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_303);
-    auto x_main_module_305 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_304,
-        x_main_module_213); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_306 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_305,
-        x_main_module_212,
-        x_main_module_211,
-        x_main_module_210,
-        x_main_module_209); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_307 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_306);
-    auto x_main_module_308 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_307,
-        x_main_module_208); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_309 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_308,
-        x_main_module_207,
-        x_main_module_206,
-        x_main_module_205,
-        x_main_module_204); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_310 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_309);
-    auto x_main_module_311 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_310,
-        x_main_module_203); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_312 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_311,
-        x_main_module_202,
-        x_main_module_201,
-        x_main_module_200,
-        x_main_module_199); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_313 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_304,
-        x_main_module_198); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_314 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_313,
-        x_main_module_197,
-        x_main_module_196,
-        x_main_module_195,
-        x_main_module_194); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_315 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_312, x_main_module_314);
-    auto x_main_module_316 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_315);
-    auto x_main_module_317 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_316,
-        x_main_module_193); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_318 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_317,
-        x_main_module_192,
-        x_main_module_191,
-        x_main_module_190,
-        x_main_module_189); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_319 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_318);
-    auto x_main_module_320 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_319,
-        x_main_module_188); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_321 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_320,
-        x_main_module_187,
-        x_main_module_186,
-        x_main_module_185,
-        x_main_module_184); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_322 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_321);
-    auto x_main_module_323 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_322,
-        x_main_module_183); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_324 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_323,
-        x_main_module_182,
-        x_main_module_181,
-        x_main_module_180,
-        x_main_module_179); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_325 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_324, x_main_module_316);
-    auto x_main_module_326 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_325);
-    auto x_main_module_327 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_326,
-        x_main_module_178); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_328 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_327,
-        x_main_module_177,
-        x_main_module_176,
-        x_main_module_175,
-        x_main_module_174); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_329 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_328);
-    auto x_main_module_330 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_329,
-        x_main_module_173); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_331 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_330,
-        x_main_module_172,
-        x_main_module_171,
-        x_main_module_170,
-        x_main_module_169); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_332 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_331);
-    auto x_main_module_333 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_332,
-        x_main_module_168); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_334 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_333,
-        x_main_module_167,
-        x_main_module_166,
-        x_main_module_165,
-        x_main_module_164); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_335 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_334, x_main_module_326);
-    auto x_main_module_336 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_335);
-    auto x_main_module_337 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_336,
-        x_main_module_163); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_338 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_337,
-        x_main_module_162,
-        x_main_module_161,
-        x_main_module_160,
-        x_main_module_159); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_339 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_338);
-    auto x_main_module_340 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_339,
-        x_main_module_158); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_341 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_340,
-        x_main_module_157,
-        x_main_module_156,
-        x_main_module_155,
-        x_main_module_154); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_342 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_341);
-    auto x_main_module_343 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_342,
-        x_main_module_153); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_344 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_343,
-        x_main_module_152,
-        x_main_module_151,
-        x_main_module_150,
-        x_main_module_149); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_345 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_344, x_main_module_336);
-    auto x_main_module_346 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_345);
-    auto x_main_module_347 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_346,
-        x_main_module_148); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_348 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_347,
-        x_main_module_147,
-        x_main_module_146,
-        x_main_module_145,
-        x_main_module_144); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_349 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_348);
-    auto x_main_module_350 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_349,
-        x_main_module_143); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_351 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_350,
-        x_main_module_142,
-        x_main_module_141,
-        x_main_module_140,
-        x_main_module_139); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_352 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_351);
-    auto x_main_module_353 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_352,
-        x_main_module_138); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_354 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_353,
-        x_main_module_137,
-        x_main_module_136,
-        x_main_module_135,
-        x_main_module_134); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_355 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_346,
-        x_main_module_133); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_356 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_355,
-        x_main_module_132,
-        x_main_module_131,
-        x_main_module_130,
-        x_main_module_129); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_357 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_354, x_main_module_356);
-    auto x_main_module_358 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_357);
-    auto x_main_module_359 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_358,
-        x_main_module_128); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_360 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_359,
-        x_main_module_127,
-        x_main_module_126,
-        x_main_module_125,
-        x_main_module_124); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_361 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_360);
-    auto x_main_module_362 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_361,
-        x_main_module_123); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_363 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_362,
-        x_main_module_122,
-        x_main_module_121,
-        x_main_module_120,
-        x_main_module_119); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_364 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_363);
-    auto x_main_module_365 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_364,
-        x_main_module_118); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_366 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_365,
-        x_main_module_117,
-        x_main_module_116,
-        x_main_module_115,
-        x_main_module_114); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_367 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_366, x_main_module_358);
-    auto x_main_module_368 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_367);
-    auto x_main_module_369 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_368,
-        x_main_module_113); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_370 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_369,
-        x_main_module_112,
-        x_main_module_111,
-        x_main_module_110,
-        x_main_module_109); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_371 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_370);
-    auto x_main_module_372 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_371,
-        x_main_module_108); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_373 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_372,
-        x_main_module_107,
-        x_main_module_106,
-        x_main_module_105,
-        x_main_module_104); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_374 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_373);
-    auto x_main_module_375 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_374,
-        x_main_module_103); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_376 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_375,
-        x_main_module_102,
-        x_main_module_101,
-        x_main_module_100,
-        x_main_module_99); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_377 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_376, x_main_module_368);
-    auto x_main_module_378 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_377);
-    auto x_main_module_379 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_378,
-        x_main_module_98); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_380 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_379,
-        x_main_module_97,
-        x_main_module_96,
-        x_main_module_95,
-        x_main_module_94); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_381 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_380);
-    auto x_main_module_382 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_381,
-        x_main_module_93); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_383 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_382,
-        x_main_module_92,
-        x_main_module_91,
-        x_main_module_90,
-        x_main_module_89); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_384 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_383);
-    auto x_main_module_385 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_384,
-        x_main_module_88); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_386 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_385,
-        x_main_module_87,
-        x_main_module_86,
-        x_main_module_85,
-        x_main_module_84); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_387 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_386, x_main_module_378);
-    auto x_main_module_388 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_387);
-    auto x_main_module_389 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_388,
-        x_main_module_83); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_390 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_389,
-        x_main_module_82,
-        x_main_module_81,
-        x_main_module_80,
-        x_main_module_79); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_391 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_390);
-    auto x_main_module_392 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_391,
-        x_main_module_78); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_393 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_392,
-        x_main_module_77,
-        x_main_module_76,
-        x_main_module_75,
-        x_main_module_74); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_394 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_393);
-    auto x_main_module_395 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_394,
-        x_main_module_73); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_396 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_395,
-        x_main_module_72,
-        x_main_module_71,
-        x_main_module_70,
-        x_main_module_69); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_397 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_396, x_main_module_388);
-    auto x_main_module_398 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_397);
-    auto x_main_module_399 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_398,
-        x_main_module_68); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_400 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_399,
-        x_main_module_67,
-        x_main_module_66,
-        x_main_module_65,
-        x_main_module_64); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_401 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_400);
-    auto x_main_module_402 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_401,
-        x_main_module_63); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_403 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_402,
-        x_main_module_62,
-        x_main_module_61,
-        x_main_module_60,
-        x_main_module_59); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_404 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_403);
-    auto x_main_module_405 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_404,
-        x_main_module_58); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_406 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_405,
-        x_main_module_57,
-        x_main_module_56,
-        x_main_module_55,
-        x_main_module_54); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_407 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_406, x_main_module_398);
-    auto x_main_module_408 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_407);
-    auto x_main_module_409 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_408,
-        x_main_module_53); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_410 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_409,
-        x_main_module_52,
-        x_main_module_51,
-        x_main_module_50,
-        x_main_module_49); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_411 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_410);
-    auto x_main_module_412 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_411,
-        x_main_module_48); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_413 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_412,
-        x_main_module_47,
-        x_main_module_46,
-        x_main_module_45,
-        x_main_module_44); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_414 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_413);
-    auto x_main_module_415 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_414,
-        x_main_module_43); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_416 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_415,
-        x_main_module_42,
-        x_main_module_41,
-        x_main_module_40,
-        x_main_module_39); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_417 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_408,
-        x_main_module_38); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_418 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_417,
-        x_main_module_37,
-        x_main_module_36,
-        x_main_module_35,
-        x_main_module_34); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_419 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_416, x_main_module_418);
-    auto x_main_module_420 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_419);
-    auto x_main_module_421 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_420,
-        x_main_module_33); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_422 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_421,
-        x_main_module_32,
-        x_main_module_31,
-        x_main_module_30,
-        x_main_module_29); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_423 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_422);
-    auto x_main_module_424 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_423,
-        x_main_module_28); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_425 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_424,
-        x_main_module_27,
-        x_main_module_26,
-        x_main_module_25,
-        x_main_module_24); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_426 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_425);
-    auto x_main_module_427 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_426,
-        x_main_module_23); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_428 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_427,
-        x_main_module_22,
-        x_main_module_21,
-        x_main_module_20,
-        x_main_module_19); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_429 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_428, x_main_module_420);
-    auto x_main_module_430 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_429);
-    auto x_main_module_431 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_430,
-        x_main_module_18); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_432 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_431,
-        x_main_module_17,
-        x_main_module_16,
-        x_main_module_15,
-        x_main_module_14); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_433 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_432);
-    auto x_main_module_434 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_433,
-        x_main_module_13); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_435 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_434,
-        x_main_module_12,
-        x_main_module_11,
-        x_main_module_10,
-        x_main_module_9); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_436 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_435);
-    auto x_main_module_437 = mmain->add_instruction(
-        migraphx::make_op("convolution",
-                          migraphx::from_json_string(
-                              "{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_"
-                              "mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")),
-        x_main_module_436,
-        x_main_module_8); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_438 = mmain->add_instruction(
-        migraphx::make_op(
-            "batch_norm_inference",
-            migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,"
-                                       "\"momentum\":0.8999999761581421}")),
-        x_main_module_437,
-        x_main_module_7,
-        x_main_module_6,
-        x_main_module_5,
-        x_main_module_4); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_439 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_438, x_main_module_430);
-    auto x_main_module_440 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_439);
-    auto x_main_module_441 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[7,7],\"lp_order\":2,\"mode\":"
-                                       "0,\"padding\":[0,0,0,0],\"stride\":[1,1]}")),
-        x_main_module_440); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_442 = mmain->add_instruction(
-        migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")),
-        x_main_module_441); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_443 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")),
-        x_main_module_3); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_444 =
-        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_442, x_main_module_443);
-    auto x_main_module_445 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        x_main_module_2); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_446 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")),
-        x_main_module_0); // NOLINT(modernize-raw-string-literal)
-    auto x_main_module_447 =
-        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_445, x_main_module_446);
-    auto x_main_module_448 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_444, x_main_module_447);
-    mmain->add_return({x_main_module_448});
+migraphx::module_ref mmain = p.get_main_module();
+auto x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+auto x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
+auto x_main_module_2 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
+auto x_main_module_3 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
+auto x_main_module_4 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 3)));
+auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 4));
+auto x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 5));
+auto x_main_module_7 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 6)));
+auto x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 7));
+auto x_main_module_9 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 8)));
+auto x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 9));
+auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 10));
+auto x_main_module_12 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 11)));
+auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 12));
+auto x_main_module_14 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 13)));
+auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 14));
+auto x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 15));
+auto x_main_module_17 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 16)));
+auto x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 17));
+auto x_main_module_19 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 18)));
+auto x_main_module_20 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 19));
+auto x_main_module_21 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 20));
+auto x_main_module_22 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 21)));
+auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 22));
+auto x_main_module_24 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 23)));
+auto x_main_module_25 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 24));
+auto x_main_module_26 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 25));
+auto x_main_module_27 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 26)));
+auto x_main_module_28 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 27));
+auto x_main_module_29 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 28)));
+auto x_main_module_30 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 29));
+auto x_main_module_31 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 30));
+auto x_main_module_32 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 31)));
+auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 32));
+auto x_main_module_34 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 33)));
+auto x_main_module_35 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 34));
+auto x_main_module_36 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 35));
+auto x_main_module_37 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 36)));
+auto x_main_module_38 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 1024, 1, 1}}, 37));
+auto x_main_module_39 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 38)));
+auto x_main_module_40 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 39));
+auto x_main_module_41 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 40));
+auto x_main_module_42 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 41)));
+auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 42));
+auto x_main_module_44 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 43)));
+auto x_main_module_45 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 44));
+auto x_main_module_46 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 45));
+auto x_main_module_47 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 46)));
+auto x_main_module_48 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 47));
+auto x_main_module_49 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 48)));
+auto x_main_module_50 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 49));
+auto x_main_module_51 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 50));
+auto x_main_module_52 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 51)));
+auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 1024, 1, 1}}, 52));
+auto x_main_module_54 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 53)));
+auto x_main_module_55 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 54));
+auto x_main_module_56 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 55));
+auto x_main_module_57 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 56));
+auto x_main_module_58 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 57));
+auto x_main_module_59 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 58)));
+auto x_main_module_60 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 59));
+auto x_main_module_61 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 60));
+auto x_main_module_62 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 61)));
+auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 62));
+auto x_main_module_64 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 63)));
+auto x_main_module_65 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 64));
+auto x_main_module_66 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 65));
+auto x_main_module_67 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 66)));
+auto x_main_module_68 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 67));
+auto x_main_module_69 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 68)));
+auto x_main_module_70 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 69));
+auto x_main_module_71 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 70));
+auto x_main_module_72 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 71));
+auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 72));
+auto x_main_module_74 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 73)));
+auto x_main_module_75 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 74));
+auto x_main_module_76 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 75));
+auto x_main_module_77 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 76)));
+auto x_main_module_78 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 77));
+auto x_main_module_79 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 78)));
+auto x_main_module_80 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 79));
+auto x_main_module_81 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 80));
+auto x_main_module_82 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 81)));
+auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 82));
+auto x_main_module_84 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 83)));
+auto x_main_module_85 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 84));
+auto x_main_module_86 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 85));
+auto x_main_module_87 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 86));
+auto x_main_module_88 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 87));
+auto x_main_module_89 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 88)));
+auto x_main_module_90 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 89));
+auto x_main_module_91 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 90));
+auto x_main_module_92 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 91)));
+auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 92));
+auto x_main_module_94 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 93)));
+auto x_main_module_95 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 94));
+auto x_main_module_96 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 95));
+auto x_main_module_97 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 96)));
+auto x_main_module_98 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 97));
+auto x_main_module_99 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 98)));
+auto x_main_module_100 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 99));
+auto x_main_module_101 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 100));
+auto x_main_module_102 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 101));
+auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 102));
+auto x_main_module_104 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 103)));
+auto x_main_module_105 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 104));
+auto x_main_module_106 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 105));
+auto x_main_module_107 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 106)));
+auto x_main_module_108 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 107));
+auto x_main_module_109 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 108)));
+auto x_main_module_110 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 109));
+auto x_main_module_111 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 110));
+auto x_main_module_112 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 111)));
+auto x_main_module_113 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 112));
+auto x_main_module_114 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 113)));
+auto x_main_module_115 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 114));
+auto x_main_module_116 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 115));
+auto x_main_module_117 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 116));
+auto x_main_module_118 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 117));
+auto x_main_module_119 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 118)));
+auto x_main_module_120 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 119));
+auto x_main_module_121 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 120));
+auto x_main_module_122 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 121)));
+auto x_main_module_123 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 122));
+auto x_main_module_124 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 123)));
+auto x_main_module_125 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 124));
+auto x_main_module_126 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 125));
+auto x_main_module_127 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 126)));
+auto x_main_module_128 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 127));
+auto x_main_module_129 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 128)));
+auto x_main_module_130 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 129));
+auto x_main_module_131 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 130));
+auto x_main_module_132 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 131));
+auto x_main_module_133 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 512, 1, 1}}, 132));
+auto x_main_module_134 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 133)));
+auto x_main_module_135 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 134));
+auto x_main_module_136 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 135));
+auto x_main_module_137 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 136));
+auto x_main_module_138 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 137));
+auto x_main_module_139 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 138)));
+auto x_main_module_140 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 139));
+auto x_main_module_141 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 140));
+auto x_main_module_142 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 141)));
+auto x_main_module_143 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 142));
+auto x_main_module_144 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 143)));
+auto x_main_module_145 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 144));
+auto x_main_module_146 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 145));
+auto x_main_module_147 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 146)));
+auto x_main_module_148 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 512, 1, 1}}, 147));
+auto x_main_module_149 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 148)));
+auto x_main_module_150 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 149));
+auto x_main_module_151 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 150));
+auto x_main_module_152 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 151));
+auto x_main_module_153 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 152));
+auto x_main_module_154 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 153)));
+auto x_main_module_155 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 154));
+auto x_main_module_156 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 155));
+auto x_main_module_157 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 156)));
+auto x_main_module_158 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 157));
+auto x_main_module_159 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 158)));
+auto x_main_module_160 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 159));
+auto x_main_module_161 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 160));
+auto x_main_module_162 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 161)));
+auto x_main_module_163 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 162));
+auto x_main_module_164 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 163)));
+auto x_main_module_165 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 164));
+auto x_main_module_166 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 165));
+auto x_main_module_167 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 166));
+auto x_main_module_168 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 167));
+auto x_main_module_169 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 168)));
+auto x_main_module_170 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 169));
+auto x_main_module_171 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 170));
+auto x_main_module_172 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 171)));
+auto x_main_module_173 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 172));
+auto x_main_module_174 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 173)));
+auto x_main_module_175 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 174));
+auto x_main_module_176 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 175));
+auto x_main_module_177 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 176)));
+auto x_main_module_178 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 177));
+auto x_main_module_179 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 178)));
+auto x_main_module_180 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 179));
+auto x_main_module_181 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 180));
+auto x_main_module_182 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 181));
+auto x_main_module_183 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 182));
+auto x_main_module_184 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 183)));
+auto x_main_module_185 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 184));
+auto x_main_module_186 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 185));
+auto x_main_module_187 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 186)));
+auto x_main_module_188 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 187));
+auto x_main_module_189 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 188)));
+auto x_main_module_190 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 189));
+auto x_main_module_191 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 190));
+auto x_main_module_192 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 191)));
+auto x_main_module_193 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 192));
+auto x_main_module_194 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 193)));
+auto x_main_module_195 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 194));
+auto x_main_module_196 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 195));
+auto x_main_module_197 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 196));
+auto x_main_module_198 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 256, 1, 1}}, 197));
+auto x_main_module_199 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 198)));
+auto x_main_module_200 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 199));
+auto x_main_module_201 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 200));
+auto x_main_module_202 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 201));
+auto x_main_module_203 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 202));
+auto x_main_module_204 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 203)));
+auto x_main_module_205 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 204));
+auto x_main_module_206 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 205));
+auto x_main_module_207 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 206)));
+auto x_main_module_208 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 207));
+auto x_main_module_209 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 208)));
+auto x_main_module_210 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 209));
+auto x_main_module_211 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 210));
+auto x_main_module_212 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 211)));
+auto x_main_module_213 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 256, 1, 1}}, 212));
+auto x_main_module_214 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 213)));
+auto x_main_module_215 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 214));
+auto x_main_module_216 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 215));
+auto x_main_module_217 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 216));
+auto x_main_module_218 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 217));
+auto x_main_module_219 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 218)));
+auto x_main_module_220 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 219));
+auto x_main_module_221 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 220));
+auto x_main_module_222 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 221)));
+auto x_main_module_223 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 222));
+auto x_main_module_224 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 223)));
+auto x_main_module_225 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 224));
+auto x_main_module_226 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 225));
+auto x_main_module_227 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 226)));
+auto x_main_module_228 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 227));
+auto x_main_module_229 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 228)));
+auto x_main_module_230 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 229));
+auto x_main_module_231 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 230));
+auto x_main_module_232 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 231));
+auto x_main_module_233 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 232));
+auto x_main_module_234 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 233)));
+auto x_main_module_235 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 234));
+auto x_main_module_236 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 235));
+auto x_main_module_237 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 236)));
+auto x_main_module_238 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 237));
+auto x_main_module_239 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 238)));
+auto x_main_module_240 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 239));
+auto x_main_module_241 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 240));
+auto x_main_module_242 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 241)));
+auto x_main_module_243 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 242));
+auto x_main_module_244 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 243)));
+auto x_main_module_245 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 244));
+auto x_main_module_246 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 245));
+auto x_main_module_247 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 246));
+auto x_main_module_248 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 247));
+auto x_main_module_249 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 248)));
+auto x_main_module_250 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 249));
+auto x_main_module_251 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 250));
+auto x_main_module_252 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 251));
+auto x_main_module_253 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 252));
+auto x_main_module_254 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 253)));
+auto x_main_module_255 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 254));
+auto x_main_module_256 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 255));
+auto x_main_module_257 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 256)));
+auto x_main_module_258 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 257));
+auto x_main_module_259 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 258)));
+auto x_main_module_260 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 259));
+auto x_main_module_261 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 260));
+auto x_main_module_262 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 261)));
+auto x_main_module_263 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 1, 1}}, 262));
+auto x_main_module_264 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 263)));
+auto x_main_module_265 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 264));
+auto x_main_module_266 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 265));
+auto x_main_module_267 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 266)));
+auto x_main_module_268 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 3, 7, 7}}, 267));
+auto x_main_module_269 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[3,3,3,3],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_0, x_main_module_268);
+auto x_main_module_270 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_269, x_main_module_267, x_main_module_266, x_main_module_265, x_main_module_264);
+auto x_main_module_271 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_270);
+auto x_main_module_272 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[1,1,1,1],stride:[2,2]}"), x_main_module_271);
+auto x_main_module_273 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_272, x_main_module_263);
+auto x_main_module_274 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_273, x_main_module_262, x_main_module_261, x_main_module_260, x_main_module_259);
+auto x_main_module_275 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_274);
+auto x_main_module_276 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_275, x_main_module_258);
+auto x_main_module_277 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_276, x_main_module_257, x_main_module_256, x_main_module_255, x_main_module_254);
+auto x_main_module_278 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_277);
+auto x_main_module_279 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_278, x_main_module_253);
+auto x_main_module_280 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_279, x_main_module_252, x_main_module_251, x_main_module_250, x_main_module_249);
+auto x_main_module_281 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_272, x_main_module_248);
+auto x_main_module_282 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_281, x_main_module_247, x_main_module_246, x_main_module_245, x_main_module_244);
+auto x_main_module_283 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_280, x_main_module_282);
+auto x_main_module_284 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_283);
+auto x_main_module_285 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_284, x_main_module_243);
+auto x_main_module_286 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_285, x_main_module_242, x_main_module_241, x_main_module_240, x_main_module_239);
+auto x_main_module_287 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_286);
+auto x_main_module_288 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_287, x_main_module_238);
+auto x_main_module_289 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_288, x_main_module_237, x_main_module_236, x_main_module_235, x_main_module_234);
+auto x_main_module_290 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_289);
+auto x_main_module_291 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_290, x_main_module_233);
+auto x_main_module_292 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_291, x_main_module_232, x_main_module_231, x_main_module_230, x_main_module_229);
+auto x_main_module_293 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_292, x_main_module_284);
+auto x_main_module_294 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_293);
+auto x_main_module_295 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_294, x_main_module_228);
+auto x_main_module_296 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_295, x_main_module_227, x_main_module_226, x_main_module_225, x_main_module_224);
+auto x_main_module_297 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_296);
+auto x_main_module_298 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_297, x_main_module_223);
+auto x_main_module_299 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_298, x_main_module_222, x_main_module_221, x_main_module_220, x_main_module_219);
+auto x_main_module_300 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_299);
+auto x_main_module_301 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_300, x_main_module_218);
+auto x_main_module_302 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_301, x_main_module_217, x_main_module_216, x_main_module_215, x_main_module_214);
+auto x_main_module_303 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_302, x_main_module_294);
+auto x_main_module_304 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_303);
+auto x_main_module_305 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_304, x_main_module_213);
+auto x_main_module_306 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_305, x_main_module_212, x_main_module_211, x_main_module_210, x_main_module_209);
+auto x_main_module_307 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_306);
+auto x_main_module_308 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_307, x_main_module_208);
+auto x_main_module_309 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_308, x_main_module_207, x_main_module_206, x_main_module_205, x_main_module_204);
+auto x_main_module_310 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_309);
+auto x_main_module_311 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_310, x_main_module_203);
+auto x_main_module_312 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_311, x_main_module_202, x_main_module_201, x_main_module_200, x_main_module_199);
+auto x_main_module_313 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_304, x_main_module_198);
+auto x_main_module_314 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_313, x_main_module_197, x_main_module_196, x_main_module_195, x_main_module_194);
+auto x_main_module_315 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_312, x_main_module_314);
+auto x_main_module_316 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_315);
+auto x_main_module_317 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_316, x_main_module_193);
+auto x_main_module_318 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_317, x_main_module_192, x_main_module_191, x_main_module_190, x_main_module_189);
+auto x_main_module_319 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_318);
+auto x_main_module_320 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_319, x_main_module_188);
+auto x_main_module_321 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_320, x_main_module_187, x_main_module_186, x_main_module_185, x_main_module_184);
+auto x_main_module_322 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_321);
+auto x_main_module_323 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_322, x_main_module_183);
+auto x_main_module_324 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_323, x_main_module_182, x_main_module_181, x_main_module_180, x_main_module_179);
+auto x_main_module_325 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_324, x_main_module_316);
+auto x_main_module_326 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_325);
+auto x_main_module_327 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_326, x_main_module_178);
+auto x_main_module_328 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_327, x_main_module_177, x_main_module_176, x_main_module_175, x_main_module_174);
+auto x_main_module_329 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_328);
+auto x_main_module_330 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_329, x_main_module_173);
+auto x_main_module_331 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_330, x_main_module_172, x_main_module_171, x_main_module_170, x_main_module_169);
+auto x_main_module_332 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_331);
+auto x_main_module_333 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_332, x_main_module_168);
+auto x_main_module_334 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_333, x_main_module_167, x_main_module_166, x_main_module_165, x_main_module_164);
+auto x_main_module_335 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_334, x_main_module_326);
+auto x_main_module_336 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_335);
+auto x_main_module_337 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_336, x_main_module_163);
+auto x_main_module_338 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_337, x_main_module_162, x_main_module_161, x_main_module_160, x_main_module_159);
+auto x_main_module_339 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_338);
+auto x_main_module_340 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_339, x_main_module_158);
+auto x_main_module_341 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_340, x_main_module_157, x_main_module_156, x_main_module_155, x_main_module_154);
+auto x_main_module_342 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_341);
+auto x_main_module_343 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_342, x_main_module_153);
+auto x_main_module_344 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_343, x_main_module_152, x_main_module_151, x_main_module_150, x_main_module_149);
+auto x_main_module_345 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_344, x_main_module_336);
+auto x_main_module_346 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_345);
+auto x_main_module_347 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_346, x_main_module_148);
+auto x_main_module_348 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_347, x_main_module_147, x_main_module_146, x_main_module_145, x_main_module_144);
+auto x_main_module_349 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_348);
+auto x_main_module_350 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_349, x_main_module_143);
+auto x_main_module_351 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_350, x_main_module_142, x_main_module_141, x_main_module_140, x_main_module_139);
+auto x_main_module_352 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_351);
+auto x_main_module_353 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_352, x_main_module_138);
+auto x_main_module_354 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_353, x_main_module_137, x_main_module_136, x_main_module_135, x_main_module_134);
+auto x_main_module_355 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_346, x_main_module_133);
+auto x_main_module_356 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_355, x_main_module_132, x_main_module_131, x_main_module_130, x_main_module_129);
+auto x_main_module_357 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_354, x_main_module_356);
+auto x_main_module_358 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_357);
+auto x_main_module_359 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_358, x_main_module_128);
+auto x_main_module_360 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_359, x_main_module_127, x_main_module_126, x_main_module_125, x_main_module_124);
+auto x_main_module_361 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_360);
+auto x_main_module_362 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_361, x_main_module_123);
+auto x_main_module_363 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_362, x_main_module_122, x_main_module_121, x_main_module_120, x_main_module_119);
+auto x_main_module_364 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_363);
+auto x_main_module_365 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_364, x_main_module_118);
+auto x_main_module_366 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_365, x_main_module_117, x_main_module_116, x_main_module_115, x_main_module_114);
+auto x_main_module_367 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_366, x_main_module_358);
+auto x_main_module_368 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_367);
+auto x_main_module_369 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_368, x_main_module_113);
+auto x_main_module_370 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_369, x_main_module_112, x_main_module_111, x_main_module_110, x_main_module_109);
+auto x_main_module_371 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_370);
+auto x_main_module_372 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_371, x_main_module_108);
+auto x_main_module_373 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_372, x_main_module_107, x_main_module_106, x_main_module_105, x_main_module_104);
+auto x_main_module_374 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_373);
+auto x_main_module_375 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_374, x_main_module_103);
+auto x_main_module_376 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_375, x_main_module_102, x_main_module_101, x_main_module_100, x_main_module_99);
+auto x_main_module_377 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_376, x_main_module_368);
+auto x_main_module_378 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_377);
+auto x_main_module_379 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_378, x_main_module_98);
+auto x_main_module_380 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_379, x_main_module_97, x_main_module_96, x_main_module_95, x_main_module_94);
+auto x_main_module_381 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_380);
+auto x_main_module_382 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_381, x_main_module_93);
+auto x_main_module_383 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_382, x_main_module_92, x_main_module_91, x_main_module_90, x_main_module_89);
+auto x_main_module_384 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_383);
+auto x_main_module_385 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_384, x_main_module_88);
+auto x_main_module_386 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_385, x_main_module_87, x_main_module_86, x_main_module_85, x_main_module_84);
+auto x_main_module_387 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_386, x_main_module_378);
+auto x_main_module_388 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_387);
+auto x_main_module_389 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_388, x_main_module_83);
+auto x_main_module_390 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_389, x_main_module_82, x_main_module_81, x_main_module_80, x_main_module_79);
+auto x_main_module_391 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_390);
+auto x_main_module_392 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_391, x_main_module_78);
+auto x_main_module_393 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_392, x_main_module_77, x_main_module_76, x_main_module_75, x_main_module_74);
+auto x_main_module_394 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_393);
+auto x_main_module_395 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_394, x_main_module_73);
+auto x_main_module_396 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_395, x_main_module_72, x_main_module_71, x_main_module_70, x_main_module_69);
+auto x_main_module_397 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_396, x_main_module_388);
+auto x_main_module_398 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_397);
+auto x_main_module_399 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_398, x_main_module_68);
+auto x_main_module_400 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_399, x_main_module_67, x_main_module_66, x_main_module_65, x_main_module_64);
+auto x_main_module_401 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_400);
+auto x_main_module_402 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_401, x_main_module_63);
+auto x_main_module_403 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_402, x_main_module_62, x_main_module_61, x_main_module_60, x_main_module_59);
+auto x_main_module_404 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_403);
+auto x_main_module_405 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_404, x_main_module_58);
+auto x_main_module_406 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_405, x_main_module_57, x_main_module_56, x_main_module_55, x_main_module_54);
+auto x_main_module_407 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_406, x_main_module_398);
+auto x_main_module_408 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_407);
+auto x_main_module_409 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_408, x_main_module_53);
+auto x_main_module_410 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_409, x_main_module_52, x_main_module_51, x_main_module_50, x_main_module_49);
+auto x_main_module_411 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_410);
+auto x_main_module_412 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_411, x_main_module_48);
+auto x_main_module_413 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_412, x_main_module_47, x_main_module_46, x_main_module_45, x_main_module_44);
+auto x_main_module_414 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_413);
+auto x_main_module_415 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_414, x_main_module_43);
+auto x_main_module_416 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_415, x_main_module_42, x_main_module_41, x_main_module_40, x_main_module_39);
+auto x_main_module_417 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2],use_dynamic_same_auto_pad:0}"), x_main_module_408, x_main_module_38);
+auto x_main_module_418 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_417, x_main_module_37, x_main_module_36, x_main_module_35, x_main_module_34);
+auto x_main_module_419 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_416, x_main_module_418);
+auto x_main_module_420 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_419);
+auto x_main_module_421 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_420, x_main_module_33);
+auto x_main_module_422 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_421, x_main_module_32, x_main_module_31, x_main_module_30, x_main_module_29);
+auto x_main_module_423 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_422);
+auto x_main_module_424 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_423, x_main_module_28);
+auto x_main_module_425 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_424, x_main_module_27, x_main_module_26, x_main_module_25, x_main_module_24);
+auto x_main_module_426 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_425);
+auto x_main_module_427 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_426, x_main_module_23);
+auto x_main_module_428 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_427, x_main_module_22, x_main_module_21, x_main_module_20, x_main_module_19);
+auto x_main_module_429 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_428, x_main_module_420);
+auto x_main_module_430 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_429);
+auto x_main_module_431 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_430, x_main_module_18);
+auto x_main_module_432 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_431, x_main_module_17, x_main_module_16, x_main_module_15, x_main_module_14);
+auto x_main_module_433 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_432);
+auto x_main_module_434 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_433, x_main_module_13);
+auto x_main_module_435 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_434, x_main_module_12, x_main_module_11, x_main_module_10, x_main_module_9);
+auto x_main_module_436 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_435);
+auto x_main_module_437 = mmain->add_instruction(migraphx::make_json_op("convolution", "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1],use_dynamic_same_auto_pad:0}"), x_main_module_436, x_main_module_8);
+auto x_main_module_438 = mmain->add_instruction(migraphx::make_json_op("batch_norm_inference", "{bn_mode:1,epsilon:9.999999747378752e-06,momentum:0.8999999761581421}"), x_main_module_437, x_main_module_7, x_main_module_6, x_main_module_5, x_main_module_4);
+auto x_main_module_439 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_438, x_main_module_430);
+auto x_main_module_440 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_439);
+auto x_main_module_441 = mmain->add_instruction(migraphx::make_json_op("pooling", "{ceil_mode:0,lengths:[7,7],lp_order:2,mode:0,padding:[0,0,0,0],stride:[1,1]}"), x_main_module_440);
+auto x_main_module_442 = mmain->add_instruction(migraphx::make_json_op("flatten", "{axis:1}"), x_main_module_441);
+auto x_main_module_443 = mmain->add_instruction(migraphx::make_json_op("transpose", "{permutation:[1,0]}"), x_main_module_3);
+auto x_main_module_444 = mmain->add_instruction(migraphx::make_op("dot"), x_main_module_442, x_main_module_443);
+auto x_main_module_445 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_2);
+auto x_main_module_446 = mmain->add_instruction(migraphx::make_json_op("multibroadcast", "{out_lens:[1,1000]}"), x_main_module_0);
+auto x_main_module_447 = mmain->add_instruction(migraphx::make_op("mul"), x_main_module_445, x_main_module_446);
+auto x_main_module_448 = mmain->add_instruction(migraphx::make_op("add"), x_main_module_444, x_main_module_447);
+mmain->add_return({x_main_module_448});
+
 
     return p;
 }

--- a/src/driver/resnet50.cpp
+++ b/src/driver/resnet50.cpp
@@ -27,1031 +27,464 @@
 #include <migraphx/generate.hpp>
 #include <migraphx/json.hpp>
 #include "models.hpp"
-
 namespace migraphx {
 namespace driver {
 inline namespace MIGRAPHX_INLINE_NS {
-
 migraphx::program resnet50(unsigned batch) // NOLINT(readability-function-size)
 {
     migraphx::program p;
-    migraphx::module_ref mmain = p.get_main_module();
-    auto x_main_module_0       = mmain->add_literal(migraphx::abs(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
-    auto x_input_1             = mmain->add_parameter(
-        "input.1", migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
-    auto x_main_module_2 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 1));
-    auto x_main_module_3 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 2));
-    auto x_main_module_4 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 3));
-    auto x_main_module_5 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 4));
-    auto x_main_module_6 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 5));
-    auto x_main_module_7 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 6));
-    auto x_main_module_8 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 7));
-    auto x_main_module_9  = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 8));
-    auto x_main_module_10 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 9));
-    auto x_main_module_11 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 10));
-    auto x_main_module_12 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 11));
-    auto x_main_module_13 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 12));
-    auto x_main_module_14 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 13));
-    auto x_main_module_15 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 14));
-    auto x_main_module_16 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 15));
-    auto x_main_module_17 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {2048, 1024, 1, 1}}, 16));
-    auto x_main_module_18 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 17));
-    auto x_main_module_19 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 18));
-    auto x_main_module_20 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 19));
-    auto x_main_module_21 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 20));
-    auto x_main_module_22 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 21));
-    auto x_main_module_23 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 1024, 1, 1}}, 22));
-    auto x_main_module_24 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 23));
-    auto x_main_module_25 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 24));
-    auto x_main_module_26 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 25));
-    auto x_main_module_27 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 26));
-    auto x_main_module_28 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 27));
-    auto x_main_module_29 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 28));
-    auto x_main_module_30 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 29));
-    auto x_main_module_31 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 30));
-    auto x_main_module_32 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 31));
-    auto x_main_module_33 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 32));
-    auto x_main_module_34 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 33));
-    auto x_main_module_35 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 34));
-    auto x_main_module_36 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 35));
-    auto x_main_module_37 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 36));
-    auto x_main_module_38 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 37));
-    auto x_main_module_39 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 38));
-    auto x_main_module_40 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 39));
-    auto x_main_module_41 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 40));
-    auto x_main_module_42 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 41));
-    auto x_main_module_43 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 42));
-    auto x_main_module_44 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 43));
-    auto x_main_module_45 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 44));
-    auto x_main_module_46 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 45));
-    auto x_main_module_47 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 46));
-    auto x_main_module_48 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 47));
-    auto x_main_module_49 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 48));
-    auto x_main_module_50 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 49));
-    auto x_main_module_51 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 50));
-    auto x_main_module_52 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 51));
-    auto x_main_module_53 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 52));
-    auto x_main_module_54 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 53));
-    auto x_main_module_55 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 512, 1, 1}}, 54));
-    auto x_main_module_56 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 55));
-    auto x_main_module_57 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 56));
-    auto x_main_module_58 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 57));
-    auto x_main_module_59 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 58));
-    auto x_main_module_60 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 59));
-    auto x_main_module_61 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 512, 1, 1}}, 60));
-    auto x_main_module_62 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 61));
-    auto x_main_module_63 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 62));
-    auto x_main_module_64 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 63));
-    auto x_main_module_65 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 64));
-    auto x_main_module_66 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 65));
-    auto x_main_module_67 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 66));
-    auto x_main_module_68 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 67));
-    auto x_main_module_69 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 68));
-    auto x_main_module_70 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 69));
-    auto x_main_module_71 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 70));
-    auto x_main_module_72 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 71));
-    auto x_main_module_73 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 72));
-    auto x_main_module_74 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 73));
-    auto x_main_module_75 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 74));
-    auto x_main_module_76 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 75));
-    auto x_main_module_77 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 76));
-    auto x_main_module_78 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 77));
-    auto x_main_module_79 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 78));
-    auto x_main_module_80 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 79));
-    auto x_main_module_81 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 256, 1, 1}}, 80));
-    auto x_main_module_82 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 81));
-    auto x_main_module_83 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 82));
-    auto x_main_module_84 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 83));
-    auto x_main_module_85 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 84));
-    auto x_main_module_86 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 85));
-    auto x_main_module_87 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {128, 256, 1, 1}}, 86));
-    auto x_main_module_88 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 87));
-    auto x_main_module_89 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 88));
-    auto x_main_module_90 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 89));
-    auto x_main_module_91 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 90));
-    auto x_main_module_92 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 91));
-    auto x_main_module_93 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 92));
-    auto x_main_module_94 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 93));
-    auto x_main_module_95 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 94));
-    auto x_main_module_96 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 95));
-    auto x_main_module_97 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 96));
-    auto x_main_module_98 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 97));
-    auto x_main_module_99  = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 98));
-    auto x_main_module_100 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 99));
-    auto x_main_module_101 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 100));
-    auto x_main_module_102 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 101));
-    auto x_main_module_103 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 102));
-    auto x_main_module_104 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 103));
-    auto x_main_module_105 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 104));
-    auto x_main_module_106 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 105));
-    auto x_main_module_107 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 64, 1, 1}}, 106));
-    auto x_main_module_108 = mmain->add_literal(
-        migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 107));
-    auto x_main_module_109 = mmain->add_literal(migraphx::generate_literal(
-        migraphx::shape{migraphx::shape::float_type, {64, 3, 7, 7}}, 108));
-    auto x_main_module_110 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[3,3,3,3],padding_mode:0,stride:[2,2]}")),
-        x_input_1,
-        x_main_module_109);
-    auto x_main_module_111 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,112,112]}")),
-        x_main_module_108);
-    auto x_main_module_112 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_110, x_main_module_111);
-    auto x_main_module_113 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_112);
-    auto x_main_module_114 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[3,3],lp_order:2,mode:1,padding:[1,1,1,1],stride:[2,2]}")),
-        x_main_module_113);
-    auto x_main_module_115 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_114,
-        x_main_module_107);
-    auto x_main_module_116 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,56,56]}")),
-        x_main_module_106);
-    auto x_main_module_117 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_115, x_main_module_116);
-    auto x_main_module_118 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_117);
-    auto x_main_module_119 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_118,
-        x_main_module_105);
-    auto x_main_module_120 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,56,56]}")),
-        x_main_module_104);
-    auto x_main_module_121 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_119, x_main_module_120);
-    auto x_main_module_122 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_121);
-    auto x_main_module_123 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_122,
-        x_main_module_103);
-    auto x_main_module_124 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,56,56]}")),
-        x_main_module_102);
-    auto x_main_module_125 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_123, x_main_module_124);
-    auto x_main_module_126 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_114,
-        x_main_module_101);
-    auto x_main_module_127 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,56,56]}")),
-        x_main_module_100);
-    auto x_main_module_128 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_126, x_main_module_127);
-    auto x_main_module_129 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_125, x_main_module_128);
-    auto x_main_module_130 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_129);
-    auto x_main_module_131 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_130,
-        x_main_module_99);
-    auto x_main_module_132 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,56,56]}")),
-        x_main_module_98);
-    auto x_main_module_133 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_131, x_main_module_132);
-    auto x_main_module_134 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_133);
-    auto x_main_module_135 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_134,
-        x_main_module_97);
-    auto x_main_module_136 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,56,56]}")),
-        x_main_module_96);
-    auto x_main_module_137 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_135, x_main_module_136);
-    auto x_main_module_138 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_137);
-    auto x_main_module_139 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_138,
-        x_main_module_95);
-    auto x_main_module_140 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,56,56]}")),
-        x_main_module_94);
-    auto x_main_module_141 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_139, x_main_module_140);
-    auto x_main_module_142 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_141, x_main_module_130);
-    auto x_main_module_143 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_142);
-    auto x_main_module_144 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_143,
-        x_main_module_93);
-    auto x_main_module_145 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,56,56]}")),
-        x_main_module_92);
-    auto x_main_module_146 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_144, x_main_module_145);
-    auto x_main_module_147 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_146);
-    auto x_main_module_148 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_147,
-        x_main_module_91);
-    auto x_main_module_149 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,64,56,56]}")),
-        x_main_module_90);
-    auto x_main_module_150 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_148, x_main_module_149);
-    auto x_main_module_151 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_150);
-    auto x_main_module_152 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_151,
-        x_main_module_89);
-    auto x_main_module_153 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,56,56]}")),
-        x_main_module_88);
-    auto x_main_module_154 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_152, x_main_module_153);
-    auto x_main_module_155 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_154, x_main_module_143);
-    auto x_main_module_156 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_155);
-    auto x_main_module_157 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_156,
-        x_main_module_87);
-    auto x_main_module_158 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,128,56,56]}")),
-        x_main_module_86);
-    auto x_main_module_159 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_157, x_main_module_158);
-    auto x_main_module_160 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_159);
-    auto x_main_module_161 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[2,2]}")),
-        x_main_module_160,
-        x_main_module_85);
-    auto x_main_module_162 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,128,28,28]}")),
-        x_main_module_84);
-    auto x_main_module_163 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_161, x_main_module_162);
-    auto x_main_module_164 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_163);
-    auto x_main_module_165 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_164,
-        x_main_module_83);
-    auto x_main_module_166 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,512,28,28]}")),
-        x_main_module_82);
-    auto x_main_module_167 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_165, x_main_module_166);
-    auto x_main_module_168 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2]}")),
-        x_main_module_156,
-        x_main_module_81);
-    auto x_main_module_169 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,512,28,28]}")),
-        x_main_module_80);
-    auto x_main_module_170 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_168, x_main_module_169);
-    auto x_main_module_171 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_167, x_main_module_170);
-    auto x_main_module_172 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_171);
-    auto x_main_module_173 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_172,
-        x_main_module_79);
-    auto x_main_module_174 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,128,28,28]}")),
-        x_main_module_78);
-    auto x_main_module_175 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_173, x_main_module_174);
-    auto x_main_module_176 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_175);
-    auto x_main_module_177 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_176,
-        x_main_module_77);
-    auto x_main_module_178 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,128,28,28]}")),
-        x_main_module_76);
-    auto x_main_module_179 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_177, x_main_module_178);
-    auto x_main_module_180 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_179);
-    auto x_main_module_181 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_180,
-        x_main_module_75);
-    auto x_main_module_182 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,512,28,28]}")),
-        x_main_module_74);
-    auto x_main_module_183 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_181, x_main_module_182);
-    auto x_main_module_184 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_183, x_main_module_172);
-    auto x_main_module_185 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_184);
-    auto x_main_module_186 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_185,
-        x_main_module_73);
-    auto x_main_module_187 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,128,28,28]}")),
-        x_main_module_72);
-    auto x_main_module_188 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_186, x_main_module_187);
-    auto x_main_module_189 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_188);
-    auto x_main_module_190 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_189,
-        x_main_module_71);
-    auto x_main_module_191 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,128,28,28]}")),
-        x_main_module_70);
-    auto x_main_module_192 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_190, x_main_module_191);
-    auto x_main_module_193 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_192);
-    auto x_main_module_194 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_193,
-        x_main_module_69);
-    auto x_main_module_195 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,512,28,28]}")),
-        x_main_module_68);
-    auto x_main_module_196 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_194, x_main_module_195);
-    auto x_main_module_197 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_196, x_main_module_185);
-    auto x_main_module_198 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_197);
-    auto x_main_module_199 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_198,
-        x_main_module_67);
-    auto x_main_module_200 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,128,28,28]}")),
-        x_main_module_66);
-    auto x_main_module_201 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_199, x_main_module_200);
-    auto x_main_module_202 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_201);
-    auto x_main_module_203 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_202,
-        x_main_module_65);
-    auto x_main_module_204 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,128,28,28]}")),
-        x_main_module_64);
-    auto x_main_module_205 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_203, x_main_module_204);
-    auto x_main_module_206 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_205);
-    auto x_main_module_207 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_206,
-        x_main_module_63);
-    auto x_main_module_208 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,512,28,28]}")),
-        x_main_module_62);
-    auto x_main_module_209 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_207, x_main_module_208);
-    auto x_main_module_210 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_209, x_main_module_198);
-    auto x_main_module_211 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_210);
-    auto x_main_module_212 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_211,
-        x_main_module_61);
-    auto x_main_module_213 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,28,28]}")),
-        x_main_module_60);
-    auto x_main_module_214 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_212, x_main_module_213);
-    auto x_main_module_215 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_214);
-    auto x_main_module_216 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[2,2]}")),
-        x_main_module_215,
-        x_main_module_59);
-    auto x_main_module_217 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,14,14]}")),
-        x_main_module_58);
-    auto x_main_module_218 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_216, x_main_module_217);
-    auto x_main_module_219 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_218);
-    auto x_main_module_220 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_219,
-        x_main_module_57);
-    auto x_main_module_221 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,1024,14,14]}")),
-        x_main_module_56);
-    auto x_main_module_222 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_220, x_main_module_221);
-    auto x_main_module_223 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2]}")),
-        x_main_module_211,
-        x_main_module_55);
-    auto x_main_module_224 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,1024,14,14]}")),
-        x_main_module_54);
-    auto x_main_module_225 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_223, x_main_module_224);
-    auto x_main_module_226 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_222, x_main_module_225);
-    auto x_main_module_227 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_226);
-    auto x_main_module_228 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_227,
-        x_main_module_53);
-    auto x_main_module_229 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,14,14]}")),
-        x_main_module_52);
-    auto x_main_module_230 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_228, x_main_module_229);
-    auto x_main_module_231 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_230);
-    auto x_main_module_232 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_231,
-        x_main_module_51);
-    auto x_main_module_233 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,14,14]}")),
-        x_main_module_50);
-    auto x_main_module_234 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_232, x_main_module_233);
-    auto x_main_module_235 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_234);
-    auto x_main_module_236 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_235,
-        x_main_module_49);
-    auto x_main_module_237 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,1024,14,14]}")),
-        x_main_module_48);
-    auto x_main_module_238 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_236, x_main_module_237);
-    auto x_main_module_239 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_238, x_main_module_227);
-    auto x_main_module_240 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_239);
-    auto x_main_module_241 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_240,
-        x_main_module_47);
-    auto x_main_module_242 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,14,14]}")),
-        x_main_module_46);
-    auto x_main_module_243 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_241, x_main_module_242);
-    auto x_main_module_244 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_243);
-    auto x_main_module_245 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_244,
-        x_main_module_45);
-    auto x_main_module_246 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,14,14]}")),
-        x_main_module_44);
-    auto x_main_module_247 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_245, x_main_module_246);
-    auto x_main_module_248 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_247);
-    auto x_main_module_249 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_248,
-        x_main_module_43);
-    auto x_main_module_250 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,1024,14,14]}")),
-        x_main_module_42);
-    auto x_main_module_251 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_249, x_main_module_250);
-    auto x_main_module_252 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_251, x_main_module_240);
-    auto x_main_module_253 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_252);
-    auto x_main_module_254 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_253,
-        x_main_module_41);
-    auto x_main_module_255 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,14,14]}")),
-        x_main_module_40);
-    auto x_main_module_256 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_254, x_main_module_255);
-    auto x_main_module_257 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_256);
-    auto x_main_module_258 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_257,
-        x_main_module_39);
-    auto x_main_module_259 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,14,14]}")),
-        x_main_module_38);
-    auto x_main_module_260 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_258, x_main_module_259);
-    auto x_main_module_261 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_260);
-    auto x_main_module_262 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_261,
-        x_main_module_37);
-    auto x_main_module_263 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,1024,14,14]}")),
-        x_main_module_36);
-    auto x_main_module_264 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_262, x_main_module_263);
-    auto x_main_module_265 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_264, x_main_module_253);
-    auto x_main_module_266 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_265);
-    auto x_main_module_267 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_266,
-        x_main_module_35);
-    auto x_main_module_268 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,14,14]}")),
-        x_main_module_34);
-    auto x_main_module_269 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_267, x_main_module_268);
-    auto x_main_module_270 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_269);
-    auto x_main_module_271 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_270,
-        x_main_module_33);
-    auto x_main_module_272 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,14,14]}")),
-        x_main_module_32);
-    auto x_main_module_273 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_271, x_main_module_272);
-    auto x_main_module_274 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_273);
-    auto x_main_module_275 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_274,
-        x_main_module_31);
-    auto x_main_module_276 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,1024,14,14]}")),
-        x_main_module_30);
-    auto x_main_module_277 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_275, x_main_module_276);
-    auto x_main_module_278 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_277, x_main_module_266);
-    auto x_main_module_279 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_278);
-    auto x_main_module_280 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_279,
-        x_main_module_29);
-    auto x_main_module_281 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,14,14]}")),
-        x_main_module_28);
-    auto x_main_module_282 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_280, x_main_module_281);
-    auto x_main_module_283 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_282);
-    auto x_main_module_284 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_283,
-        x_main_module_27);
-    auto x_main_module_285 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,256,14,14]}")),
-        x_main_module_26);
-    auto x_main_module_286 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_284, x_main_module_285);
-    auto x_main_module_287 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_286);
-    auto x_main_module_288 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_287,
-        x_main_module_25);
-    auto x_main_module_289 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,1024,14,14]}")),
-        x_main_module_24);
-    auto x_main_module_290 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_288, x_main_module_289);
-    auto x_main_module_291 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_290, x_main_module_279);
-    auto x_main_module_292 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_291);
-    auto x_main_module_293 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_292,
-        x_main_module_23);
-    auto x_main_module_294 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,512,14,14]}")),
-        x_main_module_22);
-    auto x_main_module_295 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_293, x_main_module_294);
-    auto x_main_module_296 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_295);
-    auto x_main_module_297 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[2,2]}")),
-        x_main_module_296,
-        x_main_module_21);
-    auto x_main_module_298 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,512,7,7]}")),
-        x_main_module_20);
-    auto x_main_module_299 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_297, x_main_module_298);
-    auto x_main_module_300 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_299);
-    auto x_main_module_301 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_300,
-        x_main_module_19);
-    auto x_main_module_302 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,2048,7,7]}")),
-        x_main_module_18);
-    auto x_main_module_303 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_301, x_main_module_302);
-    auto x_main_module_304 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[2,2]}")),
-        x_main_module_292,
-        x_main_module_17);
-    auto x_main_module_305 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,2048,7,7]}")),
-        x_main_module_16);
-    auto x_main_module_306 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_304, x_main_module_305);
-    auto x_main_module_307 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_303, x_main_module_306);
-    auto x_main_module_308 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_307);
-    auto x_main_module_309 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_308,
-        x_main_module_15);
-    auto x_main_module_310 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,512,7,7]}")),
-        x_main_module_14);
-    auto x_main_module_311 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_309, x_main_module_310);
-    auto x_main_module_312 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_311);
-    auto x_main_module_313 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_312,
-        x_main_module_13);
-    auto x_main_module_314 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,512,7,7]}")),
-        x_main_module_12);
-    auto x_main_module_315 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_313, x_main_module_314);
-    auto x_main_module_316 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_315);
-    auto x_main_module_317 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_316,
-        x_main_module_11);
-    auto x_main_module_318 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,2048,7,7]}")),
-        x_main_module_10);
-    auto x_main_module_319 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_317, x_main_module_318);
-    auto x_main_module_320 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_319, x_main_module_308);
-    auto x_main_module_321 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_320);
-    auto x_main_module_322 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_321,
-        x_main_module_9);
-    auto x_main_module_323 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,512,7,7]}")),
-        x_main_module_8);
-    auto x_main_module_324 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_322, x_main_module_323);
-    auto x_main_module_325 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_324);
-    auto x_main_module_326 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[1,1,1,1],padding_mode:0,stride:[1,1]}")),
-        x_main_module_325,
-        x_main_module_7);
-    auto x_main_module_327 = mmain->add_instruction(
-        migraphx::make_op("broadcast", migraphx::from_json_string("{axis:1,out_lens:[1,512,7,7]}")),
-        x_main_module_6);
-    auto x_main_module_328 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_326, x_main_module_327);
-    auto x_main_module_329 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_328);
-    auto x_main_module_330 = mmain->add_instruction(
-        migraphx::make_op(
-            "convolution",
-            migraphx::from_json_string(
-                "{dilation:[1,1],group:1,padding:[0,0,0,0],padding_mode:0,stride:[1,1]}")),
-        x_main_module_329,
-        x_main_module_5);
-    auto x_main_module_331 = mmain->add_instruction(
-        migraphx::make_op("broadcast",
-                          migraphx::from_json_string("{axis:1,out_lens:[1,2048,7,7]}")),
-        x_main_module_4);
-    auto x_main_module_332 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_330, x_main_module_331);
-    auto x_main_module_333 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_332, x_main_module_321);
-    auto x_main_module_334 = mmain->add_instruction(migraphx::make_op("relu"), x_main_module_333);
-    auto x_main_module_335 = mmain->add_instruction(
-        migraphx::make_op(
-            "pooling",
-            migraphx::from_json_string(
-                "{ceil_mode:0,lengths:[7,7],lp_order:2,mode:0,padding:[0,0,0,0],stride:[1,1]}")),
-        x_main_module_334);
-    auto x_main_module_336 = mmain->add_instruction(
-        migraphx::make_op("reshape", migraphx::from_json_string("{dims:[1,-1]}")),
-        x_main_module_335);
-    auto x_main_module_337 = mmain->add_instruction(
-        migraphx::make_op("transpose", migraphx::from_json_string("{permutation:[1,0]}")),
-        x_main_module_2);
-    auto x_main_module_338 =
-        mmain->add_instruction(migraphx::make_op("dot"), x_main_module_336, x_main_module_337);
-    auto x_main_module_339 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{out_lens:[1,1000]}")),
-        x_main_module_3);
-    auto x_main_module_340 = mmain->add_instruction(
-        migraphx::make_op("multibroadcast", migraphx::from_json_string("{out_lens:[1,1000]}")),
-        x_main_module_0);
-    auto x_main_module_341 =
-        mmain->add_instruction(migraphx::make_op("mul"), x_main_module_339, x_main_module_340);
-    auto x_main_module_342 =
-        mmain->add_instruction(migraphx::make_op("add"), x_main_module_338, x_main_module_341);
-    mmain->add_return({x_main_module_342});
+migraphx::module_ref mmain = p.get_main_module();
+auto _x_main_module_0 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1}}, 0)));
+auto _x_0 = mmain->add_parameter("0",migraphx::shape{migraphx::shape::float_type, {batch, 3, 224, 224}});
+auto _x_main_module_2 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000}}, 1));
+auto _x_main_module_3 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1000, 2048}}, 2));
+auto _x_main_module_4 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 3)));
+auto _x_main_module_5 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 4));
+auto _x_main_module_6 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 5));
+auto _x_main_module_7 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 6)));
+auto _x_main_module_8 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 7));
+auto _x_main_module_9 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 8)));
+auto _x_main_module_10 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 9));
+auto _x_main_module_11 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 10));
+auto _x_main_module_12 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 11)));
+auto _x_main_module_13 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 12));
+auto _x_main_module_14 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 13)));
+auto _x_main_module_15 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 14));
+auto _x_main_module_16 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 15));
+auto _x_main_module_17 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 16)));
+auto _x_main_module_18 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 17));
+auto _x_main_module_19 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 18)));
+auto _x_main_module_20 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 19));
+auto _x_main_module_21 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 20));
+auto _x_main_module_22 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 21)));
+auto _x_main_module_23 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 22));
+auto _x_main_module_24 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 23)));
+auto _x_main_module_25 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 24));
+auto _x_main_module_26 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 25));
+auto _x_main_module_27 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 26)));
+auto _x_main_module_28 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 27));
+auto _x_main_module_29 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 28)));
+auto _x_main_module_30 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 29));
+auto _x_main_module_31 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 30));
+auto _x_main_module_32 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 31)));
+auto _x_main_module_33 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 2048, 1, 1}}, 32));
+auto _x_main_module_34 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 33)));
+auto _x_main_module_35 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 34));
+auto _x_main_module_36 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 35));
+auto _x_main_module_37 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 36)));
+auto _x_main_module_38 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 1024, 1, 1}}, 37));
+auto _x_main_module_39 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 38)));
+auto _x_main_module_40 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 39));
+auto _x_main_module_41 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 40));
+auto _x_main_module_42 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048}}, 41)));
+auto _x_main_module_43 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {2048, 512, 1, 1}}, 42));
+auto _x_main_module_44 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 43)));
+auto _x_main_module_45 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 44));
+auto _x_main_module_46 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 45));
+auto _x_main_module_47 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 46)));
+auto _x_main_module_48 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 512, 3, 3}}, 47));
+auto _x_main_module_49 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 48)));
+auto _x_main_module_50 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 49));
+auto _x_main_module_51 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 50));
+auto _x_main_module_52 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 51)));
+auto _x_main_module_53 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 1024, 1, 1}}, 52));
+auto _x_main_module_54 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 53)));
+auto _x_main_module_55 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 54));
+auto _x_main_module_56 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 55));
+auto _x_main_module_57 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 56));
+auto _x_main_module_58 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 57));
+auto _x_main_module_59 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 58)));
+auto _x_main_module_60 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 59));
+auto _x_main_module_61 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 60));
+auto _x_main_module_62 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 61)));
+auto _x_main_module_63 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 62));
+auto _x_main_module_64 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 63)));
+auto _x_main_module_65 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 64));
+auto _x_main_module_66 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 65));
+auto _x_main_module_67 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 66)));
+auto _x_main_module_68 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 67));
+auto _x_main_module_69 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 68)));
+auto _x_main_module_70 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 69));
+auto _x_main_module_71 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 70));
+auto _x_main_module_72 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 71));
+auto _x_main_module_73 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 72));
+auto _x_main_module_74 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 73)));
+auto _x_main_module_75 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 74));
+auto _x_main_module_76 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 75));
+auto _x_main_module_77 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 76)));
+auto _x_main_module_78 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 77));
+auto _x_main_module_79 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 78)));
+auto _x_main_module_80 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 79));
+auto _x_main_module_81 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 80));
+auto _x_main_module_82 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 81)));
+auto _x_main_module_83 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 82));
+auto _x_main_module_84 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 83)));
+auto _x_main_module_85 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 84));
+auto _x_main_module_86 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 85));
+auto _x_main_module_87 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 86));
+auto _x_main_module_88 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 87));
+auto _x_main_module_89 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 88)));
+auto _x_main_module_90 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 89));
+auto _x_main_module_91 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 90));
+auto _x_main_module_92 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 91)));
+auto _x_main_module_93 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 92));
+auto _x_main_module_94 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 93)));
+auto _x_main_module_95 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 94));
+auto _x_main_module_96 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 95));
+auto _x_main_module_97 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 96)));
+auto _x_main_module_98 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 97));
+auto _x_main_module_99 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 98)));
+auto _x_main_module_100 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 99));
+auto _x_main_module_101 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 100));
+auto _x_main_module_102 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 101));
+auto _x_main_module_103 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 102));
+auto _x_main_module_104 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 103)));
+auto _x_main_module_105 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 104));
+auto _x_main_module_106 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 105));
+auto _x_main_module_107 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 106)));
+auto _x_main_module_108 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 107));
+auto _x_main_module_109 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 108)));
+auto _x_main_module_110 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 109));
+auto _x_main_module_111 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 110));
+auto _x_main_module_112 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 111)));
+auto _x_main_module_113 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 112));
+auto _x_main_module_114 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 113)));
+auto _x_main_module_115 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 114));
+auto _x_main_module_116 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 115));
+auto _x_main_module_117 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 116));
+auto _x_main_module_118 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 117));
+auto _x_main_module_119 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 118)));
+auto _x_main_module_120 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 119));
+auto _x_main_module_121 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 120));
+auto _x_main_module_122 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 121)));
+auto _x_main_module_123 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 122));
+auto _x_main_module_124 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 123)));
+auto _x_main_module_125 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 124));
+auto _x_main_module_126 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 125));
+auto _x_main_module_127 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 126)));
+auto _x_main_module_128 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 1024, 1, 1}}, 127));
+auto _x_main_module_129 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 128)));
+auto _x_main_module_130 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 129));
+auto _x_main_module_131 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 130));
+auto _x_main_module_132 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 131));
+auto _x_main_module_133 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 512, 1, 1}}, 132));
+auto _x_main_module_134 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 133)));
+auto _x_main_module_135 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 134));
+auto _x_main_module_136 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 135));
+auto _x_main_module_137 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024}}, 136));
+auto _x_main_module_138 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {1024, 256, 1, 1}}, 137));
+auto _x_main_module_139 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 138)));
+auto _x_main_module_140 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 139));
+auto _x_main_module_141 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 140));
+auto _x_main_module_142 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 141)));
+auto _x_main_module_143 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 256, 3, 3}}, 142));
+auto _x_main_module_144 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 143)));
+auto _x_main_module_145 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 144));
+auto _x_main_module_146 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 145));
+auto _x_main_module_147 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 146)));
+auto _x_main_module_148 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 512, 1, 1}}, 147));
+auto _x_main_module_149 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 148)));
+auto _x_main_module_150 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 149));
+auto _x_main_module_151 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 150));
+auto _x_main_module_152 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 151));
+auto _x_main_module_153 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 152));
+auto _x_main_module_154 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 153)));
+auto _x_main_module_155 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 154));
+auto _x_main_module_156 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 155));
+auto _x_main_module_157 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 156)));
+auto _x_main_module_158 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 157));
+auto _x_main_module_159 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 158)));
+auto _x_main_module_160 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 159));
+auto _x_main_module_161 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 160));
+auto _x_main_module_162 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 161)));
+auto _x_main_module_163 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 162));
+auto _x_main_module_164 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 163)));
+auto _x_main_module_165 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 164));
+auto _x_main_module_166 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 165));
+auto _x_main_module_167 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 166));
+auto _x_main_module_168 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 167));
+auto _x_main_module_169 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 168)));
+auto _x_main_module_170 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 169));
+auto _x_main_module_171 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 170));
+auto _x_main_module_172 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 171)));
+auto _x_main_module_173 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 172));
+auto _x_main_module_174 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 173)));
+auto _x_main_module_175 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 174));
+auto _x_main_module_176 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 175));
+auto _x_main_module_177 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 176)));
+auto _x_main_module_178 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 177));
+auto _x_main_module_179 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 178)));
+auto _x_main_module_180 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 179));
+auto _x_main_module_181 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 180));
+auto _x_main_module_182 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 181));
+auto _x_main_module_183 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 182));
+auto _x_main_module_184 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 183)));
+auto _x_main_module_185 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 184));
+auto _x_main_module_186 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 185));
+auto _x_main_module_187 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 186)));
+auto _x_main_module_188 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 187));
+auto _x_main_module_189 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 188)));
+auto _x_main_module_190 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 189));
+auto _x_main_module_191 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 190));
+auto _x_main_module_192 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 191)));
+auto _x_main_module_193 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 512, 1, 1}}, 192));
+auto _x_main_module_194 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 193)));
+auto _x_main_module_195 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 194));
+auto _x_main_module_196 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 195));
+auto _x_main_module_197 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 196));
+auto _x_main_module_198 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 256, 1, 1}}, 197));
+auto _x_main_module_199 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 198)));
+auto _x_main_module_200 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 199));
+auto _x_main_module_201 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 200));
+auto _x_main_module_202 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512}}, 201));
+auto _x_main_module_203 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {512, 128, 1, 1}}, 202));
+auto _x_main_module_204 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 203)));
+auto _x_main_module_205 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 204));
+auto _x_main_module_206 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 205));
+auto _x_main_module_207 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 206)));
+auto _x_main_module_208 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 128, 3, 3}}, 207));
+auto _x_main_module_209 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 208)));
+auto _x_main_module_210 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 209));
+auto _x_main_module_211 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 210));
+auto _x_main_module_212 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128}}, 211)));
+auto _x_main_module_213 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {128, 256, 1, 1}}, 212));
+auto _x_main_module_214 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 213)));
+auto _x_main_module_215 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 214));
+auto _x_main_module_216 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 215));
+auto _x_main_module_217 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 216));
+auto _x_main_module_218 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 217));
+auto _x_main_module_219 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 218)));
+auto _x_main_module_220 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 219));
+auto _x_main_module_221 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 220));
+auto _x_main_module_222 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 221)));
+auto _x_main_module_223 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 222));
+auto _x_main_module_224 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 223)));
+auto _x_main_module_225 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 224));
+auto _x_main_module_226 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 225));
+auto _x_main_module_227 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 226)));
+auto _x_main_module_228 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 227));
+auto _x_main_module_229 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 228)));
+auto _x_main_module_230 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 229));
+auto _x_main_module_231 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 230));
+auto _x_main_module_232 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 231));
+auto _x_main_module_233 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 232));
+auto _x_main_module_234 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 233)));
+auto _x_main_module_235 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 234));
+auto _x_main_module_236 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 235));
+auto _x_main_module_237 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 236)));
+auto _x_main_module_238 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 237));
+auto _x_main_module_239 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 238)));
+auto _x_main_module_240 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 239));
+auto _x_main_module_241 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 240));
+auto _x_main_module_242 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 241)));
+auto _x_main_module_243 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 256, 1, 1}}, 242));
+auto _x_main_module_244 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 243)));
+auto _x_main_module_245 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 244));
+auto _x_main_module_246 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 245));
+auto _x_main_module_247 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 246));
+auto _x_main_module_248 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 247));
+auto _x_main_module_249 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 248)));
+auto _x_main_module_250 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 249));
+auto _x_main_module_251 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 250));
+auto _x_main_module_252 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256}}, 251));
+auto _x_main_module_253 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {256, 64, 1, 1}}, 252));
+auto _x_main_module_254 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 253)));
+auto _x_main_module_255 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 254));
+auto _x_main_module_256 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 255));
+auto _x_main_module_257 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 256)));
+auto _x_main_module_258 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 3, 3}}, 257));
+auto _x_main_module_259 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 258)));
+auto _x_main_module_260 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 259));
+auto _x_main_module_261 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 260));
+auto _x_main_module_262 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 261)));
+auto _x_main_module_263 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 64, 1, 1}}, 262));
+auto _x_main_module_264 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 263)));
+auto _x_main_module_265 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 264));
+auto _x_main_module_266 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 265));
+auto _x_main_module_267 = mmain->add_literal(migraphx::abs(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64}}, 266)));
+auto _x_main_module_268 = mmain->add_literal(migraphx::generate_literal(migraphx::shape{migraphx::shape::float_type, {64, 3, 7, 7}}, 267));
+auto _x_main_module_269 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[3,3,3,3],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_0, _x_main_module_268);
+auto _x_main_module_270 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_269, _x_main_module_267, _x_main_module_266, _x_main_module_265, _x_main_module_264);
+auto _x_main_module_271 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_270);
+auto _x_main_module_272 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[3,3],\"lp_order\":2,\"mode\":1,\"padding\":[1,1,1,1],\"stride\":[2,2]}")), _x_main_module_271);
+auto _x_main_module_273 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_272, _x_main_module_263);
+auto _x_main_module_274 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_273, _x_main_module_262, _x_main_module_261, _x_main_module_260, _x_main_module_259);
+auto _x_main_module_275 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_274);
+auto _x_main_module_276 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_275, _x_main_module_258);
+auto _x_main_module_277 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_276, _x_main_module_257, _x_main_module_256, _x_main_module_255, _x_main_module_254);
+auto _x_main_module_278 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_277);
+auto _x_main_module_279 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_278, _x_main_module_253);
+auto _x_main_module_280 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_279, _x_main_module_252, _x_main_module_251, _x_main_module_250, _x_main_module_249);
+auto _x_main_module_281 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_272, _x_main_module_248);
+auto _x_main_module_282 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_281, _x_main_module_247, _x_main_module_246, _x_main_module_245, _x_main_module_244);
+auto _x_main_module_283 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_280, _x_main_module_282);
+auto _x_main_module_284 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_283);
+auto _x_main_module_285 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_284, _x_main_module_243);
+auto _x_main_module_286 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_285, _x_main_module_242, _x_main_module_241, _x_main_module_240, _x_main_module_239);
+auto _x_main_module_287 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_286);
+auto _x_main_module_288 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_287, _x_main_module_238);
+auto _x_main_module_289 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_288, _x_main_module_237, _x_main_module_236, _x_main_module_235, _x_main_module_234);
+auto _x_main_module_290 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_289);
+auto _x_main_module_291 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_290, _x_main_module_233);
+auto _x_main_module_292 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_291, _x_main_module_232, _x_main_module_231, _x_main_module_230, _x_main_module_229);
+auto _x_main_module_293 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_292, _x_main_module_284);
+auto _x_main_module_294 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_293);
+auto _x_main_module_295 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_294, _x_main_module_228);
+auto _x_main_module_296 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_295, _x_main_module_227, _x_main_module_226, _x_main_module_225, _x_main_module_224);
+auto _x_main_module_297 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_296);
+auto _x_main_module_298 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_297, _x_main_module_223);
+auto _x_main_module_299 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_298, _x_main_module_222, _x_main_module_221, _x_main_module_220, _x_main_module_219);
+auto _x_main_module_300 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_299);
+auto _x_main_module_301 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_300, _x_main_module_218);
+auto _x_main_module_302 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_301, _x_main_module_217, _x_main_module_216, _x_main_module_215, _x_main_module_214);
+auto _x_main_module_303 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_302, _x_main_module_294);
+auto _x_main_module_304 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_303);
+auto _x_main_module_305 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_304, _x_main_module_213);
+auto _x_main_module_306 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_305, _x_main_module_212, _x_main_module_211, _x_main_module_210, _x_main_module_209);
+auto _x_main_module_307 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_306);
+auto _x_main_module_308 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_307, _x_main_module_208);
+auto _x_main_module_309 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_308, _x_main_module_207, _x_main_module_206, _x_main_module_205, _x_main_module_204);
+auto _x_main_module_310 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_309);
+auto _x_main_module_311 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_310, _x_main_module_203);
+auto _x_main_module_312 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_311, _x_main_module_202, _x_main_module_201, _x_main_module_200, _x_main_module_199);
+auto _x_main_module_313 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_304, _x_main_module_198);
+auto _x_main_module_314 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_313, _x_main_module_197, _x_main_module_196, _x_main_module_195, _x_main_module_194);
+auto _x_main_module_315 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_312, _x_main_module_314);
+auto _x_main_module_316 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_315);
+auto _x_main_module_317 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_316, _x_main_module_193);
+auto _x_main_module_318 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_317, _x_main_module_192, _x_main_module_191, _x_main_module_190, _x_main_module_189);
+auto _x_main_module_319 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_318);
+auto _x_main_module_320 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_319, _x_main_module_188);
+auto _x_main_module_321 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_320, _x_main_module_187, _x_main_module_186, _x_main_module_185, _x_main_module_184);
+auto _x_main_module_322 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_321);
+auto _x_main_module_323 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_322, _x_main_module_183);
+auto _x_main_module_324 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_323, _x_main_module_182, _x_main_module_181, _x_main_module_180, _x_main_module_179);
+auto _x_main_module_325 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_324, _x_main_module_316);
+auto _x_main_module_326 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_325);
+auto _x_main_module_327 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_326, _x_main_module_178);
+auto _x_main_module_328 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_327, _x_main_module_177, _x_main_module_176, _x_main_module_175, _x_main_module_174);
+auto _x_main_module_329 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_328);
+auto _x_main_module_330 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_329, _x_main_module_173);
+auto _x_main_module_331 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_330, _x_main_module_172, _x_main_module_171, _x_main_module_170, _x_main_module_169);
+auto _x_main_module_332 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_331);
+auto _x_main_module_333 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_332, _x_main_module_168);
+auto _x_main_module_334 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_333, _x_main_module_167, _x_main_module_166, _x_main_module_165, _x_main_module_164);
+auto _x_main_module_335 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_334, _x_main_module_326);
+auto _x_main_module_336 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_335);
+auto _x_main_module_337 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_336, _x_main_module_163);
+auto _x_main_module_338 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_337, _x_main_module_162, _x_main_module_161, _x_main_module_160, _x_main_module_159);
+auto _x_main_module_339 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_338);
+auto _x_main_module_340 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_339, _x_main_module_158);
+auto _x_main_module_341 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_340, _x_main_module_157, _x_main_module_156, _x_main_module_155, _x_main_module_154);
+auto _x_main_module_342 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_341);
+auto _x_main_module_343 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_342, _x_main_module_153);
+auto _x_main_module_344 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_343, _x_main_module_152, _x_main_module_151, _x_main_module_150, _x_main_module_149);
+auto _x_main_module_345 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_344, _x_main_module_336);
+auto _x_main_module_346 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_345);
+auto _x_main_module_347 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_346, _x_main_module_148);
+auto _x_main_module_348 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_347, _x_main_module_147, _x_main_module_146, _x_main_module_145, _x_main_module_144);
+auto _x_main_module_349 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_348);
+auto _x_main_module_350 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_349, _x_main_module_143);
+auto _x_main_module_351 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_350, _x_main_module_142, _x_main_module_141, _x_main_module_140, _x_main_module_139);
+auto _x_main_module_352 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_351);
+auto _x_main_module_353 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_352, _x_main_module_138);
+auto _x_main_module_354 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_353, _x_main_module_137, _x_main_module_136, _x_main_module_135, _x_main_module_134);
+auto _x_main_module_355 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_346, _x_main_module_133);
+auto _x_main_module_356 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_355, _x_main_module_132, _x_main_module_131, _x_main_module_130, _x_main_module_129);
+auto _x_main_module_357 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_354, _x_main_module_356);
+auto _x_main_module_358 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_357);
+auto _x_main_module_359 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_358, _x_main_module_128);
+auto _x_main_module_360 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_359, _x_main_module_127, _x_main_module_126, _x_main_module_125, _x_main_module_124);
+auto _x_main_module_361 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_360);
+auto _x_main_module_362 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_361, _x_main_module_123);
+auto _x_main_module_363 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_362, _x_main_module_122, _x_main_module_121, _x_main_module_120, _x_main_module_119);
+auto _x_main_module_364 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_363);
+auto _x_main_module_365 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_364, _x_main_module_118);
+auto _x_main_module_366 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_365, _x_main_module_117, _x_main_module_116, _x_main_module_115, _x_main_module_114);
+auto _x_main_module_367 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_366, _x_main_module_358);
+auto _x_main_module_368 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_367);
+auto _x_main_module_369 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_368, _x_main_module_113);
+auto _x_main_module_370 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_369, _x_main_module_112, _x_main_module_111, _x_main_module_110, _x_main_module_109);
+auto _x_main_module_371 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_370);
+auto _x_main_module_372 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_371, _x_main_module_108);
+auto _x_main_module_373 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_372, _x_main_module_107, _x_main_module_106, _x_main_module_105, _x_main_module_104);
+auto _x_main_module_374 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_373);
+auto _x_main_module_375 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_374, _x_main_module_103);
+auto _x_main_module_376 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_375, _x_main_module_102, _x_main_module_101, _x_main_module_100, _x_main_module_99);
+auto _x_main_module_377 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_376, _x_main_module_368);
+auto _x_main_module_378 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_377);
+auto _x_main_module_379 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_378, _x_main_module_98);
+auto _x_main_module_380 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_379, _x_main_module_97, _x_main_module_96, _x_main_module_95, _x_main_module_94);
+auto _x_main_module_381 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_380);
+auto _x_main_module_382 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_381, _x_main_module_93);
+auto _x_main_module_383 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_382, _x_main_module_92, _x_main_module_91, _x_main_module_90, _x_main_module_89);
+auto _x_main_module_384 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_383);
+auto _x_main_module_385 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_384, _x_main_module_88);
+auto _x_main_module_386 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_385, _x_main_module_87, _x_main_module_86, _x_main_module_85, _x_main_module_84);
+auto _x_main_module_387 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_386, _x_main_module_378);
+auto _x_main_module_388 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_387);
+auto _x_main_module_389 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_388, _x_main_module_83);
+auto _x_main_module_390 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_389, _x_main_module_82, _x_main_module_81, _x_main_module_80, _x_main_module_79);
+auto _x_main_module_391 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_390);
+auto _x_main_module_392 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_391, _x_main_module_78);
+auto _x_main_module_393 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_392, _x_main_module_77, _x_main_module_76, _x_main_module_75, _x_main_module_74);
+auto _x_main_module_394 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_393);
+auto _x_main_module_395 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_394, _x_main_module_73);
+auto _x_main_module_396 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_395, _x_main_module_72, _x_main_module_71, _x_main_module_70, _x_main_module_69);
+auto _x_main_module_397 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_396, _x_main_module_388);
+auto _x_main_module_398 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_397);
+auto _x_main_module_399 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_398, _x_main_module_68);
+auto _x_main_module_400 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_399, _x_main_module_67, _x_main_module_66, _x_main_module_65, _x_main_module_64);
+auto _x_main_module_401 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_400);
+auto _x_main_module_402 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_401, _x_main_module_63);
+auto _x_main_module_403 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_402, _x_main_module_62, _x_main_module_61, _x_main_module_60, _x_main_module_59);
+auto _x_main_module_404 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_403);
+auto _x_main_module_405 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_404, _x_main_module_58);
+auto _x_main_module_406 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_405, _x_main_module_57, _x_main_module_56, _x_main_module_55, _x_main_module_54);
+auto _x_main_module_407 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_406, _x_main_module_398);
+auto _x_main_module_408 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_407);
+auto _x_main_module_409 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_408, _x_main_module_53);
+auto _x_main_module_410 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_409, _x_main_module_52, _x_main_module_51, _x_main_module_50, _x_main_module_49);
+auto _x_main_module_411 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_410);
+auto _x_main_module_412 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_411, _x_main_module_48);
+auto _x_main_module_413 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_412, _x_main_module_47, _x_main_module_46, _x_main_module_45, _x_main_module_44);
+auto _x_main_module_414 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_413);
+auto _x_main_module_415 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_414, _x_main_module_43);
+auto _x_main_module_416 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_415, _x_main_module_42, _x_main_module_41, _x_main_module_40, _x_main_module_39);
+auto _x_main_module_417 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[2,2],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_408, _x_main_module_38);
+auto _x_main_module_418 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_417, _x_main_module_37, _x_main_module_36, _x_main_module_35, _x_main_module_34);
+auto _x_main_module_419 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_416, _x_main_module_418);
+auto _x_main_module_420 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_419);
+auto _x_main_module_421 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_420, _x_main_module_33);
+auto _x_main_module_422 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_421, _x_main_module_32, _x_main_module_31, _x_main_module_30, _x_main_module_29);
+auto _x_main_module_423 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_422);
+auto _x_main_module_424 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_423, _x_main_module_28);
+auto _x_main_module_425 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_424, _x_main_module_27, _x_main_module_26, _x_main_module_25, _x_main_module_24);
+auto _x_main_module_426 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_425);
+auto _x_main_module_427 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_426, _x_main_module_23);
+auto _x_main_module_428 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_427, _x_main_module_22, _x_main_module_21, _x_main_module_20, _x_main_module_19);
+auto _x_main_module_429 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_428, _x_main_module_420);
+auto _x_main_module_430 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_429);
+auto _x_main_module_431 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_430, _x_main_module_18);
+auto _x_main_module_432 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_431, _x_main_module_17, _x_main_module_16, _x_main_module_15, _x_main_module_14);
+auto _x_main_module_433 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_432);
+auto _x_main_module_434 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[1,1,1,1],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_433, _x_main_module_13);
+auto _x_main_module_435 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_434, _x_main_module_12, _x_main_module_11, _x_main_module_10, _x_main_module_9);
+auto _x_main_module_436 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_435);
+auto _x_main_module_437 = mmain->add_instruction(migraphx::make_op("convolution", migraphx::from_json_string("{\"dilation\":[1,1],\"group\":1,\"padding\":[0,0,0,0],\"padding_mode\":0,\"stride\":[1,1],\"use_dynamic_same_auto_pad\":0}")), _x_main_module_436, _x_main_module_8);
+auto _x_main_module_438 = mmain->add_instruction(migraphx::make_op("batch_norm_inference", migraphx::from_json_string("{\"bn_mode\":1,\"epsilon\":9.999999747378752e-06,\"momentum\":0.8999999761581421}")), _x_main_module_437, _x_main_module_7, _x_main_module_6, _x_main_module_5, _x_main_module_4);
+auto _x_main_module_439 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_438, _x_main_module_430);
+auto _x_main_module_440 = mmain->add_instruction(migraphx::make_op("relu"), _x_main_module_439);
+auto _x_main_module_441 = mmain->add_instruction(migraphx::make_op("pooling", migraphx::from_json_string("{\"ceil_mode\":0,\"lengths\":[7,7],\"lp_order\":2,\"mode\":0,\"padding\":[0,0,0,0],\"stride\":[1,1]}")), _x_main_module_440);
+auto _x_main_module_442 = mmain->add_instruction(migraphx::make_op("flatten", migraphx::from_json_string("{\"axis\":1}")), _x_main_module_441);
+auto _x_main_module_443 = mmain->add_instruction(migraphx::make_op("transpose", migraphx::from_json_string("{\"permutation\":[1,0]}")), _x_main_module_3);
+auto _x_main_module_444 = mmain->add_instruction(migraphx::make_op("dot"), _x_main_module_442, _x_main_module_443);
+auto _x_main_module_445 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), _x_main_module_2);
+auto _x_main_module_446 = mmain->add_instruction(migraphx::make_op("multibroadcast", migraphx::from_json_string("{\"out_lens\":[1,1000]}")), _x_main_module_0);
+auto _x_main_module_447 = mmain->add_instruction(migraphx::make_op("mul"), _x_main_module_445, _x_main_module_446);
+auto _x_main_module_448 = mmain->add_instruction(migraphx::make_op("add"), _x_main_module_444, _x_main_module_447);
+mmain->add_return({_x_main_module_448});
+
 
     return p;
 }

--- a/src/include/migraphx/make_op.hpp
+++ b/src/include/migraphx/make_op.hpp
@@ -48,7 +48,7 @@ operation make_op(const std::string& name, const Value& v)
     return make_op_from_value(name, v);
 }
 
-operation make_json_op(const std::string& name, const std::string& str);
+operation make_json_op(const std::string& name, const std::string& s);
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/include/migraphx/make_op.hpp
+++ b/src/include/migraphx/make_op.hpp
@@ -27,6 +27,8 @@
 #include <migraphx/config.hpp>
 #include <migraphx/operation.hpp>
 #include <migraphx/value.hpp>
+#include <migraphx/json.hpp>
+#include <migraphx/convert_to_json.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -45,6 +47,8 @@ operation make_op(const std::string& name, const Value& v)
 {
     return make_op_from_value(name, v);
 }
+
+operation make_json_op(const std::string& name, const std::string& str);
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/make_op.cpp
+++ b/src/make_op.cpp
@@ -64,5 +64,10 @@ operation make_op_from_value(const std::string& name, const value& v)
     });
 }
 
+operation make_json_op(const std::string& name, const std::string& s)
+{
+    return make_op(name, from_json_string(convert_to_json(s)));
+}
+
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -788,12 +788,16 @@ static std::string cpp_var_name(const std::string& name)
 
 static void print_make_op(std::ostream& os, const operation& op)
 {
-    os << "migraphx::make_op(" << enclose_name(op.name());
     auto v = op.to_value();
     if(not v.empty())
     {
+            os << "migraphx::make_json_op(" << enclose_name(op.name());
         os << ", "
-           << "migraphx::from_json_string(" << enclose_name(to_json_string(v)) << ")";
+           << enclose_name(to_json_string(v));
+    }        
+    else
+    {
+        os << "migraphx::make_op(" << enclose_name(op.name());
     }
     os << ")";
 }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -783,7 +783,7 @@ static std::string to_c_id(const std::string& name, char rep = '_')
 
 static std::string cpp_var_name(const std::string& name)
 {
-    return to_c_id("\"x_\"" + replace_string(name, ":", "_module_"));
+    return to_c_id("x_" + replace_string(name, ":", "_module_"));
 }
 
 static void print_make_op(std::ostream& os, const operation& op)

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -783,7 +783,7 @@ static std::string to_c_id(const std::string& name, char rep = '_')
 
 static std::string cpp_var_name(const std::string& name)
 {
-    return to_c_id("x_" + replace_string(name, ":", "_module_"));
+    return to_c_id("\"x_\"" + replace_string(name, ":", "_module_"));
 }
 
 static void print_make_op(std::ostream& os, const operation& op)

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -791,10 +791,9 @@ static void print_make_op(std::ostream& os, const operation& op)
     auto v = op.to_value();
     if(not v.empty())
     {
-            os << "migraphx::make_json_op(" << enclose_name(op.name());
-        os << ", "
-           << enclose_name(to_json_string(v));
-    }        
+        os << "migraphx::make_json_op(" << enclose_name(op.name());
+        os << ", " << enclose_name(to_json_string(v));
+    }
     else
     {
         os << "migraphx::make_op(" << enclose_name(op.name());


### PR DESCRIPTION
The previous change to use json strings was throwing exceptions because the keys were not enclosed in quotes. This generates the correct json strings.