### PR TITLE
Rocm55 neg param fix

### DIFF
--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -975,10 +975,7 @@ struct find_neg_unit_ops
         auto ins  = r.result;
         auto c_in = r.instructions["x"];
 
-        if(c_in->name() == "@param")
-            return;
-
-        auto neg = m.add_instruction(make_op("neg"), c_in);
+        auto neg = m.insert_instruction(ins, make_op("neg"), c_in);
         m.replace_instruction(ins, neg);
     }
 };

--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -975,6 +975,9 @@ struct find_neg_unit_ops
         auto ins  = r.result;
         auto c_in = r.instructions["x"];
 
+        if(c_in->name() == "@param")
+            return;
+
         auto neg = m.add_instruction(make_op("neg"), c_in);
         m.replace_instruction(ins, neg);
     }

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -1042,15 +1042,15 @@ TEST_CASE(simplify_neg_unit_mult_const)
     migraphx::module m1;
     {
         auto x    = m1.add_parameter("x", {migraphx::shape::int32_type, {1, 6}});
-        auto unit = m1.add_literal(migraphx::literal{{migraphx::shape::int32_type, {1,6}},
-            std::vector<int>(6, -1)});
+        auto unit = m1.add_literal(
+            migraphx::literal{{migraphx::shape::int32_type, {1, 6}}, std::vector<int>(6, -1)});
         m1.add_instruction(migraphx::make_op("mul"), x, unit);
     }
     run_pass(m1);
 
     migraphx::module m2;
     {
-        auto x = m2.add_parameter("x", {migraphx::shape::int32_type, {1, 6}});
+        auto x  = m2.add_parameter("x", {migraphx::shape::int32_type, {1, 6}});
         auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
         m2.add_instruction(migraphx::make_op("identity"), x2);
     }
@@ -1070,7 +1070,7 @@ TEST_CASE(simplify_neg_unit_mult_const2)
 
     migraphx::module m2;
     {
-        auto x = m2.add_parameter("x", {migraphx::shape::int32_type, {1}});
+        auto x  = m2.add_parameter("x", {migraphx::shape::int32_type, {1}});
         auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
         m2.add_instruction(migraphx::make_op("identity"), x2);
     }
@@ -1084,14 +1084,14 @@ TEST_CASE(simplify_neg_unit_mult_const_add)
     {
         auto unit = m1.add_literal(-1);
         auto x    = m1.add_parameter("x", {migraphx::shape::int32_type, {1}});
-        auto x2 = m1.add_instruction(migraphx::make_op("mul"), unit, x);
+        auto x2   = m1.add_instruction(migraphx::make_op("mul"), unit, x);
         m1.add_instruction(migraphx::make_op("add"), x2, x2);
     }
     run_pass(m1);
 
     migraphx::module m2;
     {
-        auto x = m2.add_parameter("x", {migraphx::shape::int32_type, {1}});
+        auto x  = m2.add_parameter("x", {migraphx::shape::int32_type, {1}});
         auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
         m2.add_instruction(migraphx::make_op("add"), x2, x2);
     }
@@ -1115,7 +1115,7 @@ TEST_CASE(simplify_neg_unit_mul_const_vec)
 
     migraphx::module m2;
     {
-        auto x = m2.add_parameter("x", x_shape);
+        auto x  = m2.add_parameter("x", x_shape);
         auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
         m2.add_instruction(migraphx::make_op("identity"), x2);
     }
@@ -1139,7 +1139,7 @@ TEST_CASE(simplify_neg_unit_mul_const_vec2)
 
     migraphx::module m2;
     {
-        auto x = m2.add_parameter("x", x_shape);
+        auto x  = m2.add_parameter("x", x_shape);
         auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
         m2.add_instruction(migraphx::make_op("identity"), x2);
     }
@@ -1159,7 +1159,7 @@ TEST_CASE(simplify_neg_unit_div_const)
 
     migraphx::module m2;
     {
-        auto x = m2.add_parameter("x", {migraphx::shape::int32_type, {1}});
+        auto x  = m2.add_parameter("x", {migraphx::shape::int32_type, {1}});
         auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
         m2.add_instruction(migraphx::make_op("identity"), x2);
     }
@@ -1183,7 +1183,7 @@ TEST_CASE(simplify_neg_unit_div_const_vec)
 
     migraphx::module m2;
     {
-        auto x = m2.add_parameter("x", x_shape);
+        auto x  = m2.add_parameter("x", x_shape);
         auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
         m2.add_instruction(migraphx::make_op("identity"), x2);
     }
@@ -1244,7 +1244,7 @@ TEST_CASE(simplify_sub_neg_zero_const)
 
     migraphx::module m2;
     {
-        auto x = m2.add_parameter("x", {migraphx::shape::int32_type, {1}});
+        auto x  = m2.add_parameter("x", {migraphx::shape::int32_type, {1}});
         auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
         m2.add_instruction(migraphx::make_op("identity"), x2);
     }
@@ -1267,7 +1267,7 @@ TEST_CASE(simplify_sub_neg_zero_const_vec)
 
     migraphx::module m2;
     {
-        auto x = m2.add_parameter("x", x_shape);
+        auto x  = m2.add_parameter("x", x_shape);
         auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
         m2.add_instruction(migraphx::make_op("identity"), x2);
     }

