### PR TITLE
Fix overflow for workspace size

### DIFF
--- a/src/targets/gpu/compile_miopen.cpp
+++ b/src/targets/gpu/compile_miopen.cpp
@@ -64,7 +64,7 @@ std::size_t compile_miopen::compile(operation& op, instruction_ref ins, bool for
 {
     op.from_value({{"int8_x4_format", format}});
     auto v = op.compile(*ctx, ins->get_shape(), to_shapes(ins->inputs()));
-    return v.get("workspace", 0);
+    return v.get<std::size_t>("workspace", 0);
 }
 
 void compile_miopen::apply(module& m) const


### PR DESCRIPTION
By default, `get()` method was picking `int` data type and it caused overflow for workspace size larger than 2 Bilion bytes (max int32 value).  Workspace size comes out to be 3+ Billion bytes for 3DUnet on certain Hardwares which caused it to fail in QA tests.

