### PR TITLE
Disabled concurrency for performance action jobs

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -26,8 +26,6 @@ on:
         required: true
         default: '-s'
 
-concurrency: benchmark
-
 jobs:
   release:
     uses: rocmsoftwareplatform/migraphx-benchmark/.github/workflows/perf-test.yml@main


### PR DESCRIPTION
Concurrency with github actions jobs of the performance CI tests where causing jobs to be skipped.  This happened when too many PRs where getting updated and the perf testing couldn't keep up.  This change; along with CI job changes will ensure every PR gets a performance run 