--- a/test/simplify_algebra_test.cpp
+++ b/test/simplify_algebra_test.cpp
@@ -1041,16 +1041,18 @@ TEST_CASE(simplify_neg_unit_mult_const)
 {
     migraphx::module m1;
     {
-        auto x    = m1.add_parameter("x", {migraphx::shape::int32_type, {1}});
-        auto unit = m1.add_literal(-1);
+        auto x    = m1.add_parameter("x", {migraphx::shape::int32_type, {1, 6}});
+        auto unit = m1.add_literal(migraphx::literal{{migraphx::shape::int32_type, {1,6}},
+            std::vector<int>(6, -1)});
         m1.add_instruction(migraphx::make_op("mul"), x, unit);
     }
     run_pass(m1);
 
     migraphx::module m2;
     {
-        auto x = m2.add_parameter("x", {migraphx::shape::int32_type, {1}});
-        m2.add_instruction(migraphx::make_op("neg"), x);
+        auto x = m2.add_parameter("x", {migraphx::shape::int32_type, {1, 6}});
+        auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
+        m2.add_instruction(migraphx::make_op("identity"), x2);
     }
 
     EXPECT((m1 == m2));
@@ -1069,7 +1071,29 @@ TEST_CASE(simplify_neg_unit_mult_const2)
     migraphx::module m2;
     {
         auto x = m2.add_parameter("x", {migraphx::shape::int32_type, {1}});
-        m2.add_instruction(migraphx::make_op("neg"), x);
+        auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
+        m2.add_instruction(migraphx::make_op("identity"), x2);
+    }
+
+    EXPECT((m1 == m2));
+}
+
+TEST_CASE(simplify_neg_unit_mult_const_add)
+{
+    migraphx::module m1;
+    {
+        auto unit = m1.add_literal(-1);
+        auto x    = m1.add_parameter("x", {migraphx::shape::int32_type, {1}});
+        auto x2 = m1.add_instruction(migraphx::make_op("mul"), unit, x);
+        m1.add_instruction(migraphx::make_op("add"), x2, x2);
+    }
+    run_pass(m1);
+
+    migraphx::module m2;
+    {
+        auto x = m2.add_parameter("x", {migraphx::shape::int32_type, {1}});
+        auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
+        m2.add_instruction(migraphx::make_op("add"), x2, x2);
     }
 
     EXPECT((m1 == m2));
@@ -1092,7 +1116,8 @@ TEST_CASE(simplify_neg_unit_mul_const_vec)
     migraphx::module m2;
     {
         auto x = m2.add_parameter("x", x_shape);
-        m2.add_instruction(migraphx::make_op("neg"), x);
+        auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
+        m2.add_instruction(migraphx::make_op("identity"), x2);
     }
 
     EXPECT(m1 == m2);
@@ -1115,7 +1140,8 @@ TEST_CASE(simplify_neg_unit_mul_const_vec2)
     migraphx::module m2;
     {
         auto x = m2.add_parameter("x", x_shape);
-        m2.add_instruction(migraphx::make_op("neg"), x);
+        auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
+        m2.add_instruction(migraphx::make_op("identity"), x2);
     }
 
     EXPECT(m1 == m2);
@@ -1134,7 +1160,8 @@ TEST_CASE(simplify_neg_unit_div_const)
     migraphx::module m2;
     {
         auto x = m2.add_parameter("x", {migraphx::shape::int32_type, {1}});
-        m2.add_instruction(migraphx::make_op("neg"), x);
+        auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
+        m2.add_instruction(migraphx::make_op("identity"), x2);
     }
 
     EXPECT(m1 == m2);
@@ -1157,7 +1184,8 @@ TEST_CASE(simplify_neg_unit_div_const_vec)
     migraphx::module m2;
     {
         auto x = m2.add_parameter("x", x_shape);
-        m2.add_instruction(migraphx::make_op("neg"), x);
+        auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
+        m2.add_instruction(migraphx::make_op("identity"), x2);
     }
 
     EXPECT(m1 == m2);
@@ -1217,7 +1245,8 @@ TEST_CASE(simplify_sub_neg_zero_const)
     migraphx::module m2;
     {
         auto x = m2.add_parameter("x", {migraphx::shape::int32_type, {1}});
-        m2.add_instruction(migraphx::make_op("neg"), x);
+        auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
+        m2.add_instruction(migraphx::make_op("identity"), x2);
     }
     EXPECT(m1 == m2);
 }
@@ -1239,7 +1268,8 @@ TEST_CASE(simplify_sub_neg_zero_const_vec)
     migraphx::module m2;
     {
         auto x = m2.add_parameter("x", x_shape);
-        m2.add_instruction(migraphx::make_op("neg"), x);
+        auto x2 = m2.add_instruction(migraphx::make_op("neg"), x);
+        m2.add_instruction(migraphx::make_op("identity"), x2);
     }
 
     EXPECT(m1 == m2);


### PR DESCRIPTION
Using add_instruction for the neg op was causing issues on replace_instruction. Changed to use insert_instruction. As a result, I've modified existing tests and added a new one that is failing without the change.