### PR TITLE
Prune candidates in NMS 

### DIFF
--- a/src/eliminate_data_type.cpp
+++ b/src/eliminate_data_type.cpp
@@ -38,6 +38,7 @@ void eliminate_data_type::apply(module& m) const
                                                            "if",
                                                            "loop",
                                                            "roialign",
+                                                           "nonmaxsuppression",
                                                            "scatternd_add",
                                                            "scatternd_mul",
                                                            "scatternd_none"};

--- a/src/include/migraphx/op/nonmaxsuppression.hpp
+++ b/src/include/migraphx/op/nonmaxsuppression.hpp
@@ -278,20 +278,17 @@ struct nonmaxsuppression
                 selected_indices.push_back(batch_idx);
                 selected_indices.push_back(class_idx);
                 selected_indices.push_back(next_top_score.second);
-                auto temp_heap =
-                    boxes_heap; // priority_queue doesn't support iteration, make a copy
-                std::priority_queue<std::pair<double, int64_t>> remainder;
-                while(!temp_heap.empty())
+                while(not boxes_heap.empty())
                 {
-                    auto tmp_top_box = temp_heap.top();
+                    auto current_box = boxes_heap.top();
                     if(not this->suppress_by_iou(
-                           batch_box(batch_boxes_start, tmp_top_box.second),
+                           batch_box(batch_boxes_start, current_box.second),
                            batch_box(batch_boxes_start, next_top_score.second),
                            iou_threshold))
                     {
                         remainder.push(tmp_top_box);
                     }
-                    temp_heap.pop();
+                    boxes_heap.pop();
                 }
                 boxes_heap = remainder;
             }

--- a/src/include/migraphx/op/nonmaxsuppression.hpp
+++ b/src/include/migraphx/op/nonmaxsuppression.hpp
@@ -278,20 +278,20 @@ struct nonmaxsuppression
                 selected_indices.push_back(batch_idx);
                 selected_indices.push_back(class_idx);
                 selected_indices.push_back(next_top_score.second);
-                std::priority_queue<std::pair<double, int64_t>> remainder;
+                std::priority_queue<std::pair<double, int64_t>> remainder_boxes;
                 while(not boxes_heap.empty())
                 {
-                    auto current_box = boxes_heap.top();
+                    auto iou_candidate_box = boxes_heap.top();
                     if(not this->suppress_by_iou(
-                           batch_box(batch_boxes_start, current_box.second),
+                           batch_box(batch_boxes_start, iou_candidate_box.second),
                            batch_box(batch_boxes_start, next_top_score.second),
                            iou_threshold))
                     {
-                        remainder.push(current_box);
+                        remainder_boxes.push(iou_candidate_box);
                     }
                     boxes_heap.pop();
                 }
-                boxes_heap = remainder;
+                boxes_heap = remainder_boxes;
             }
         });
         std::copy(selected_indices.begin(), selected_indices.end(), output.begin());

--- a/src/include/migraphx/op/nonmaxsuppression.hpp
+++ b/src/include/migraphx/op/nonmaxsuppression.hpp
@@ -278,6 +278,7 @@ struct nonmaxsuppression
                 selected_indices.push_back(batch_idx);
                 selected_indices.push_back(class_idx);
                 selected_indices.push_back(next_top_score.second);
+                std::priority_queue<std::pair<double, int64_t>> remainder;
                 while(not boxes_heap.empty())
                 {
                     auto current_box = boxes_heap.top();
@@ -286,7 +287,7 @@ struct nonmaxsuppression
                            batch_box(batch_boxes_start, next_top_score.second),
                            iou_threshold))
                     {
-                        remainder.push(tmp_top_box);
+                        remainder.push(current_box);
                     }
                     boxes_heap.pop();
                 }

--- a/test/ref_ops_test.cpp
+++ b/test/ref_ops_test.cpp
@@ -34,7 +34,6 @@
 #include <migraphx/verify.hpp>
 #include <migraphx/onnx.hpp>
 #include <migraphx/make_op.hpp>
-#include <migraphx/time.hpp>
 
 #include <migraphx/serialize.hpp>
 
@@ -4929,17 +4928,7 @@ TEST_CASE(nms_dyn_out_test)
     mm->add_return({r});
 
     p.compile(migraphx::ref::target{});
