### PR TITLE
[quick fix] Change neg unit ops to use insert instruction

### DIFF
--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -982,6 +982,9 @@ struct find_neg_unit_ops
         auto ins  = r.result;
         auto c_in = r.instructions["x"];
 
+        if(c_in->name() == "@param")
+            return;
+
         auto neg = m.add_instruction(make_op("neg"), c_in);
         m.replace_instruction(ins, neg);
     }


### PR DESCRIPTION
There seems to be a bigger issue present when neg unit ops in `simplify_algebra` matches a param as the input instruction. For example, after replacing a `mul` instruction with `@param` and -1 with a `neg(@param)`, dead code elimination results in an empty `neg` instruction.