### PR TITLE
Multibroadcast find_mul_conv

### DIFF
--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -84,24 +84,26 @@ struct find_mul_conv
         // check broadcasted along channels
         auto a_lens    = a_ins->get_shape().lens();
         auto a_strides = a_ins->get_shape().strides();
-        // handle case of stride = 1 and len = 1
+        // handle len = 1 case
         auto invalid_sl = [&](std::size_t i) {
             if(a_strides[i] != 0)
             {
-                if(a_strides[i] == 1 and a_lens[i] == 1)
+                if(a_lens[i] == 1)
+                {
                     return false;
+                }
                 return true;
             }
             return false;
         };
-        auto check = false;
+        auto invalid_case = false;
         for(int i = 2; i < a_lens.size(); ++i)
         {
             if(invalid_sl(i))
-                check = true;
+                invalid_case = true;
         }
 
-        if(invalid_sl(0) or a_strides.at(1) != 1 or check)
+        if(invalid_sl(0) or a_strides.at(1) != 1 or invalid_case)
             return;
 
         auto sq    = m.insert_instruction(ins, make_op("squeeze"), a_ins->inputs().front());

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -74,15 +74,11 @@ struct find_mul_conv
         auto a_ins    = r.instructions["a"];
         auto w_ins    = r.instructions["w"];
 
-        // check that the channels stride is 1
         auto a_shape   = a_ins->get_shape();
-        auto a_lens    = a_shape.lens();
         auto a_strides = a_shape.strides();
-        if(a_strides.at(1) != 1)
-            return;
-        else if(a_strides.at(0) != 0 or std::any_of(a_strides.cbegin() + 2,
-                                                    a_strides.cend(),
-                                                    [](std::size_t i) { return i != 0; }))
+        if(a_strides.at(0) != 0 or a_strides.at(1) != 1 or
+           std::any_of(
+               a_strides.cbegin() + 2, a_strides.cend(), [](std::size_t i) { return i != 0; }))
             return;
 
         auto sq    = m.insert_instruction(ins, make_op("squeeze"), a_ins->inputs().front());

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -57,12 +57,14 @@ auto conv_const_weights()
 
 auto reduction() { return match::name_contains("reduce"); }
 
+// conv(x, w) * a => conv(x, a * w)
 struct find_mul_conv
 {
     auto matcher() const
     {
-        return match::name("mul")(match::either_arg(0, 1)(conv_const_weights().bind("conv"),
-                                                          match::name("broadcast").bind("a")));
+        return match::name("mul")(
+            match::either_arg(0, 1)(conv_const_weights().bind("conv"),
+                                    match::name("broadcast", "multibroadcast").bind("a")));
     }
 
     void apply(module& m, const match::matcher_result& r) const
@@ -72,14 +74,20 @@ struct find_mul_conv
         auto a_ins    = r.instructions["a"];
         auto w_ins    = r.instructions["w"];
 
-        auto broadcast_op = any_cast<op::broadcast>(a_ins->get_operator());
-        if(broadcast_op.axis != 1)
+        // check that the channels stride is 1
+        auto a_shape   = a_ins->get_shape();
+        auto a_lens    = a_shape.lens();
+        auto a_strides = a_shape.strides();
+        if(a_strides.at(1) != 1)
+            return;
+        else if(a_strides.at(0) != 0 or std::any_of(a_strides.cbegin() + 2,
+                                                    a_strides.cend(),
+                                                    [](std::size_t i) { return i != 0; }))
             return;
 
+        auto sq    = m.insert_instruction(ins, make_op("squeeze"), a_ins->inputs().front());
         auto new_a = m.insert_instruction(
-            ins,
-            make_op("broadcast", {{"axis", 0}, {"out_lens", w_ins->get_shape().lens()}}),
-            a_ins->inputs().front());
+            ins, make_op("broadcast", {{"axis", 0}, {"out_lens", w_ins->get_shape().lens()}}), sq);
         auto new_mul  = m.insert_instruction(ins, make_op("mul"), new_a, w_ins);
         auto new_conv = m.insert_instruction(
             ins, conv_ins->get_operator(), conv_ins->inputs().front(), new_mul);

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -88,11 +88,7 @@ struct find_mul_conv
         auto invalid_sl = [&](std::size_t i) {
             if(a_strides[i] != 0)
             {
-                if(a_lens[i] == 1)
-                {
-                    return false;
-                }
-                return true;
+                return a_lens[i] != 1;
             }
             return false;
         };

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -74,8 +74,7 @@ struct find_mul_conv
         auto a_ins    = r.instructions["a"];
         auto w_ins    = r.instructions["w"];
 
