### PR TITLE
Fix parse if shapes and literals

### DIFF
--- a/src/include/migraphx/literal.hpp
+++ b/src/include/migraphx/literal.hpp
@@ -49,7 +49,7 @@ struct literal : raw_data<literal>
      * Empty literal with a specific shape type
      */
     explicit literal(shape::type_t shape_type)
-        : m_shape(shape_type, {1}, {0}), buffer(make_shared_array<char>(m_shape.type_size()))
+        : m_shape(shape_type, {}, {}), buffer(make_shared_array<char>(m_shape.type_size()))
     {
     }
 

--- a/src/include/migraphx/op/multibroadcast.hpp
+++ b/src/include/migraphx/op/multibroadcast.hpp
@@ -50,7 +50,7 @@ struct multibroadcast
         auto t     = inputs.at(0).type();
         auto input = inputs.at(0);
 
-        if(input.lens().empty())
+        if(input.lens().empty() or input.strides().empty())
         {
             MIGRAPHX_THROW("MULTIBROADCAST: inputs dimensions should be > 0");
         }

--- a/src/onnx/parse_constant.cpp
+++ b/src/onnx/parse_constant.cpp
@@ -43,7 +43,7 @@ struct parse_constant : op_parser<parse_constant>
         // return empty literal
         if(v.get_shape().elements() == 0)
         {
-            return info.add_literal(literal{v.get_shape().type()});
+            return info.add_literal(literal{migraphx::shape{v.get_shape().type(), {1}, {0}}, {0}});
         }
 
         auto dim_size = info.attributes.at("value").t().dims_size();

--- a/src/onnx/parse_constant_of_shape.cpp
+++ b/src/onnx/parse_constant_of_shape.cpp
@@ -68,7 +68,9 @@ struct parse_constant_of_shape : op_parser<parse_constant_of_shape>
             // empty input tensor, output is a scalar
             if(args[0]->get_shape().elements() == 0)
             {
-                s = migraphx::shape{type, {1}, {0}};
+                std::vector<size_t> lens(1, 1);
+                std::vector<size_t> strides(1, 0);
+                s = migraphx::shape(type, lens, strides);
             }
             else
             {
@@ -84,8 +86,16 @@ struct parse_constant_of_shape : op_parser<parse_constant_of_shape>
             l_val.visit([&](auto val) {
                 using val_type = std::remove_cv_t<typename decltype(val)::value_type>;
                 // l_val contains only one element
-                std::vector<val_type> out_vec(s.elements(), val.front());
-                l_out = literal(s, out_vec);
+                if(s.elements() > 0)
+                {
+                    std::vector<val_type> out_vec(s.elements(), val.front());
+                    l_out = literal(s, out_vec);
+                }
+                else
+                {
+                    std::vector<val_type> out_vec{val.front()};
+                    l_out = literal(s, out_vec);
+                }
             });
 
             return info.add_literal(l_out);

--- a/src/onnx/parse_if.cpp
+++ b/src/onnx/parse_if.cpp
@@ -120,8 +120,10 @@ struct parse_if : op_parser<parse_if>
                 continue;
             }
 
-            auto then_lens = then_out_shape.lens();
-            auto else_lens = else_out_shape.lens();
+            auto then_lens    = then_out_shape.lens();
+            auto else_lens    = else_out_shape.lens();
+            auto then_strides = then_out_shape.strides();
+            auto else_strides = else_out_shape.strides();
 
             assert(not(then_lens.empty() and else_lens.empty()));
 
@@ -144,11 +146,11 @@ struct parse_if : op_parser<parse_if>
 
             // Handle one empty branch by setting output identical to the other
             // need to update the then_shape before we do further checks
-            if(then_lens.empty())
+            if(then_strides.empty() or (then_strides.front() == 0 and then_lens.front() <= 1))
             {
                 then_lens = handle_empty_branch(then_mdl, i, else_out_shape);
             }
-            else if(else_lens.empty())
+            else if(else_strides.empty() or (else_strides.front() == 0 and else_lens.front() <= 1))
             {
                 else_lens = handle_empty_branch(else_mdl, i, then_out_shape);
             }

