### PR TITLE
Add opset-13 support for parse_split

### DIFF
--- a/src/onnx/parse_split.cpp
+++ b/src/onnx/parse_split.cpp
@@ -58,7 +58,10 @@ struct parse_split : op_parser<parse_split>
         }
         else if(args.size() == 2)
         {
-            assert(args[1]->can_eval());
+            if(not args[1]->can_eval())
+            {
+                MIGRAPHX_THROW("PARSE_SPLIT: invalid split input arg");
+            }
 
             auto s = args[1]->eval();
             s.visit([&](auto v) { vec_splits.assign(v.begin(), v.end()); });

--- a/src/onnx/parse_split.cpp
+++ b/src/onnx/parse_split.cpp
@@ -58,6 +58,8 @@ struct parse_split : op_parser<parse_split>
         }
         else if(args.size() == 2)
         {
+            assert(args[1]->can_eval());
+
             auto s = args[1]->eval();
             s.visit([&](auto v) { vec_splits.assign(v.begin(), v.end()); });
         }

--- a/src/onnx/parse_split.cpp
+++ b/src/onnx/parse_split.cpp
@@ -26,6 +26,7 @@
 #include <migraphx/ranges.hpp>
 #include <migraphx/make_op.hpp>
 #include <migraphx/tune_axis.hpp>
+#include <migraphx/onnx/checks.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -58,12 +59,8 @@ struct parse_split : op_parser<parse_split>
         }
         else if(args.size() == 2)
         {
-            if(not args[1]->can_eval())
-            {
-                MIGRAPHX_THROW("PARSE_SPLIT: invalid split input arg");
-            }
-
             auto s = args[1]->eval();
+            check_arg_empty(s, "Split: dynamic shape is not supported");
             s.visit([&](auto v) { vec_splits.assign(v.begin(), v.end()); });
         }
         // no split attribute, input is equally divided

--- a/src/onnx/parse_split.cpp
+++ b/src/onnx/parse_split.cpp
@@ -28,6 +28,8 @@
 #include <migraphx/tune_axis.hpp>
 #include <migraphx/onnx/checks.hpp>
 
+#include <migraphx/stringutils.hpp>
+
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace onnx {
@@ -78,18 +80,10 @@ struct parse_split : op_parser<parse_split>
         if(std::accumulate(vec_splits.begin(), vec_splits.end(), int64_t(0)) !=
            static_cast<int64_t>(lens[tuned_axis]))
         {
-            std::string output;
-            for(const auto& index : vec_splits)
-                output += std::to_string(index) + ",";
-
-            std::string len_output;
-            for(const auto& len_vec : lens)
-                len_output += std::to_string(len_vec) + ",";
-
             MIGRAPHX_THROW(
                 "PARSE_SPLIT: sum of split attribute unequal to dim size of axis! tuned axis:" +
-                std::to_string(lens[tuned_axis]) + " Output " + output + " Rank " +
-                std::to_string(n_rank) + " Len outs " + len_output);
+                std::to_string(lens[tuned_axis]) + " Output " + to_string_range(vec_splits) +
+                " Rank " + std::to_string(n_rank) + " Len outs " + to_string_range(lens));
         }
 
         std::vector<instruction_ref> ret_ins;

--- a/test/onnx/gen_onnx.py
+++ b/test/onnx/gen_onnx.py
@@ -5758,6 +5758,22 @@ def split_test_invalid_split():
 
 
 @onnx_test
+def split_test_no_attribute_invalid_input_split():
+    x = helper.make_tensor_value_info('x', TensorProto.FLOAT, [10, 15])
+    y1 = helper.make_tensor_value_info('y1', TensorProto.FLOAT, [10, 7])
+    y2 = helper.make_tensor_value_info('y2', TensorProto.FLOAT, [10, 4])
+    y3 = helper.make_tensor_value_info('y3', TensorProto.FLOAT, [10, 4])
+
+    node = onnx.helper.make_node('Split',
+                                 inputs=['x'],
+                                 outputs=['y1', 'y2', 'y3'],
+                                 axis=1,
+                                 split=[])
+
+    return ([node], [x], [y1, y2, y3])
+
+
+@onnx_test
 def sqrt_test():
     x = helper.make_tensor_value_info('x', TensorProto.FLOAT, [10, 15])
     y = helper.make_tensor_value_info('y', TensorProto.FLOAT, [10, 15])

