### PR TITLE
Fix split_reshape for slice len of 1

### DIFF
--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -985,32 +985,36 @@ struct find_split_reshape
         auto rsp_lens    = rsp->get_shape().lens();
         auto rsp_strides = rsp->get_shape().strides();
         rsp_strides.insert(rsp_strides.begin(), rsp_strides[0] * rsp_lens[0]);
-        
-        auto ait = std::find(rsp_strides.begin(), rsp_strides.end(), slc_dim_size);
+
+        auto ait     = std::find(rsp_strides.begin(), rsp_strides.end(), slc_dim_size);
         int rsp_axis = -1;
         if(ait == rsp_strides.end())
         {
             return;
-        } else if(ait == rsp_strides.end()-1) { 
+        }
+        else if(ait == rsp_strides.end() - 1)
+        {
             // edge case
-            // slice_dim == 1, in that case it would match with last stride of 1. 
-            // it should accumulate lengths from last dim in that case. discount 1 to avoid going out of bounds. 
-            rsp_axis = std::distance(rsp_strides.begin(), ait)-1;
-        } else {
+            // slice_dim == 1, in that case it would match with last stride of 1.
+            // it should accumulate lengths from last dim in that case. discount 1 to avoid going
+            // out of bounds.
+            rsp_axis = std::distance(rsp_strides.begin(), ait) - 1;
+        }
+        else
+        {
             rsp_axis = std::distance(rsp_strides.begin(), ait);
         }
         // calculate reshape output shape
         std::vector<int64_t> vec_dims(vec_rsp.size());
-       
+
         std::transform(vec_rsp.begin(), vec_rsp.end(), vec_dims.begin(), [&](auto is) {
             return is->get_shape().lens()[rsp_axis];
         });
-       
+
         std::vector<int64_t> rsp_out_lens(rsp_lens.begin(), rsp_lens.end());
-        
 
         rsp_out_lens[rsp_axis] = std::accumulate(vec_dims.begin(), vec_dims.end(), std::int64_t{0});
