### PR TITLE
Fix test suite compile in Ubuntu 22.04

### DIFF
--- a/src/include/migraphx/target_assignments.hpp
+++ b/src/include/migraphx/target_assignments.hpp
@@ -25,6 +25,7 @@
 #define MIGRAPHX_GUARD_MIGRAPHX_ASSIGNMENT_HPP
 
 #include <unordered_map>
+#include <string>
 
 #include <migraphx/instruction_ref.hpp>
 


### PR DESCRIPTION
Fixes a compile issue for `make check` target on Ubuntu 22.04 with sccache disabled.