-    auto output        = p.eval({}).back();
-    auto run_func      = [&]() { output = p.eval({}).back(); };
-    double host_time   = 0.0f;
-    using microseconds = std::chrono::duration<double, std::micro>;
-
-    for(size_t i = 0; i < 10000; i++)
-    {
-        host_time += migraphx::time<microseconds>(run_func);
-    }
-    std::cout << "NMS dyn_out test host_time : " << host_time << "\n";
-
+    auto output = p.eval({}).back();
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
     std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5};
@@ -4982,18 +4971,9 @@ TEST_CASE(nms_dyn_batch_test)
     migraphx::shape input_fixed_shape0{migraphx::shape::float_type, {2, 6, 4}};
     migraphx::shape input_fixed_shape1{migraphx::shape::float_type, {2, 1, 6}};
     migraphx::parameter_map params0;
-    params0["boxes"]   = migraphx::argument(input_fixed_shape0, boxes_vec.data());
-    params0["scores"]  = migraphx::argument(input_fixed_shape1, scores_vec.data());
-    auto output        = p.eval(params0).back();
-    auto run_func      = [&]() { output = p.eval({params0}).back(); };
-    double host_time   = 0.0f;
-    using microseconds = std::chrono::duration<double, std::micro>;
-
-    for(size_t i = 0; i < 10000; i++)
-    {
-        host_time += migraphx::time<microseconds>(run_func);
-    }
-    std::cout << "NMS dyn_batch test host_time : " << host_time << "\n";
+    params0["boxes"]  = migraphx::argument(input_fixed_shape0, boxes_vec.data());
+    params0["scores"] = migraphx::argument(input_fixed_shape1, scores_vec.data());
+    auto output       = p.eval(params0).back();
 
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
@@ -5034,18 +5014,9 @@ TEST_CASE(nms_dyn_boxes_test)
     migraphx::shape input_fixed_shape0{migraphx::shape::float_type, {1, 6, 4}};
     migraphx::shape input_fixed_shape1{migraphx::shape::float_type, {1, 1, 6}};
     migraphx::parameter_map params0;
-    params0["boxes"]   = migraphx::argument(input_fixed_shape0, boxes_vec.data());
-    params0["scores"]  = migraphx::argument(input_fixed_shape1, scores_vec.data());
-    auto output        = p.eval(params0).back();
-    auto run_func      = [&]() { output = p.eval({params0}).back(); };
-    double host_time   = 0.0f;
-    using microseconds = std::chrono::duration<double, std::micro>;
-
-    for(size_t i = 0; i < 10000; i++)
-    {
-        host_time += migraphx::time<microseconds>(run_func);
-    }
-    std::cout << "NMS dyn_boxes test host_time : " << host_time << "\n";
+    params0["boxes"]  = migraphx::argument(input_fixed_shape0, boxes_vec.data());
+    params0["scores"] = migraphx::argument(input_fixed_shape1, scores_vec.data());
+    auto output       = p.eval(params0).back();
 
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
@@ -5087,18 +5058,9 @@ TEST_CASE(nms_dyn_classes_test)
     migraphx::shape input_fixed_shape0{migraphx::shape::float_type, {1, 6, 4}};
     migraphx::shape input_fixed_shape1{migraphx::shape::float_type, {1, 2, 6}};
     migraphx::parameter_map params0;
-    params0["boxes"]   = migraphx::argument(input_fixed_shape0, boxes_vec.data());
-    params0["scores"]  = migraphx::argument(input_fixed_shape1, scores_vec.data());
-    auto output        = p.eval(params0).back();
-    auto run_func      = [&]() { output = p.eval({params0}).back(); };
-    double host_time   = 0.0f;
-    using microseconds = std::chrono::duration<double, std::micro>;
-
-    for(size_t i = 0; i < 10000; i++)
-    {
-        host_time += migraphx::time<microseconds>(run_func);
-    }
-    std::cout << "NMS dyn_classes test host_time : " << host_time << "\n";
+    params0["boxes"]  = migraphx::argument(input_fixed_shape0, boxes_vec.data());
+    params0["scores"] = migraphx::argument(input_fixed_shape1, scores_vec.data());
+    auto output       = p.eval(params0).back();
 
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
@@ -5135,16 +5097,7 @@ TEST_CASE(nms_not_center_test)
     mm->add_return({r});
 
     p.compile(migraphx::ref::target{});
