### PR TITLE
Requirements.txt obselete, now split into different requirements files

### DIFF
--- a/tools/build_and_test_onnxrt.sh
+++ b/tools/build_and_test_onnxrt.sh
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 #####################################################################################
 cd /onnxruntime
-pip3 install -r requirements.txt
+pip3 install -r requirements-dev.txt
 # Add newer cmake to the path
 export PATH="/opt/cmake/bin:$PATH"
 export CXXFLAGS="-D__HIP_PLATFORM_HCC__=1 -w"


### PR DESCRIPTION
Use requirements-dev.txt instead of the other instances