-      
+
         // insert the reshape instruction and add contiguous if needed
         if(not input->get_shape().standard())
         {

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -995,7 +995,7 @@ struct find_split_reshape
         else if(ait == rsp_strides.end() - 1)
         {
             // edge case
-            // slice_dim == 1, in that case it would match with last stride of 1.
+            // slice_dim == 1, in that case it could match with last stride of 1.
             // it should accumulate lengths from last dim in that case. discount 1 to avoid going
             // out of bounds.
             rsp_axis = std::distance(rsp_strides.begin(), ait) - 1;

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -998,6 +998,7 @@ struct find_split_reshape
             // slice_dim == 1, in that case it could match with last stride of 1.
             // it should accumulate lengths from last dim in that case. discount 1 to avoid going
             // out of bounds.
+            assert(slc_dim_size == 1);
             rsp_axis = std::distance(rsp_strides.begin(), ait) - 1;
         }
         else

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -985,22 +985,32 @@ struct find_split_reshape
         auto rsp_lens    = rsp->get_shape().lens();
         auto rsp_strides = rsp->get_shape().strides();
         rsp_strides.insert(rsp_strides.begin(), rsp_strides[0] * rsp_lens[0]);
+        
         auto ait = std::find(rsp_strides.begin(), rsp_strides.end(), slc_dim_size);
+        int rsp_axis = -1;
         if(ait == rsp_strides.end())
         {
             return;
+        } else if(ait == rsp_strides.end()-1) { 
+            // edge case
+            // slice_dim == 1, in that case it would match with last stride of 1. 
+            // it should accumulate lengths from last dim in that case. discount 1 to avoid going out of bounds. 
+            rsp_axis = std::distance(rsp_strides.begin(), ait)-1;
+        } else {
+            rsp_axis = std::distance(rsp_strides.begin(), ait);
         }
-        int rsp_axis = std::distance(rsp_strides.begin(), ait);
-
         // calculate reshape output shape
         std::vector<int64_t> vec_dims(vec_rsp.size());
+       
         std::transform(vec_rsp.begin(), vec_rsp.end(), vec_dims.begin(), [&](auto is) {
             return is->get_shape().lens()[rsp_axis];
         });
-
+       
         std::vector<int64_t> rsp_out_lens(rsp_lens.begin(), rsp_lens.end());
-        rsp_out_lens[rsp_axis] = std::accumulate(vec_dims.begin(), vec_dims.end(), std::int64_t{0});
+        
 
+        rsp_out_lens[rsp_axis] = std::accumulate(vec_dims.begin(), vec_dims.end(), std::int64_t{0});
+      
         // insert the reshape instruction and add contiguous if needed
         if(not input->get_shape().standard())
         {

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -2077,7 +2077,8 @@ TEST_CASE(reorder_reshape_slice_move_axis2)
     EXPECT(m1.sort() == m2.sort());
 }
 
-TEST_CASE(reorder_reshape_slice_len_1) {
+TEST_CASE(reorder_reshape_slice_len_1)
+{
     migraphx::module m1;
     {
         migraphx::shape s{migraphx::shape::float_type, {1, 128, 3}};
@@ -2123,7 +2124,6 @@ TEST_CASE(reorder_reshape_slice_len_1) {
 
     run_pass(m1);
     EXPECT(m1.sort() == m2.sort());
-
 }
 
 TEST_CASE(reorder_reshape_slice_not_apply)

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -2077,6 +2077,55 @@ TEST_CASE(reorder_reshape_slice_move_axis2)
     EXPECT(m1.sort() == m2.sort());
 }
 
+TEST_CASE(reorder_reshape_slice_len_1) {
+    migraphx::module m1;
+    {
+        migraphx::shape s{migraphx::shape::float_type, {1, 128, 3}};
+        auto input = m1.add_parameter("input", s);
+        auto slc0  = m1.add_instruction(
+            migraphx::make_op("slice", {{"axes", {2}}, {"starts", {0}}, {"ends", {1}}}), input);
+        auto slc1 = m1.add_instruction(
+            migraphx::make_op("slice", {{"axes", {2}}, {"starts", {1}}, {"ends", {2}}}), input);
+        auto slc2 = m1.add_instruction(
+            migraphx::make_op("slice", {{"axes", {2}}, {"starts", {2}}, {"ends", {3}}}), input);
+
+        auto c0 = m1.add_instruction(migraphx::make_op("contiguous"), slc0);
+        auto c1 = m1.add_instruction(migraphx::make_op("contiguous"), slc1);
+        auto c2 = m1.add_instruction(migraphx::make_op("contiguous"), slc2);
+
+        std::vector<int64_t> lens = {1, 128};
+        auto r0 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c0);
+        auto r1 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c1);
+        auto r2 = m1.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), c2);
+
+        auto sum = m1.add_instruction(migraphx::make_op("add"), r0, r1);
+        auto ret = m1.add_instruction(migraphx::make_op("mul"), sum, r2);
+        m1.add_return({ret});
+    };
+
+    migraphx::module m2;
+    {
+        auto s                    = migraphx::shape{migraphx::shape::float_type, {1, 128, 3}};
+        auto input                = m2.add_parameter("input", s);
+        std::vector<int64_t> lens = {1, 384};
+        auto rsp  = m2.add_instruction(migraphx::make_op("reshape", {{"dims", lens}}), input);
+        auto slc0 = m2.add_instruction(
+            migraphx::make_op("slice", {{"axes", {1}}, {"starts", {0}}, {"ends", {128}}}), rsp);
+        auto slc1 = m2.add_instruction(
+            migraphx::make_op("slice", {{"axes", {1}}, {"starts", {128}}, {"ends", {256}}}), rsp);
+        auto slc2 = m2.add_instruction(
+            migraphx::make_op("slice", {{"axes", {1}}, {"starts", {256}}, {"ends", {384}}}), rsp);
+
+        auto sum = m2.add_instruction(migraphx::make_op("add"), slc0, slc1);
+        auto ret = m2.add_instruction(migraphx::make_op("mul"), sum, slc2);
+        m2.add_return({ret});
+    };
+
+    run_pass(m1);
+    EXPECT(m1.sort() == m2.sort());
+
+}
+
 TEST_CASE(reorder_reshape_slice_not_apply)
 {
     auto create_p = [] {


### PR DESCRIPTION
If the slice is of length 1 then, it would match with stride of 1 at the last dimension, which would cause reshape_lengths calculation to go out of  bounds in current logic. 
This fix checks for this case and calcualtes reshape axis accordingly. 