--- a/src/onnx/parse_if.cpp
+++ b/src/onnx/parse_if.cpp
@@ -147,11 +147,12 @@ struct parse_if : op_parser<parse_if>
 
             // Handle one empty branch by setting output identical to the other
             // need to update the then_shape before we do further checks
-            if(then_strides.empty() or (then_strides.front() == 0 and then_lens.front() <= 1))
+            if(then_strides.empty() or (then_strides.front() == 0 and else_strides.front() != 0))
             {
                 then_lens = handle_empty_branch(then_mdl, i, else_out_shape);
             }
-            else if(else_strides.empty() or (else_strides.front() == 0 and else_lens.front() <= 1))
+            else if(else_strides.empty() or
+                    (else_strides.front() == 0 and then_strides.front() != 0))
             {
                 else_lens = handle_empty_branch(else_mdl, i, then_out_shape);
             }

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -59,7 +59,7 @@ struct shape_impl
         m_strides.resize(m_lens.size(), 0);
 
         if(m_lens.empty() or (m_lens.front() == 0 and m_lens.size() == 1))
-            m_lens.at(0) = 1;
+            m_lens.resize(1, 1);
         else
             this->calculate_strides();
 

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -54,7 +54,15 @@ struct shape_impl
         : m_type(t), m_lens(std::move(l)), m_standard(true)
     {
         assert(t != shape::tuple_type);
-        this->calculate_strides();
+
+        m_strides.clear();
+        m_strides.resize(m_lens.size(), 0);
+
+        if(m_lens.empty() or (m_lens.front() == 0 and m_lens.size() == 1))
+            m_lens.at(0) = 1;
+        else
+            this->calculate_strides();
+
         assert(m_lens.size() == m_strides.size());
     }
     shape_impl(shape::type_t t, std::vector<std::size_t> l, std::vector<std::size_t> s)
@@ -83,8 +91,6 @@ struct shape_impl
 
     void calculate_strides()
     {
-        m_strides.clear();
-        m_strides.resize(m_lens.size(), 0);
         if(m_strides.empty())
             return;
         m_strides.back() = 1;

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -55,11 +55,11 @@ struct shape_impl
     {
         assert(t != shape::tuple_type);
 
-        m_strides.clear();
-        m_strides.resize(m_lens.size(), 0);
-
         if(m_lens.empty() or (m_lens.front() == 0 and m_lens.size() == 1))
+        {
+            m_strides.resize(m_lens.size(), 0);
             m_lens.resize(1, 1);
+        }
         else
             this->calculate_strides();
 
@@ -91,6 +91,8 @@ struct shape_impl
 
     void calculate_strides()
     {
+        m_strides.clear();
+        m_strides.resize(m_lens.size(), 0);
         if(m_strides.empty())
             return;
         m_strides.back() = 1;

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -58,7 +58,8 @@ struct shape_impl
         if(m_lens.empty() or (m_lens.front() == 0 and m_lens.size() == 1))
         {
             m_strides.resize(m_lens.size(), 0);
-            m_lens.resize(1, 1);
+            m_lens.resize(1);
+            m_lens.at(0) = 1;
         }
         else
             this->calculate_strides();

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -762,6 +762,7 @@ TEST_CASE(constant_empty_scalar_int64_test)
     migraphx::program p;
     auto* mm = p.get_main_module();
     mm->add_literal(migraphx::literal{migraphx::shape::int64_type});
+
     auto prog = optimize_onnx("constant_empty_scalar_int64_test.onnx");
 
     EXPECT(p == prog);
@@ -2429,13 +2430,14 @@ TEST_CASE(if_literal_test)
     auto* then_mod           = p.create_module("If_1_if");
     std::vector<float> data1 = {1, 2, 3, 4, 5};
     auto l1                  = then_mod->add_literal(migraphx::literal(s, data1));
-    then_mod->add_literal({});
+    migraphx::shape empty_shape{migraphx::shape::float_type, {1}, {0}};
+    then_mod->add_literal(migraphx::literal({empty_shape}, {0}));
     then_mod->add_return({l1});
 
     auto* else_mod           = p.create_module("If_1_else");
     std::vector<float> data2 = {5, 4, 3, 2, 1};
     auto l2                  = else_mod->add_literal(migraphx::literal(s, data2));
-    else_mod->add_literal({});
+    else_mod->add_literal(migraphx::literal(empty_shape, {0}));
     else_mod->add_return({l2});
 
     auto ret = mm->add_instruction(migraphx::make_op("if"), {cond}, {then_mod, else_mod});
@@ -2617,7 +2619,6 @@ TEST_CASE(if_then_empty_constant_test)
     auto ret = mm->add_instruction(migraphx::make_op("if"), {cond}, {then_mod, else_mod});
     auto r   = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), ret);
     mm->add_return({r});
-
     auto prog = migraphx::parse_onnx("if_then_empty_constant_test.onnx");
     EXPECT(p == prog);
 }
