### PR TITLE
update codecov version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -268,7 +268,9 @@ jobs:
         lcov --directory . --capture --output-file $(pwd)/coverage.info
         lcov --remove $(pwd)/coverage.info '/usr/*' --output-file $(pwd)/coverage.info
         lcov --list $(pwd)/coverage.info
-        curl -s https://codecov.io/bash | bash
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
+        ./codecov -t ${CODECOV_TOKEN}
         echo "Uploaded"
 
   linux-fpga:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -366,5 +366,7 @@ jobs:
     #    lcov --directory . --capture --output-file $(pwd)/coverage.info
     #    lcov --remove $(pwd)/coverage.info '/usr/*' --output-file $(pwd)/coverage.info
     #    lcov --list $(pwd)/coverage.info
-    #    curl -s https://codecov.io/bash | bash
+    #    curl -Os https://uploader.codecov.io/latest/linux/codecov
+    #    chmod +x codecov
+    #    ./codecov -t ${CODECOV_TOKEN}
     #    echo "Uploaded"


### PR DESCRIPTION
Codecov announced deprecating the bash uploader.  Our CI is failing now.  
https://docs.codecov.com/docs/about-the-codecov-bash-uploader
https://docs.codecov.com/docs/codecov-uploader