### PR TITLE
[MLIR] add dot offloads with manual tuning support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN git clone --single-branch --branch ${ONNXRUNTIME_BRANCH} --recursive ${ONNXR
 
 ADD tools/build_and_test_onnxrt.sh /onnxruntime/build_and_test_onnxrt.sh
 
-RUN cget -p /usr/local install ROCmSoftwarePlatform/rocMLIR@78b706fe9879587ab98b6614ae539265374a3fae -DBUILD_MIXR_TARGET=On -DLLVM_ENABLE_ZSTD=Off -DLLVM_ENABLE_THREADS=Off
+RUN cget -p /usr/local install ROCmSoftwarePlatform/rocMLIR@5b4cd34a0a1486cfacf449fa005783e0427e59ba -DBUILD_MIXR_TARGET=On -DLLVM_ENABLE_ZSTD=Off -DLLVM_ENABLE_THREADS=Off
 
 ENV MIOPEN_FIND_DB_PATH=/tmp/miopen/find-db
 ENV MIOPEN_USER_DB_PATH=/tmp/miopen/user-db

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN git clone --single-branch --branch ${ONNXRUNTIME_BRANCH} --recursive ${ONNXR
 
 ADD tools/build_and_test_onnxrt.sh /onnxruntime/build_and_test_onnxrt.sh
 
-RUN cget -p /usr/local install ROCmSoftwarePlatform/rocMLIR@5b4cd34a0a1486cfacf449fa005783e0427e59ba -DBUILD_MIXR_TARGET=On -DLLVM_ENABLE_ZSTD=Off -DLLVM_ENABLE_THREADS=Off
+RUN cget -p /usr/local install ROCmSoftwarePlatform/rocMLIR@acb727b348086b58a7f261b32c0e4f0686a4c0ee -DBUILD_MIXR_TARGET=On -DLLVM_ENABLE_ZSTD=Off -DLLVM_ENABLE_THREADS=Off
 
 ENV MIOPEN_FIND_DB_PATH=/tmp/miopen/find-db
 ENV MIOPEN_USER_DB_PATH=/tmp/miopen/user-db

--- a/src/targets/gpu/jit/mlir.cpp
+++ b/src/targets/gpu/jit/mlir.cpp
@@ -32,7 +32,7 @@ namespace gpu {
 
 struct mlir_compiler : compiler<mlir_compiler>
 {
-    std::vector<std::string> names() const { return {"gpu::mlir_conv"}; }
+    std::vector<std::string> names() const { return {"gpu::mlir_conv", "gpu::mlir_dot"}; }
 
     operation compile_op(context&, const std::vector<shape>&, const value&) const { return {}; }
 

--- a/src/targets/gpu/jit/mlir.cpp
+++ b/src/targets/gpu/jit/mlir.cpp
@@ -32,7 +32,7 @@ namespace gpu {
 
 struct mlir_compiler : compiler<mlir_compiler>
 {
-    std::vector<std::string> names() const { return {"gpu::mlir_conv", "gpu::mlir_dot"}; }
+    std::vector<std::string> names() const { return {"gpu::mlir_op"}; }
 
     operation compile_op(context&, const std::vector<shape>&, const value&) const { return {}; }
 


### PR DESCRIPTION
This commit adds dot + pointwise fusion support
along with manual tuning using rocMLIR.

# Usage

## Non-tuning (heuristic mode) default flow

```
MIGRAPHX_ENABLE_MLIR=1 ./bin/migraphx-driver perf --onnx ../models/model_torch_export_fp32.onnx --fill1 input_ids --input-dim @input_ids 1 384
```

This would show warnings that the current compilation is not using tuning db as follows : 

```
Compiling ... 
Reading: ../models/model_torch_export_fp32.onnx
WARNING: MLIR tuning db not found. Please set MIGRAPHX_MLIR_TUNING_DB for optimal performance.
fails to set param ongfx90a:sramecc+:xnack-	-transA false -transB false -g 1 -m 384 -n 768 -k 768 -t f32
WARNING: MLIR tuning db not found. Please set MIGRAPHX_MLIR_TUNING_DB for optimal performance.
....
```

## The manual tuning process

### Obtain the tuning configuration for the model

```
MIGRAPHX_ENABLE_MLIR=1 MIGRAPHX_MLIR_TUNING_CFG=bert.cfg ./bin/migraphx-driver compile --onnx ../models/model_torch_export_fp32.onnx --fill1 input_ids --input-dim @input_ids 1 384
```

This will create at most two files:
1) bert.cfg.gemm
2) bert.cfg.conv (if fused convs were present in the model -- no for bert case)

### Tune using helper python scripts of rocMLIR

1) checkout https://github.com/ROCmSoftwarePlatform/rocMLIR
2) build using the target : ninja check-rocmlir-build-only ci-performance-scripts
3) tune using the configs from the previous step

```
cd build
./bin/tuningRunner.py --op=gemm --configs_file=/var/mkarunar/work/AMDMIGraphX/build/bert.cfg.gemm --output=bt.tsv --verify-mode=none
# if convs were present
./bin/tuningRunner.py --op=conv --configs_file=/var/mkarunar/work/AMDMIGraphX/build/bert.cfg.conv --output=bt.tsv --verify-mode=none
```

Note : even if the .cfg has duplicated lines, the tuning will not perform duplicated tuning and it will append .tsv files. Therefore, one could do this for several models and obtain a single database file.

### Use tuning db with MIGraphX

```
MIGRAPHX_ENABLE_MLIR=1 MIGRAPHX_MLIR_TUNING_DB=/var/mkarunar/work/rocMLIR/build/bt.tsv ./bin/migraphx-driver perf --onnx ../models/model_torch_export_fp32.onnx --fill1 input_ids --input-dim @input_ids 1 384
```

Ideally the above command should not give any warning as we expect all the problem configs to be found in the tuned database.

closes : https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/823 (more like not needed now if we can make this work)