-    auto output        = p.eval({}).back();
-    auto run_func      = [&]() { output = p.eval({}).back(); };
-    double host_time   = 0.0f;
-    using microseconds = std::chrono::duration<double, std::micro>;
-
-    for(size_t i = 0; i < 10000; i++)
-    {
-        host_time += migraphx::time<microseconds>(run_func);
-    }
-    std::cout << "NMS non-center test host_time : " << host_time << "\n";
+    auto output = p.eval({}).back();
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
     std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -5178,17 +5131,7 @@ TEST_CASE(nms_test)
     mm->add_return({r});
 
     p.compile(migraphx::ref::target{});
-    auto output        = p.eval({}).back();
-    auto run_func      = [&]() { output = p.eval({}).back(); };
-    double host_time   = 0.0f;
-    using microseconds = std::chrono::duration<double, std::micro>;
-
-    for(size_t i = 0; i < 10000; i++)
-    {
-        host_time += migraphx::time<microseconds>(run_func);
-    }
-    std::cout << "NMS test host_time : " << host_time << "\n";
-
+    auto output = p.eval({}).back();
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
     std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -5226,17 +5169,7 @@ TEST_CASE(nms_transpose1_test)
     mm->add_return({r});
 
     p.compile(migraphx::ref::target{});
-    auto output        = p.eval({}).back();
-    auto run_func      = [&]() { output = p.eval({}).back(); };
-    double host_time   = 0.0f;
-    using microseconds = std::chrono::duration<double, std::micro>;
-
-    for(size_t i = 0; i < 10000; i++)
-    {
-        host_time += migraphx::time<microseconds>(run_func);
-    }
-    std::cout << "NMS transpose test_1 host_time : " << host_time << "\n";
-
+    auto output = p.eval({}).back();
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
     std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -5274,17 +5207,7 @@ TEST_CASE(nms_transpose2_test)
     mm->add_return({r});
 
     p.compile(migraphx::ref::target{});
-    auto output        = p.eval({}).back();
-    auto run_func      = [&]() { output = p.eval({}).back(); };
-    double host_time   = 0.0f;
-    using microseconds = std::chrono::duration<double, std::micro>;
-
-    for(size_t i = 0; i < 10000; i++)
-    {
-        host_time += migraphx::time<microseconds>(run_func);
-    }
-    std::cout << "NMS tranpose test 2 host_time : " << host_time << "\n";
-
+    auto output = p.eval({}).back();
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
     std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0};

--- a/test/ref_ops_test.cpp
+++ b/test/ref_ops_test.cpp
@@ -34,6 +34,7 @@
 #include <migraphx/verify.hpp>
 #include <migraphx/onnx.hpp>
 #include <migraphx/make_op.hpp>
+#include <migraphx/time.hpp>
 
 #include <migraphx/serialize.hpp>
 
@@ -4928,7 +4929,17 @@ TEST_CASE(nms_dyn_out_test)
     mm->add_return({r});
 
     p.compile(migraphx::ref::target{});
-    auto output = p.eval({}).back();
+    auto output        = p.eval({}).back();
+    auto run_func      = [&]() { output = p.eval({}).back(); };
+    double host_time   = 0.0f;
+    using microseconds = std::chrono::duration<double, std::micro>;
+
+    for(size_t i = 0; i < 10000; i++)
+    {
+        host_time += migraphx::time<microseconds>(run_func);
+    }
+    std::cout << "NMS dyn_out test host_time : " << host_time << "\n";
+
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
     std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5};
@@ -4971,9 +4982,18 @@ TEST_CASE(nms_dyn_batch_test)
     migraphx::shape input_fixed_shape0{migraphx::shape::float_type, {2, 6, 4}};
     migraphx::shape input_fixed_shape1{migraphx::shape::float_type, {2, 1, 6}};
     migraphx::parameter_map params0;
