### PR TITLE
Patch to pass shared linker flags missing in custom lib target

### DIFF
--- a/src/py/CMakeLists.txt
+++ b/src/py/CMakeLists.txt
@@ -30,7 +30,8 @@ if(MIGRAPHX_ENABLE_PYTHON)
 
     foreach(PYTHON_VERSION ${PYTHON_VERSIONS})
         py_add_module(migraphx_py_${PYTHON_VERSION} migraphx_py.cpp PYTHON_VERSION ${PYTHON_VERSION} PYTHON_MODULE migraphx)
-        target_link_libraries(migraphx_py_${PYTHON_VERSION} PRIVATE migraphx migraphx_tf migraphx_onnx migraphx_all_targets)
+        target_link_libraries(migraphx_py_${PYTHON_VERSION} PRIVATE
+                              migraphx migraphx_tf migraphx_onnx migraphx_all_targets "${CMAKE_SHARED_LINKER_FLAGS}" )
         rocm_install_targets(TARGETS migraphx_py_${PYTHON_VERSION})
         add_dependencies(migraphx_py migraphx_py_${PYTHON_VERSION})
     endforeach()


### PR DESCRIPTION
Proposed Changes:
- Shared Linker flags added to custom target link libraries.
- Address 364410 observation of not listing link libraries of the library (custom target lib when MIGRAPHX_ENABLE_PYTHON on)