### PR TITLE
Fix CI failure: move from AWS to download.onnxruntime.ai for onnx model testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,6 @@ ADD doc/requirements.txt /doc-requirements.txt
 RUN pip3 install -r /doc-requirements.txt
 
 # Download real models to run onnx unit tests
-ENV ONNX_HOME=/root
 COPY ./tools/download_models.sh /
 RUN /download_models.sh && rm /download_models.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ ADD doc/requirements.txt /doc-requirements.txt
 RUN pip3 install -r /doc-requirements.txt
 
 # Download real models to run onnx unit tests
-ENV ONNX_HOME=$HOME/.onnx
+ENV ONNX_HOME=/root
 COPY ./tools/download_models.sh /
 RUN /download_models.sh && rm /download_models.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ ADD doc/requirements.txt /doc-requirements.txt
 RUN pip3 install -r /doc-requirements.txt
 
 # Download real models to run onnx unit tests
-ENV ONNX_HOME=$HOME
+ENV ONNX_HOME=$HOME/.onnx
 COPY ./tools/download_models.sh /
 RUN /download_models.sh && rm /download_models.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ ADD doc/requirements.txt /doc-requirements.txt
 RUN pip3 install -r /doc-requirements.txt
 
 # Download real models to run onnx unit tests
-ENV ONNX_HOME=/root/.onnx
+ENV ONNX_HOME=/.onnx
 COPY ./tools/download_models.sh /
 RUN /download_models.sh && rm /download_models.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,7 @@ ADD doc/requirements.txt /doc-requirements.txt
 RUN pip3 install -r /doc-requirements.txt
 
 # Download real models to run onnx unit tests
