### PR TITLE
Run performance benchmarks on PRs

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -1,11 +1,9 @@
 name: MIGraphX Performance Tests
 
 on:
-  push:
-    branches: [develop]
-
   pull_request:
     branches: [develop]
+    types: [opened, synchronize, closed]
   schedule:
     - cron: "0 5 * * 1-6"
 


### PR DESCRIPTION
Remove running during a Push but run the benchmark suite on a pull 