-        auto a_shape   = a_ins->get_shape();
-        auto a_strides = a_shape.strides();
+        auto a_strides = a_ins->get_shape().strides();
         if(a_strides.at(0) != 0 or a_strides.at(1) != 1 or
            std::any_of(
                a_strides.cbegin() + 2, a_strides.cend(), [](std::size_t i) { return i != 0; }))

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -74,7 +74,7 @@ struct find_mul_conv
         auto a_ins    = r.instructions["a"];
         auto w_ins    = r.instructions["w"];
 
-        auto a_input_lens = a_ins->inputs().front()->get_shape().lens();
+        const auto& a_input_lens = a_ins->inputs().front()->get_shape().lens();
 
         std::size_t num_not_one_dims = std::count_if(
             a_input_lens.cbegin(), a_input_lens.cend(), [](auto dim) { return dim != 1; });
@@ -82,24 +82,17 @@ struct find_mul_conv
             return;
 
         // check broadcasted along channels
-        auto a_lens    = a_ins->get_shape().lens();
-        auto a_strides = a_ins->get_shape().strides();
-        // handle len = 1 case
-        auto invalid_sl = [&](std::size_t i) {
-            if(a_strides[i] != 0)
-            {
-                return a_lens[i] != 1;
-            }
-            return false;
-        };
-        auto invalid_case = false;
-        for(int i = 2; i < a_lens.size(); ++i)
-        {
-            if(invalid_sl(i))
-                invalid_case = true;
-        }
+        const auto& a_lens    = a_ins->get_shape().lens();
+        const auto& a_strides = a_ins->get_shape().strides();
 
-        if(invalid_sl(0) or a_strides.at(1) != 1 or invalid_case)
+        auto is_broadcasted_axis = [](auto len, auto stride) { return len == 1 or stride == 0; };
+
+        if(a_strides.at(1) != 1 or not is_broadcasted_axis(a_lens.front(), a_strides.front()) or
+           not std::equal(a_lens.begin() + 2,
+                          a_lens.end(),
+                          a_strides.begin() + 2,
+                          a_strides.end(),
+                          is_broadcasted_axis))
             return;
 
         auto sq    = m.insert_instruction(ins, make_op("squeeze"), a_ins->inputs().front());

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -87,8 +87,13 @@ struct find_mul_conv
 
         auto is_broadcasted_axis = [](auto len, auto stride) { return len == 1 or stride == 0; };
 
-        if(a_strides.at(1) != 1 or not is_broadcasted_axis(a_lens.front(), a_strides.front()) or
-           not std::equal(a_lens.begin() + 2,
+        if(a_strides.at(1) != 1)
+            return;
+
+        if(not is_broadcasted_axis(a_lens.front(), a_strides.front()))
+            return;
+
+        if(not std::equal(a_lens.begin() + 2,
                           a_lens.end(),
                           a_strides.begin() + 2,
                           a_strides.end(),

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -260,7 +260,7 @@ TEST_CASE(simplify_mul_conv2)
     EXPECT(new_conv->outputs().front()->name() != "mul");
 }
 
-// stride = 1 and len = 1 case
+// len = 1 case
 TEST_CASE(simplify_mul_conv3)
 {
     migraphx::module m;
@@ -273,7 +273,7 @@ TEST_CASE(simplify_mul_conv3)
         x,
         w);
     auto a = m.add_literal(
-        migraphx::generate_literal({migraphx::shape::int32_type, {256, 1, 1}, {1, 1, 1}}));
+        migraphx::generate_literal({migraphx::shape::int32_type, {256, 1, 1}, {1, 18, 1}}));
     auto b =
         m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {1, 256, 14, 14}}}), a);
     auto mul = m.add_instruction(migraphx::make_op("mul"), conv, b);


### PR DESCRIPTION
Change find_mul_conv to work with multibroadcast also. Checks the strides instead of the broadcast axis.