+ENV ONNX_HOME=/root/.onnx
 COPY ./tools/download_models.sh /
 RUN /download_models.sh && rm /download_models.sh
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,9 +25,6 @@ def rocmtestnode(Map conf) {
             export CXX=${compiler}
             export CXXFLAGS='-Werror'
             env
-            whoami
-            echo $UID
-            ls -la /root
             rm -rf build
             mkdir build
             cd build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,9 @@ def rocmtestnode(Map conf) {
             export CXX=${compiler}
             export CXXFLAGS='-Werror'
             env
+            whoami
+            echo $UID
+            ls -la /root
             rm -rf build
             mkdir build
             cd build

--- a/test/py/onnx_backend_test.py
+++ b/test/py/onnx_backend_test.py
@@ -51,7 +51,7 @@ class MIGraphXBackendTest(onnx.backend.test.BackendTest):
             np.testing.assert_equal(ref_outputs[i].dtype,
                                     outputs[i].dtype,
                                     err_msg=prog_string)
-            if ref_outputs[i].dtype == np.object:
+            if ref_outputs[i].dtype == object:
                 np.testing.assert_array_equal(ref_outputs[i],
                                               outputs[i],
                                               err_msg=prog_string)
@@ -250,15 +250,19 @@ def create_backend_test(testname=None, target_device=None):
         backend_test.include(r'.*test_ZeroPad2d*')
 
         # # Onnx native model tests
-        backend_test.include(r'.*test_bvlc_alexnet.*')
-        backend_test.include(r'.*test_densenet121.*')
-        backend_test.include(r'.*test_inception_v1.*')
-        backend_test.include(r'.*test_inception_v2.*')
-        backend_test.include(r'.*test_resnet50.*')
-        backend_test.include(r'.*test_shufflenet.*')
-        backend_test.include(r'.*test_squeezenet.*')
-        backend_test.include(r'.*test_vgg19.*')
-        backend_test.include(r'.*test_zfnet512.*')
+        # TODO add back, nothing wrong with these tests, it the location
+        # where onnx gets them from has been removed (AWS)
+        # See onnx/onnx#4857 and microsoft/onnxruntime#14606 for details
+        #
+        # backend_test.include(r'.*test_bvlc_alexnet.*')
+        # backend_test.include(r'.*test_densenet121.*')
+        # backend_test.include(r'.*test_inception_v1.*')
+        # backend_test.include(r'.*test_inception_v2.*')
+        # backend_test.include(r'.*test_resnet50.*')
+        # backend_test.include(r'.*test_shufflenet.*')
+        # backend_test.include(r'.*test_squeezenet.*')
+        # backend_test.include(r'.*test_vgg19.*')
+        # backend_test.include(r'.*test_zfnet512.*')
 
         # exclude unenabled ops get pulled in with wildcards
         # test_constant_pad gets pulled in with the test_constant* wildcard. Explicitly disable padding tests for now.

--- a/test/py/onnx_backend_test.py
+++ b/test/py/onnx_backend_test.py
@@ -250,19 +250,15 @@ def create_backend_test(testname=None, target_device=None):
         backend_test.include(r'.*test_ZeroPad2d*')
 
         # # Onnx native model tests
-        # TODO add back, nothing wrong with these tests, it the location
-        # where onnx gets them from has been removed (AWS)
-        # See onnx/onnx#4857 and microsoft/onnxruntime#14606 for details
-        #
-        # backend_test.include(r'.*test_bvlc_alexnet.*')
-        # backend_test.include(r'.*test_densenet121.*')
-        # backend_test.include(r'.*test_inception_v1.*')
-        # backend_test.include(r'.*test_inception_v2.*')
-        # backend_test.include(r'.*test_resnet50.*')
-        # backend_test.include(r'.*test_shufflenet.*')
-        # backend_test.include(r'.*test_squeezenet.*')
-        # backend_test.include(r'.*test_vgg19.*')
-        # backend_test.include(r'.*test_zfnet512.*')
+        backend_test.include(r'.*test_bvlc_alexnet.*')
+        backend_test.include(r'.*test_densenet121.*')
+        backend_test.include(r'.*test_inception_v1.*')
+        backend_test.include(r'.*test_inception_v2.*')
+        backend_test.include(r'.*test_resnet50.*')
+        backend_test.include(r'.*test_shufflenet.*')
+        backend_test.include(r'.*test_squeezenet.*')
+        backend_test.include(r'.*test_vgg19.*')
+        backend_test.include(r'.*test_zfnet512.*')
 
         # exclude unenabled ops get pulled in with wildcards
         # test_constant_pad gets pulled in with the test_constant* wildcard. Explicitly disable padding tests for now.

--- a/tools/download_models.sh
+++ b/tools/download_models.sh
@@ -40,10 +40,8 @@ models="bvlc_alexnet \
         vgg19 \
         zfnet512"
 
-#for name in $models
-#do
-# TODO : temporarily disable model downloads to get CI running again
-# See https://github.com/onnx/onnx/issues/4857 for problem
-#curl https://s3.amazonaws.com/download.onnx/models/opset_9/$name.tar.gz --output $tmp_dir/$name.tar.gz
-#tar -xzvf $tmp_dir/$name.tar.gz --directory $model_dir && rm $tmp_dir/$name.tar.gz
-#done
+for name in $models
+do
+curl https://download.onnxruntime.ai/onnx/models/$name.tar.gz --output $tmp_dir/$name.tar.gz
+tar -xzvf $tmp_dir/$name.tar.gz --directory $model_dir && rm $tmp_dir/$name.tar.gz
+done

--- a/tools/download_models.sh
+++ b/tools/download_models.sh
@@ -26,10 +26,12 @@
 
 if [ -z "$ONNX_HOME" ]
 then
-   ONNX_HOME=$HOME
+   # The onnx library uses ONNX_HOME, by default if it doesn't exist
+   # the path of " ~/.onnx " is used
+   ONNX_HOME=$HOME/.onnx
 fi
 
-model_dir=$ONNX_HOME/.onnx/models
+model_dir=$ONNX_HOME/models
 tmp_dir=$ONNX_HOME/tmp/
 mkdir -p $model_dir
 mkdir -p $tmp_dir

--- a/tools/download_models.sh
+++ b/tools/download_models.sh
@@ -42,7 +42,9 @@ models="bvlc_alexnet \
 
 for name in $models
 do
-curl https://s3.amazonaws.com/download.onnx/models/opset_9/$name.tar.gz --output $tmp_dir/$name.tar.gz
-tar -xzvf $tmp_dir/$name.tar.gz --directory $model_dir && rm $tmp_dir/$name.tar.gz
+# TODO : temporarily disable model downloads to get CI running again
+# See https://github.com/onnx/onnx/issues/4857 for problem
+#curl https://s3.amazonaws.com/download.onnx/models/opset_9/$name.tar.gz --output $tmp_dir/$name.tar.gz
+#tar -xzvf $tmp_dir/$name.tar.gz --directory $model_dir && rm $tmp_dir/$name.tar.gz
 done
 

--- a/tools/download_models.sh
+++ b/tools/download_models.sh
@@ -40,11 +40,10 @@ models="bvlc_alexnet \
         vgg19 \
         zfnet512"
 
-for name in $models
-do
+#for name in $models
+#do
 # TODO : temporarily disable model downloads to get CI running again
 # See https://github.com/onnx/onnx/issues/4857 for problem
 #curl https://s3.amazonaws.com/download.onnx/models/opset_9/$name.tar.gz --output $tmp_dir/$name.tar.gz
 #tar -xzvf $tmp_dir/$name.tar.gz --directory $model_dir && rm $tmp_dir/$name.tar.gz
-done
-
+#done


### PR DESCRIPTION
AWS ONNX models no longer download.  This is causing CI failures.  The correct fix is going to be to download from a different location.  See https://github.com/onnx/onnx/issues/4857 and https://github.com/microsoft/onnxruntime/pull/14606 for additional details