### PR TITLE
Fixci 55

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,8 @@ CheckOptions:
     value:           risky   
   - key:             modernize-loop-convert.NamingStyle
     value:           lower_case
+  - key:             misc-const-correctness.AnalyzeValues
+    value:           'false'
   - key:             performance-unnecessary-copy-initialization.AllowedTypes
     value:           'shape'
   - key:             performance-unnecessary-value-param.AllowedTypes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,8 @@ jobs:
     # In this step, this action saves a list of existing images,
     # the cache is created without them in the post run.
     # It also restores the cache if it exists.
-    - uses: satackey/action-docker-layer-caching@v0.0.11
+    # name: Docker Layer Caching2
+    - uses: jpribyl/action-docker-layer-caching@v0.1.1
       # Ignore the failure of a step and avoid terminating the job.
       continue-on-error: true
 
@@ -81,7 +82,7 @@ jobs:
     # In this step, this action saves a list of existing images,
     # the cache is created without them in the post run.
     # It also restores the cache if it exists.
-    - uses: satackey/action-docker-layer-caching@v0.0.11
+    - uses: jpribyl/action-docker-layer-caching@v0.1.1
       # Ignore the failure of a step and avoid terminating the job.
       continue-on-error: true
 
@@ -126,7 +127,7 @@ jobs:
     # In this step, this action saves a list of existing images,
     # the cache is created without them in the post run.
     # It also restores the cache if it exists.
-    - uses: satackey/action-docker-layer-caching@v0.0.11
+    - uses: jpribyl/action-docker-layer-caching@v0.1.1
       # Ignore the failure of a step and avoid terminating the job.
       continue-on-error: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y gnupg2 --no-install-recommends curl && 
     curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - 
 
 # Add rocm repository
-RUN sh -c 'echo deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/5.3/ ubuntu main > /etc/apt/sources.list.d/rocm.list'
+RUN sh -c 'echo deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/5.4.2/ ubuntu main > /etc/apt/sources.list.d/rocm.list'
 
 # Install dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ ADD doc/requirements.txt /doc-requirements.txt
 RUN pip3 install -r /doc-requirements.txt
 
 # Download real models to run onnx unit tests
-ENV ONNX_HOME=$HOME
+ENV ONNX_HOME=/.onnx
 COPY ./tools/download_models.sh /
 RUN /download_models.sh && rm /download_models.sh
 

--- a/hip-clang.docker
+++ b/hip-clang.docker
@@ -6,7 +6,7 @@ ARG PREFIX=/usr/local
 RUN dpkg --add-architecture i386
 
 # Add rocm repository
-RUN sh -c 'echo deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/5.3/ ubuntu main > /etc/apt/sources.list.d/rocm.list'
+RUN sh -c 'echo deb [arch=amd64 trusted=yes] http://repo.radeon.com/rocm/apt/5.4.2/ ubuntu main > /etc/apt/sources.list.d/rocm.list'
 
 # Install dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \

--- a/src/include/migraphx/half.hpp
+++ b/src/include/migraphx/half.hpp
@@ -58,12 +58,12 @@ using deduce = typename detail::deduce<T>::type;
 namespace std {
 
 template <class T>
-struct common_type<migraphx::half, T> : std::common_type<float, T>
+struct common_type<migraphx::half, T> : std::common_type<float, T> // NOLINT
 {
 };
 
 template <class T>
-struct common_type<T, migraphx::half> : std::common_type<float, T>
+struct common_type<T, migraphx::half> : std::common_type<float, T> // NOLINT
 {
 };
 

--- a/src/include/migraphx/instruction_ref.hpp
+++ b/src/include/migraphx/instruction_ref.hpp
@@ -41,7 +41,7 @@ migraphx::instruction* as_address(const instruction_ref& ins) noexcept;
 
 namespace std {
 template <>
-struct hash<migraphx::instruction_ref>
+struct hash<migraphx::instruction_ref> // NOLINT
 {
     using argument_type = migraphx::instruction_ref;
     using result_type   = std::size_t;
@@ -52,7 +52,7 @@ struct hash<migraphx::instruction_ref>
 };
 
 template <>
-struct equal_to<migraphx::instruction_ref>
+struct equal_to<migraphx::instruction_ref> // NOLINT
 {
     using argument_type = migraphx::instruction_ref;
     using result_type   = bool;

--- a/test/py/onnx_backend_test.py
+++ b/test/py/onnx_backend_test.py
@@ -51,7 +51,7 @@ class MIGraphXBackendTest(onnx.backend.test.BackendTest):
             np.testing.assert_equal(ref_outputs[i].dtype,
                                     outputs[i].dtype,
                                     err_msg=prog_string)
-            if ref_outputs[i].dtype == np.object:
+            if ref_outputs[i].dtype == object:
                 np.testing.assert_array_equal(ref_outputs[i],
                                               outputs[i],
                                               err_msg=prog_string)

--- a/tools/download_models.sh
+++ b/tools/download_models.sh
@@ -26,10 +26,12 @@
 
 if [ -z "$ONNX_HOME" ]
 then
-   ONNX_HOME=$HOME
+   # The onnx library uses ONNX_HOME, by default if it doesn't exist
+   # the path of " ~/.onnx " is used
+   ONNX_HOME=$HOME/.onnx
 fi
 
-model_dir=$ONNX_HOME/.onnx/models
+model_dir=$ONNX_HOME/models
 tmp_dir=$ONNX_HOME/tmp/
 mkdir -p $model_dir
 mkdir -p $tmp_dir
@@ -42,7 +44,6 @@ models="bvlc_alexnet \
 
 for name in $models
 do
-curl https://s3.amazonaws.com/download.onnx/models/opset_9/$name.tar.gz --output $tmp_dir/$name.tar.gz
+curl https://download.onnxruntime.ai/onnx/models/$name.tar.gz --output $tmp_dir/$name.tar.gz
 tar -xzvf $tmp_dir/$name.tar.gz --directory $model_dir && rm $tmp_dir/$name.tar.gz
 done
-


### PR DESCRIPTION
Change for our rocm 5.5 branch.  These changes are already in Develop

CI failure: move from AWS to download.onnxruntime.ai for onnx model testing (#1555)
CI failure: Migrate to Docker Layer Caching2 (#1550)
upgrade to ROCm 5.4.2 in CI (#1543)