### PR TITLE
Fix default target in driver

### DIFF
--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -44,7 +44,13 @@ set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${CMAKE_RUNTIME_
 rocm_clang_tidy_check(driver)
 target_link_libraries(driver migraphx migraphx_onnx migraphx_tf)
 if(MIGRAPHX_ENABLE_GPU)
-target_compile_definitions(driver PUBLIC -DHAVE_GPU)
+        target_compile_definitions(driver PUBLIC -DHAVE_GPU)
+endif()
+if(MIGRAPHX_ENABLE_CPU)
+        target_compile_definitions(driver PUBLIC -DHAVE_CPU)
+endif()
+if(MIGRAPHX_ENABLE_FPGA)
+        target_compile_definitions(driver PUBLIC -DHAVE_FPGA)
 endif()
 
 rocm_install_targets(

--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -42,16 +42,8 @@ add_custom_command(
 )
 set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/driver)
 rocm_clang_tidy_check(driver)
-target_link_libraries(driver migraphx migraphx_onnx migraphx_tf)
-if(MIGRAPHX_ENABLE_GPU)
-        target_compile_definitions(driver PUBLIC -DHAVE_GPU)
-endif()
-if(MIGRAPHX_ENABLE_CPU)
-        target_compile_definitions(driver PUBLIC -DHAVE_CPU)
-endif()
-if(MIGRAPHX_ENABLE_FPGA)
-        target_compile_definitions(driver PUBLIC -DHAVE_FPGA)
-endif()
+
+target_link_libraries(driver migraphx_all_targets migraphx_onnx migraphx_tf)
 
 rocm_install_targets(
   TARGETS driver

--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -43,6 +43,9 @@ add_custom_command(
 set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/driver)
 rocm_clang_tidy_check(driver)
 target_link_libraries(driver migraphx migraphx_onnx migraphx_tf)
+if(MIGRAPHX_ENABLE_GPU)
+target_compile_definitions(driver PUBLIC -DHAVE_GPU)
+endif()
 
 rocm_install_targets(
   TARGETS driver

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -305,8 +305,12 @@ struct compiler_target
 {
 #ifdef HAVE_GPU
     std::string target_name = "gpu";
-#else
+#elif HAVE_CPU
     std::string target_name = "cpu";
+#elif HAVE_FPGA
+    std::string target_name = "fpga"
+#else
+    std::string target_name = "ref"
 #endif
 
     void parse(argument_parser& ap)


### PR DESCRIPTION
Recent changes #1608  removed `migraphx_all_target` lib from `driver` and that led to missing compile time definitions.

Missing compile definitions led to change of default target in `driver`.

This PR fixes that. 

can't use lazy loading in `driver`. it requires GPU header files for perf measurements.