--- a/test/onnx/gen_onnx.py
+++ b/test/onnx/gen_onnx.py
@@ -5688,6 +5688,33 @@ def split_test_default():
 
 
 @onnx_test
+def split_test_no_attribute():
+    x = helper.make_tensor_value_info('x', TensorProto.FLOAT, [300, 15])
+    y1 = helper.make_tensor_value_info('y1', TensorProto.FLOAT, [75, 15])
+    y2 = helper.make_tensor_value_info('y2', TensorProto.FLOAT, [75, 15])
+    y3 = helper.make_tensor_value_info('y3', TensorProto.FLOAT, [75, 15])
+    y4 = helper.make_tensor_value_info('y4', TensorProto.FLOAT, [75, 15])
+
+    split = np.ones(4) * 75
+    split_tensor = helper.make_tensor(name="split",
+                                      data_type=TensorProto.INT64,
+                                      dims=split.shape,
+                                      vals=split.astype(np.int64))
+    const_node = helper.make_node("Constant",
+                                  inputs=[],
+                                  outputs=['split'],
+                                  value=split_tensor)
+
+    node = onnx.helper.make_node(
+        'Split',
+        inputs=['x', 'split'],
+        outputs=['y1', 'y2', 'y3', 'y4'],
+    )
+
+    return ([const_node, node], [x], [y1, y2, y3, y4])
+
+
+@onnx_test
 def sqrt_test():
     x = helper.make_tensor_value_info('x', TensorProto.FLOAT, [10, 15])
     y = helper.make_tensor_value_info('y', TensorProto.FLOAT, [10, 15])

--- a/test/onnx/gen_onnx.py
+++ b/test/onnx/gen_onnx.py
@@ -5715,6 +5715,49 @@ def split_test_no_attribute():
 
 
 @onnx_test
+def split_test_no_attribute_invalid_split():
+    x = helper.make_tensor_value_info('x', TensorProto.FLOAT, [300, 15])
+    y1 = helper.make_tensor_value_info('y1', TensorProto.FLOAT, [75, 15])
+    y2 = helper.make_tensor_value_info('y2', TensorProto.FLOAT, [75, 15])
+    y3 = helper.make_tensor_value_info('y3', TensorProto.FLOAT, [75, 15])
+    y4 = helper.make_tensor_value_info('y4', TensorProto.FLOAT, [75, 15])
+
+    split = np.ones(4)
+    split_tensor = helper.make_tensor(name="split",
+                                      data_type=TensorProto.INT64,
+                                      dims=split.shape,
+                                      vals=split.astype(np.int64))
+    const_node = helper.make_node("Constant",
+                                  inputs=[],
+                                  outputs=['split'],
+                                  value=split_tensor)
+
+    node = onnx.helper.make_node(
+        'Split',
+        inputs=['x', 'split'],
+        outputs=['y1', 'y2', 'y3', 'y4'],
+    )
+
+    return ([const_node, node], [x], [y1, y2, y3, y4])
+
+
+@onnx_test
+def split_test_invalid_split():
+    x = helper.make_tensor_value_info('x', TensorProto.FLOAT, [10, 15])
+    y1 = helper.make_tensor_value_info('y1', TensorProto.FLOAT, [10, 7])
+    y2 = helper.make_tensor_value_info('y2', TensorProto.FLOAT, [10, 4])
+    y3 = helper.make_tensor_value_info('y3', TensorProto.FLOAT, [10, 4])
+
+    node = onnx.helper.make_node('Split',
+                                 inputs=['x'],
+                                 outputs=['y1', 'y2', 'y3'],
+                                 axis=1,
+                                 split=[1, 1, 1])
+
+    return ([node], [x], [y1, y2, y3])
+
+
+@onnx_test
 def sqrt_test():
     x = helper.make_tensor_value_info('x', TensorProto.FLOAT, [10, 15])
     y = helper.make_tensor_value_info('y', TensorProto.FLOAT, [10, 15])

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -5537,6 +5537,31 @@ TEST_CASE(split_test)
     EXPECT(p == prog);
 }
 
