### PR TITLE
Use minimum block size of 64 threads 

### DIFF
--- a/src/targets/gpu/compile_hip_code_object.cpp
+++ b/src/targets/gpu/compile_hip_code_object.cpp
@@ -145,8 +145,7 @@ compute_global_for(context& ctx, std::size_t n, std::size_t over)
 std::size_t compute_block_size(std::size_t n, std::size_t max_block_size)
 {
     const std::size_t min_block_size  = 64;
-    const std::size_t base_block_size = 32;
-    auto block_size                   = (((n - 1) / base_block_size + 1)) * base_block_size;
+    auto block_size                   = (((n - 1) / min_block_size + 1)) * min_block_size;
     return std::min(std::max(min_block_size, block_size), max_block_size);
 }
 

--- a/src/targets/gpu/compile_hip_code_object.cpp
+++ b/src/targets/gpu/compile_hip_code_object.cpp
@@ -144,8 +144,8 @@ compute_global_for(context& ctx, std::size_t n, std::size_t over)
 
 std::size_t compute_block_size(std::size_t n, std::size_t max_block_size)
 {
-    const std::size_t min_block_size  = 64;
-    auto block_size                   = (((n - 1) / min_block_size + 1)) * min_block_size;
+    const std::size_t min_block_size = 64;
+    auto block_size                  = (((n - 1) / min_block_size + 1)) * min_block_size;
     return std::min(std::max(min_block_size, block_size), max_block_size);
 }
 

--- a/test/verify/test_avg_pooling_2d.cpp
+++ b/test/verify/test_avg_pooling_2d.cpp
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2022 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "verify_program.hpp"
+#include <migraphx/program.hpp>
+#include <migraphx/generate.hpp>
+#include <migraphx/op/pooling.hpp>
+struct test_avg_pooling_2d : verify_program<test_avg_pooling_2d>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+        auto input =
+            mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {1, 336, 20, 20}});
+        auto op = migraphx::op::pooling{
+            migraphx::op::pooling_mode::average, {0, 0, 0, 0}, {1, 1}, {20, 20}, 0, 2};
+        mm->add_instruction(op, input);
+        return p;
+    }
+};


### PR DESCRIPTION
LocalThreads that are not multiple of 64 are causing correctness issues. 