@@ -6047,7 +6048,8 @@ TEST_CASE(squeeze_empty_axes_test)
 {
     migraphx::program p;
     auto* mm = p.get_main_module();
-    mm->add_literal(migraphx::literal{migraphx::shape::int64_type});
+    migraphx::shape empty_shape{migraphx::shape::int64_type, {1}};
+    mm->add_literal(migraphx::literal{empty_shape, {0}});
     auto l0 = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {3, 1, 5, 1}});
     auto l1 = mm->add_instruction(migraphx::make_op("squeeze"), l0);
     mm->add_return({l1});

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -2601,8 +2601,6 @@ TEST_CASE(if_then_empty_constant_test)
 
     auto* then_mod = p.create_module("If_4_if");
 
-    then_mod->add_literal(migraphx::shape::int64_type);
-
     migraphx::shape gen_shape(migraphx::shape(s.type(), {1}, {0}));
     auto literal_ins   = then_mod->add_literal(migraphx::literal(gen_shape, {0}));
     auto unsqueeze_ins = then_mod->add_instruction(
@@ -2637,20 +2635,16 @@ TEST_CASE(if_then_empty_constant_multi_output_test)
 
     auto* then_mod = p.create_module("If_4_if");
 
-    then_mod->add_literal(migraphx::shape::int64_type);
-    then_mod->add_literal(migraphx::shape::int64_type);
-
     migraphx::shape gen_shape(migraphx::shape(s.type(), {1}, {0}));
-    auto literal_ins = then_mod->add_literal(migraphx::literal(gen_shape, {0}));
+    then_mod->add_literal(migraphx::literal(gen_shape, {0}));
+    migraphx::shape gen_shape2(migraphx::shape(s.type(), {1}, {0}));
+    auto literal_ins2 = then_mod->add_literal(migraphx::literal(gen_shape2, {0}));
 
     auto unsqueeze_ins = then_mod->add_instruction(
-        migraphx::make_op("scalar", {{"scalar_bcst_dims", s.lens()}}), literal_ins);
+        migraphx::make_op("scalar", {{"scalar_bcst_dims", s.lens()}}), literal_ins2);
     auto broad_ins = then_mod->add_instruction(
         migraphx::make_op("multibroadcast", {{"out_lens", s.lens()}}), unsqueeze_ins);
     auto contig_out = then_mod->add_instruction(migraphx::make_op("contiguous"), broad_ins);
-
-    migraphx::shape gen_shape2(migraphx::shape(s.type(), {1}, {0}));
-    auto literal_ins2 = then_mod->add_literal(migraphx::literal(gen_shape2, {0}));
 
     auto unsqueeze_ins2 = then_mod->add_instruction(
         migraphx::make_op("scalar", {{"scalar_bcst_dims", s.lens()}}), literal_ins2);
@@ -2692,8 +2686,6 @@ TEST_CASE(if_else_empty_constant_test)
 
     auto* else_mod = p.create_module("If_4_else");
 
