### PR TITLE
Use migraphx-benchmark repo for updating ROCm image for CI actions

### DIFF
--- a/.github/workflows/rocm-image-release.yaml
+++ b/.github/workflows/rocm-image-release.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release:
-    uses: ROCmSoftwarePlatform/actions/.github/workflows/rocm-release.yml@main
+    uses: ROCmSoftwarePlatform/migraphx-benchmark/.github/workflows/rocm-release.yml@main
     with:
       rocm_release: ${{ github.event.inputs.rocm_release }}
     secrets:


### PR DESCRIPTION
Github actions requires public repo. 
RocmsoftarePlatform/actions is public archived. 