### PR TITLE
fix duplicate declaration error

### DIFF
--- a/src/targets/gpu/kernels/include/migraphx/kernels/index.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/index.hpp
@@ -119,11 +119,6 @@ struct index
         return compute_local_size(); // NOLINT
     }
 #endif
-    template <class N, class Stride>
-    static constexpr auto max_stride_iterations(N n, Stride stride)
-    {
-        return (n - _c<1>) / stride + _c<1>;
-    }
 
 #ifdef MIGRAPHX_NLOCAL
     constexpr index_constant<MIGRAPHX_NLOCAL> max_nlocal() const { return {}; }


### PR DESCRIPTION
While attempting to merge develop in to branch_for_ort this code block was not removed and generated a duplicate declaration of max_stride_iterations