-    else_mod->add_literal(s.type());
-
     migraphx::shape gen_shape(migraphx::shape(s.type(), {1}, {0}));
     auto literal_ins = else_mod->add_literal(migraphx::literal(gen_shape, {0}));
 
@@ -2732,19 +2724,17 @@ TEST_CASE(if_else_empty_constant_multi_output_test)
 
     auto* else_mod = p.create_module("If_4_else");
 
-    else_mod->add_literal(migraphx::shape::int64_type);
-    else_mod->add_literal(migraphx::shape::int64_type);
-
     migraphx::shape gen_shape(migraphx::shape(s.type(), {1}, {0}));
-    auto literal_ins   = else_mod->add_literal(migraphx::literal(gen_shape, {0}));
+    else_mod->add_literal(migraphx::literal(gen_shape, {0}));
+    migraphx::shape gen_shape2(migraphx::shape(s.type(), {1}, {0}));
+    auto literal_ins2 = else_mod->add_literal(migraphx::literal(gen_shape2, {0}));
+
     auto unsqueeze_ins = else_mod->add_instruction(
-        migraphx::make_op("scalar", {{"scalar_bcst_dims", s.lens()}}), literal_ins);
+        migraphx::make_op("scalar", {{"scalar_bcst_dims", s.lens()}}), literal_ins2);
     auto broad_ins = else_mod->add_instruction(
         migraphx::make_op("multibroadcast", {{"out_lens", s.lens()}}), unsqueeze_ins);
     auto contig_out = else_mod->add_instruction(migraphx::make_op("contiguous"), broad_ins);
 
-    migraphx::shape gen_shape2(migraphx::shape(s.type(), {1}, {0}));
-    auto literal_ins2   = else_mod->add_literal(migraphx::literal(gen_shape2, {0}));
     auto unsqueeze_ins2 = else_mod->add_instruction(
         migraphx::make_op("scalar", {{"scalar_bcst_dims", s.lens()}}), literal_ins2);
     auto broad_ins2 = else_mod->add_instruction(

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -761,7 +761,8 @@ TEST_CASE(constant_empty_scalar_int64_test)
 {
     migraphx::program p;
     auto* mm = p.get_main_module();
-    mm->add_literal(migraphx::literal{migraphx::shape::int64_type});
+    migraphx::shape empty_shape{migraphx::shape::int64_type, {1}, {0}};
+    mm->add_literal({empty_shape, {0}});
 
     auto prog = optimize_onnx("constant_empty_scalar_int64_test.onnx");
 
@@ -782,7 +783,8 @@ TEST_CASE(const_of_shape_empty_input_test)
 {
     migraphx::program p;
     auto* mm = p.get_main_module();
-    mm->add_literal(migraphx::literal(migraphx::shape::int32_type));
+    migraphx::shape empty_shape{migraphx::shape::int32_type, {1}, {0}};
+    mm->add_literal({empty_shape, {0}});
     migraphx::shape s(migraphx::shape::int64_type, {1}, {0});
     std::vector<int64_t> vec(s.elements(), 10);
     mm->add_literal(migraphx::literal(s, vec));
@@ -6038,8 +6040,7 @@ TEST_CASE(squeeze_empty_axes_test)
 {
     migraphx::program p;
     auto* mm = p.get_main_module();
-    migraphx::shape empty_shape{migraphx::shape::int64_type, {1}};
-    mm->add_literal(migraphx::literal{empty_shape, {0}});
+    mm->add_literal(migraphx::literal{migraphx::shape::int64_type});
     auto l0 = mm->add_parameter("x", migraphx::shape{migraphx::shape::float_type, {3, 1, 5, 1}});
     auto l1 = mm->add_instruction(migraphx::make_op("squeeze"), l0);
     mm->add_return({l1});


### PR DESCRIPTION
Fixes to get shape and literal working correclty for parse if.

- removed literal creation from parse_if and handle empty literal correctly.
- Changed literal construction such that we do this as per initializer list
- Updated unit tests which expected a variant of an empty scalar used when parsing in onnx
- Updated parse_if to scan for empty  and or scalar inputs that d