-    params0["boxes"]  = migraphx::argument(input_fixed_shape0, boxes_vec.data());
-    params0["scores"] = migraphx::argument(input_fixed_shape1, scores_vec.data());
-    auto output       = p.eval(params0).back();
+    params0["boxes"]   = migraphx::argument(input_fixed_shape0, boxes_vec.data());
+    params0["scores"]  = migraphx::argument(input_fixed_shape1, scores_vec.data());
+    auto output        = p.eval(params0).back();
+    auto run_func      = [&]() { output = p.eval({params0}).back(); };
+    double host_time   = 0.0f;
+    using microseconds = std::chrono::duration<double, std::micro>;
+
+    for(size_t i = 0; i < 10000; i++)
+    {
+        host_time += migraphx::time<microseconds>(run_func);
+    }
+    std::cout << "NMS dyn_batch test host_time : " << host_time << "\n";
 
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
@@ -5014,9 +5034,18 @@ TEST_CASE(nms_dyn_boxes_test)
     migraphx::shape input_fixed_shape0{migraphx::shape::float_type, {1, 6, 4}};
     migraphx::shape input_fixed_shape1{migraphx::shape::float_type, {1, 1, 6}};
     migraphx::parameter_map params0;
-    params0["boxes"]  = migraphx::argument(input_fixed_shape0, boxes_vec.data());
-    params0["scores"] = migraphx::argument(input_fixed_shape1, scores_vec.data());
-    auto output       = p.eval(params0).back();
+    params0["boxes"]   = migraphx::argument(input_fixed_shape0, boxes_vec.data());
+    params0["scores"]  = migraphx::argument(input_fixed_shape1, scores_vec.data());
+    auto output        = p.eval(params0).back();
+    auto run_func      = [&]() { output = p.eval({params0}).back(); };
+    double host_time   = 0.0f;
+    using microseconds = std::chrono::duration<double, std::micro>;
+
+    for(size_t i = 0; i < 10000; i++)
+    {
+        host_time += migraphx::time<microseconds>(run_func);
+    }
+    std::cout << "NMS dyn_boxes test host_time : " << host_time << "\n";
 
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
@@ -5058,9 +5087,18 @@ TEST_CASE(nms_dyn_classes_test)
     migraphx::shape input_fixed_shape0{migraphx::shape::float_type, {1, 6, 4}};
     migraphx::shape input_fixed_shape1{migraphx::shape::float_type, {1, 2, 6}};
     migraphx::parameter_map params0;
-    params0["boxes"]  = migraphx::argument(input_fixed_shape0, boxes_vec.data());
-    params0["scores"] = migraphx::argument(input_fixed_shape1, scores_vec.data());
-    auto output       = p.eval(params0).back();
+    params0["boxes"]   = migraphx::argument(input_fixed_shape0, boxes_vec.data());
+    params0["scores"]  = migraphx::argument(input_fixed_shape1, scores_vec.data());
+    auto output        = p.eval(params0).back();
+    auto run_func      = [&]() { output = p.eval({params0}).back(); };
+    double host_time   = 0.0f;
+    using microseconds = std::chrono::duration<double, std::micro>;
+
+    for(size_t i = 0; i < 10000; i++)
+    {
+        host_time += migraphx::time<microseconds>(run_func);
+    }
+    std::cout << "NMS dyn_classes test host_time : " << host_time << "\n";
 
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
@@ -5097,7 +5135,16 @@ TEST_CASE(nms_not_center_test)
     mm->add_return({r});
 
     p.compile(migraphx::ref::target{});
-    auto output = p.eval({}).back();
+    auto output        = p.eval({}).back();
+    auto run_func      = [&]() { output = p.eval({}).back(); };
+    double host_time   = 0.0f;
+    using microseconds = std::chrono::duration<double, std::micro>;
+
+    for(size_t i = 0; i < 10000; i++)
+    {
+        host_time += migraphx::time<microseconds>(run_func);
+    }
+    std::cout << "NMS non-center test host_time : " << host_time << "\n";
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
     std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -5131,7 +5178,17 @@ TEST_CASE(nms_test)
     mm->add_return({r});
 
     p.compile(migraphx::ref::target{});
