### PR TITLE
move default to migx 5.6 project

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -15,5 +15,5 @@ jobs:
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
-          project-url: https://github.com/orgs/ROCmSoftwarePlatform/projects/20
+          project-url: https://github.com/orgs/ROCmSoftwarePlatform/projects/26
           github-token: ${{ secrets.TEST_PR_WORKFLOW }}


### PR DESCRIPTION
move any issue/pr to by default be assigned to the migx 5.6 project