+TEST_CASE(split_test_no_attribute)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+
+    migraphx::shape si{migraphx::shape::int64_type, {4}, {1}};
+    std::vector<int> ind = {75, 75, 75, 75};
+
+    auto input = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {300, 15}});
+    mm->add_literal(migraphx::literal(si, ind));
+    auto r1 = mm->add_instruction(
+        migraphx::make_op("slice", {{"axes", {0}}, {"starts", {0}}, {"ends", {75}}}), input);
+    auto r2 = mm->add_instruction(
+        migraphx::make_op("slice", {{"axes", {0}}, {"starts", {75}}, {"ends", {150}}}), input);
+    auto r3 = mm->add_instruction(
+        migraphx::make_op("slice", {{"axes", {0}}, {"starts", {150}}, {"ends", {225}}}), input);
+    auto r4 = mm->add_instruction(
+        migraphx::make_op("slice", {{"axes", {0}}, {"starts", {225}}, {"ends", {300}}}), input);
+
+    mm->add_return({r1, r2, r3, r4});
+
+    auto prog = migraphx::parse_onnx("split_test_no_attribute.onnx");
+    EXPECT(p == prog);
+}
+
 TEST_CASE(split_test_default)
 {
     migraphx::program p;

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -5577,6 +5577,17 @@ TEST_CASE(split_test_default)
     EXPECT(p == prog);
 }
 
+TEST_CASE(split_test_no_attribute_invalid_split)
+{
+    EXPECT(
+        test::throws([&] { migraphx::parse_onnx("split_test_no_attribute_invalid_split.onnx"); }));
+}
+
+TEST_CASE(split_test_invalid_split)
+{
+    EXPECT(test::throws([&] { migraphx::parse_onnx("split_test_invalid_split.onnx"); }));
+}
+
 TEST_CASE(sqrt_test)
 {
     migraphx::program p;

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -5588,6 +5588,12 @@ TEST_CASE(split_test_invalid_split)
     EXPECT(test::throws([&] { migraphx::parse_onnx("split_test_invalid_split.onnx"); }));
 }
 
+TEST_CASE(split_test_no_attribute_invalid_input_split)
+{
+    EXPECT(test::throws(
+        [&] { migraphx::parse_onnx("split_test_no_attribute_invalid_input_split.onnx"); }));
+}
+
 TEST_CASE(sqrt_test)
 {
     migraphx::program p;

--- a/test/onnx/split_test_invalid_split.onnx
+++ b/test/onnx/split_test_invalid_split.onnx
@@ -1,0 +1,25 @@
+split_test_invalid_split:¨
+5
+xy1y2y3"Split*
+axis *
+split@@@ split_test_invalid_splitZ
+x
+
+
+
+b
+y1
+
+
+
+b
+y2
+
+
+
+b
+y3
+
+
+
+B

--- a/test/onnx/split_test_no_attribute.onnx
+++ b/test/onnx/split_test_no_attribute.onnx
@@ -1,0 +1,26 @@
+split_test_no_attribute:Ü
+0split"Constant*
+value*:KKKKBsplit 
+!
+x
+splity1y2y3y4"Splitsplit_test_no_attributeZ
+x
+	
+¬
+b
+y1
+
+K
+b
+y2
+
+K
+b
+y3
+
+K
+b
+y4
+
+K
+B

--- a/test/onnx/split_test_no_attribute_invalid_input_split.onnx
+++ b/test/onnx/split_test_no_attribute_invalid_input_split.onnx
@@ -1,0 +1,26 @@
++split_test_no_attribute_invalid_input_split:µ
+/
+xy1y2y3"Split*
+axis *
+
+split +split_test_no_attribute_invalid_input_splitZ
+x
+
+
+
+b
+y1
+
+
+
+b
+y2
+
+
+
+b
+y3
+
+
+
+B

--- a/test/onnx/split_test_no_attribute_invalid_split.onnx
+++ b/test/onnx/split_test_no_attribute_invalid_split.onnx
@@ -1,0 +1,26 @@
+%split_test_no_attribute_invalid_split:ê
+0split"Constant*
+value*:Bsplit 
+!
+x
+splity1y2y3y4"Split%split_test_no_attribute_invalid_splitZ
+x
+	
+¬
+b
+y1
+
+K
+b
+y2
+
+K
+b
+y3
+
+K
+b
+y4
+
+K
+B


### PR DESCRIPTION
Changes cherry picked from parse_if PR #1325 . 

This fixes parse_split so that we can support opset-13 inputs for split where there's two parameters (data and split vector)

Added additional unit tests for this to test the new cases