-    auto output = p.eval({}).back();
+    auto output        = p.eval({}).back();
+    auto run_func      = [&]() { output = p.eval({}).back(); };
+    double host_time   = 0.0f;
+    using microseconds = std::chrono::duration<double, std::micro>;
+
+    for(size_t i = 0; i < 10000; i++)
+    {
+        host_time += migraphx::time<microseconds>(run_func);
+    }
+    std::cout << "NMS test host_time : " << host_time << "\n";
+
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
     std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -5169,7 +5226,17 @@ TEST_CASE(nms_transpose1_test)
     mm->add_return({r});
 
     p.compile(migraphx::ref::target{});
-    auto output = p.eval({}).back();
+    auto output        = p.eval({}).back();
+    auto run_func      = [&]() { output = p.eval({}).back(); };
+    double host_time   = 0.0f;
+    using microseconds = std::chrono::duration<double, std::micro>;
+
+    for(size_t i = 0; i < 10000; i++)
+    {
+        host_time += migraphx::time<microseconds>(run_func);
+    }
+    std::cout << "NMS transpose test_1 host_time : " << host_time << "\n";
+
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
     std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -5207,7 +5274,17 @@ TEST_CASE(nms_transpose2_test)
     mm->add_return({r});
 
     p.compile(migraphx::ref::target{});
-    auto output = p.eval({}).back();
+    auto output        = p.eval({}).back();
+    auto run_func      = [&]() { output = p.eval({}).back(); };
+    double host_time   = 0.0f;
+    using microseconds = std::chrono::duration<double, std::micro>;
+
+    for(size_t i = 0; i < 10000; i++)
+    {
+        host_time += migraphx::time<microseconds>(run_func);
+    }
+    std::cout << "NMS tranpose test 2 host_time : " << host_time << "\n";
+
     std::vector<int64_t> result;
     output.visit([&](auto out) { result.assign(out.begin(), out.end()); });
     std::vector<int64_t> gold = {0, 0, 3, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0};


### PR DESCRIPTION
Speed up is not linear but on real data i think it should perform better. 

Off develop 10000 times
[   RUN    ] nms_dyn_out_test
NMS dyn_out test host_time : 66924.1
[ COMPLETE ] nms_dyn_out_test
[   RUN    ] nms_dyn_batch_test
NMS dyn_batch test host_time : 70200.2
[ COMPLETE ] nms_dyn_batch_test
[   RUN    ] nms_dyn_boxes_test
NMS dyn_boxes test host_time : 62569
[ COMPLETE ] nms_dyn_boxes_test
[   RUN    ] nms_dyn_classes_test
NMS dyn_classes test host_time : 57104.5
[ COMPLETE ] nms_dyn_classes_test
[   RUN    ] nms_not_center_test
NMS non-center test host_time : 61972
[ COMPLETE ] nms_not_center_test
[   RUN    ] nms_test
NMS test host_time : 62796.3
[ COMPLETE ] nms_test
[   RUN    ] nms_transpose1_test
NMS transpose test_1 host_time : 97670.9
[ COMPLETE ] nms_transpose1_test
[   RUN    ] nms_transpose2_test
NMS tranpose test 2 host_time : 98212.8
[ COMPLETE ] nms_transpose2_test



10000 times with changes 
[   RUN    ] nms_dyn_out_test
NMS dyn_out test host_time : 65745.5
[ COMPLETE ] nms_dyn_out_test
[   RUN    ] nms_dyn_batch_test
NMS dyn_batch test host_time : 71192.5
[ COMPLETE ] nms_dyn_batch_test
[   RUN    ] nms_dyn_boxes_test
NMS dyn_boxes test host_time : 60573.5
[ COMPLETE ] nms_dyn_boxes_test
[   RUN    ] nms_dyn_classes_test
NMS dyn_classes test host_time : 64699.9
[ COMPLETE ] nms_dyn_classes_test
[   RUN    ] nms_not_center_test
NMS non-center test host_time : 60937.5
[ COMPLETE ] nms_not_center_test
[   RUN    ] nms_test
NMS test host_time : 59600.2
[ COMPLETE ] nms_test
[   RUN    ] nms_transpose1_test
NMS transpose test_1 host_time : 92180.8
[ COMPLETE ] nms_transpose1_test
[   RUN    ] nms_transpose2_test
NMS tranpose test 2 host_time : 92331.8
[ COMPLETE ] nms_transpose2_test
