### PR TITLE
Remove version name from check_context 

### DIFF
--- a/examples/migraphx/migraphx_driver/README.md
+++ b/examples/migraphx/migraphx_driver/README.md
@@ -88,7 +88,7 @@ batch_norm_inference
 broadcast
 capture
 ceil
-check_context::migraphx::version_1::gpu::context
+check_context::gpu::context
 clip
 concat
 contiguous
@@ -304,7 +304,7 @@ $ /opt/rocm/bin/migraphx-driver run --onnx simple_graph.onnx
 ```
 Compiling ... 
 Reading: simple_graph.onnx
-@0 = check_context::migraphx::version_1::gpu::context -> float_type, {}, {}
+@0 = check_context::gpu::context -> float_type, {}, {}
 @1 = hip::hip_allocate_memory[shape=float_type, {256}, {1},id=scratch] -> float_type, {256}, {1}
 @2 = hip::hip_copy_literal[id=@literal:1] -> float_type, {784, 128}, {128, 1}
 x:0 = @param:x:0 -> float_type, {1, 28, 28}, {784, 28, 1}
@@ -327,7 +327,7 @@ x:0 = @param:x:0 -> float_type, {1, 28, 28}, {784, 28, 1}
 @18 = @return(@17)
 
 Allocating params ... 
-@0 = check_context::migraphx::version_1::gpu::context -> float_type, {}, {}
+@0 = check_context::gpu::context -> float_type, {}, {}
 @1 = hip::hip_allocate_memory[shape=float_type, {256}, {1},id=scratch] -> float_type, {256}, {1}
 @2 = hip::hip_copy_literal[id=@literal:1] -> float_type, {784, 128}, {128, 1}
 x:0 = @param:x:0 -> float_type, {1, 28, 28}, {784, 28, 1}
@@ -399,7 +399,7 @@ $ /opt/rocm/bin/migraphx-driver compile --gpu --fp16 simple_graph.pb
 ```
 Compiling ... 
 Reading: simple_graph.pb
-@0 = check_context::migraphx::version_1::gpu::context -> float_type, {}, {}
+@0 = check_context::gpu::context -> float_type, {}, {}
 @1 = hip::hip_allocate_memory[shape=float_type, {456}, {1},id=scratch] -> float_type, {456}, {1}
 @2 = hip::hip_copy_literal[id=@literal:0] -> half_type, {784, 128}, {128, 1}
 @3 = load[offset=256,end=1824](@1) -> half_type, {1, 28, 28}, {784, 28, 1}
@@ -502,7 +502,7 @@ x = @param:x -> float_type, {1, 28, 28}, {784, 28, 1}
 @18 = ref::softmax[axis=1](@17) -> float_type, {1, 10}, {10, 1}
 @19 = ref::identity(@18) -> float_type, {1, 10}, {10, 1}
 
-@0 = check_context::migraphx::version_1::gpu::context -> float_type, {}, {}
+@0 = check_context::gpu::context -> float_type, {}, {}
 @1 = hip::hip_allocate_memory[shape=float_type, {256}, {1},id=scratch] -> float_type, {256}, {1}
 @2 = hip::hip_copy_literal[id=@literal:3] -> float_type, {784, 128}, {128, 1}
 x = @param:x -> float_type, {1, 28, 28}, {784, 28, 1}
@@ -538,7 +538,7 @@ $ /opt/rocm/bin/migraphx-driver perf simple_graph.pb
 ```
 Compiling ... 
 Reading: simple_graph.pb
-@0 = check_context::migraphx::version_1::gpu::context -> float_type, {}, {}
+@0 = check_context::gpu::context -> float_type, {}, {}
 @1 = hip::hip_allocate_memory[shape=float_type, {256}, {1},id=scratch] -> float_type, {256}, {1}
 @2 = hip::hip_copy_literal[id=@literal:3] -> float_type, {784, 128}, {128, 1}
 @3 = load[offset=0,end=512](@1) -> float_type, {1, 128}, {128, 1}
@@ -561,7 +561,7 @@ output = @param:output -> float_type, {1, 10}, {10, 1}
 
 Allocating params ... 
 Running performance report ... 
-@0 = check_context::migraphx::version_1::gpu::context -> float_type, {}, {}: 0.00057782ms, 1%
+@0 = check_context::gpu::context -> float_type, {}, {}: 0.00057782ms, 1%
 @1 = hip::hip_allocate_memory[shape=float_type, {256}, {1},id=scratch] -> float_type, {256}, {1}: 0.000295ms, 1%
 @2 = hip::hip_copy_literal[id=@literal:3] -> float_type, {784, 128}, {128, 1}: 0.00027942ms, 1%
 @3 = load[offset=0,end=512](@1) -> float_type, {1, 128}, {128, 1}: 0.000232ms, 1%
@@ -591,7 +591,7 @@ hip::hip_copy_literal: 0.00186824ms, 1%
 load: 0.0016288ms, 1%
 @param: 0.0013428ms, 1%
 broadcast: 0.00118042ms, 1%
-check_context::migraphx::version_1::gpu::context: 0.00057782ms, 1%
+check_context::gpu::context: 0.00057782ms, 1%
 reshape: 0.00033842ms, 1%
 hip::hip_allocate_memory: 0.000295ms, 1%
 

--- a/examples/migraphx/migraphx_driver/README.md
+++ b/examples/migraphx/migraphx_driver/README.md
@@ -88,7 +88,7 @@ batch_norm_inference
 broadcast
 capture
 ceil
-check_context::gpu::context
+check_context::migraphx::gpu::context
 clip
 concat
 contiguous
@@ -304,7 +304,7 @@ $ /opt/rocm/bin/migraphx-driver run --onnx simple_graph.onnx
 ```
 Compiling ... 
 Reading: simple_graph.onnx
-@0 = check_context::gpu::context -> float_type, {}, {}
+@0 = check_context::migraphx::gpu::context -> float_type, {}, {}
 @1 = hip::hip_allocate_memory[shape=float_type, {256}, {1},id=scratch] -> float_type, {256}, {1}
 @2 = hip::hip_copy_literal[id=@literal:1] -> float_type, {784, 128}, {128, 1}
 x:0 = @param:x:0 -> float_type, {1, 28, 28}, {784, 28, 1}
@@ -327,7 +327,7 @@ x:0 = @param:x:0 -> float_type, {1, 28, 28}, {784, 28, 1}
 @18 = @return(@17)
 
 Allocating params ... 
-@0 = check_context::gpu::context -> float_type, {}, {}
+@0 = check_context::migraphx::gpu::context -> float_type, {}, {}
 @1 = hip::hip_allocate_memory[shape=float_type, {256}, {1},id=scratch] -> float_type, {256}, {1}
 @2 = hip::hip_copy_literal[id=@literal:1] -> float_type, {784, 128}, {128, 1}
 x:0 = @param:x:0 -> float_type, {1, 28, 28}, {784, 28, 1}
@@ -399,7 +399,7 @@ $ /opt/rocm/bin/migraphx-driver compile --gpu --fp16 simple_graph.pb
 ```
 Compiling ... 
 Reading: simple_graph.pb
-@0 = check_context::gpu::context -> float_type, {}, {}
+@0 = check_context::migraphx::gpu::context -> float_type, {}, {}
 @1 = hip::hip_allocate_memory[shape=float_type, {456}, {1},id=scratch] -> float_type, {456}, {1}
 @2 = hip::hip_copy_literal[id=@literal:0] -> half_type, {784, 128}, {128, 1}
 @3 = load[offset=256,end=1824](@1) -> half_type, {1, 28, 28}, {784, 28, 1}
@@ -502,7 +502,7 @@ x = @param:x -> float_type, {1, 28, 28}, {784, 28, 1}
 @18 = ref::softmax[axis=1](@17) -> float_type, {1, 10}, {10, 1}
 @19 = ref::identity(@18) -> float_type, {1, 10}, {10, 1}
 
-@0 = check_context::gpu::context -> float_type, {}, {}
+@0 = check_context::migraphx::gpu::context -> float_type, {}, {}
 @1 = hip::hip_allocate_memory[shape=float_type, {256}, {1},id=scratch] -> float_type, {256}, {1}
 @2 = hip::hip_copy_literal[id=@literal:3] -> float_type, {784, 128}, {128, 1}
 x = @param:x -> float_type, {1, 28, 28}, {784, 28, 1}
@@ -538,7 +538,7 @@ $ /opt/rocm/bin/migraphx-driver perf simple_graph.pb
 ```
 Compiling ... 
 Reading: simple_graph.pb
-@0 = check_context::gpu::context -> float_type, {}, {}
+@0 = check_context::migraphx::gpu::context -> float_type, {}, {}
 @1 = hip::hip_allocate_memory[shape=float_type, {256}, {1},id=scratch] -> float_type, {256}, {1}
 @2 = hip::hip_copy_literal[id=@literal:3] -> float_type, {784, 128}, {128, 1}
 @3 = load[offset=0,end=512](@1) -> float_type, {1, 128}, {128, 1}
@@ -561,7 +561,7 @@ output = @param:output -> float_type, {1, 10}, {10, 1}
 
 Allocating params ... 
 Running performance report ... 
-@0 = check_context::gpu::context -> float_type, {}, {}: 0.00057782ms, 1%
+@0 = check_context::migraphx::gpu::context -> float_type, {}, {}: 0.00057782ms, 1%
 @1 = hip::hip_allocate_memory[shape=float_type, {256}, {1},id=scratch] -> float_type, {256}, {1}: 0.000295ms, 1%
 @2 = hip::hip_copy_literal[id=@literal:3] -> float_type, {784, 128}, {128, 1}: 0.00027942ms, 1%
 @3 = load[offset=0,end=512](@1) -> float_type, {1, 128}, {128, 1}: 0.000232ms, 1%
@@ -591,7 +591,7 @@ hip::hip_copy_literal: 0.00186824ms, 1%
 load: 0.0016288ms, 1%
 @param: 0.0013428ms, 1%
 broadcast: 0.00118042ms, 1%
-check_context::gpu::context: 0.00057782ms, 1%
+check_context::migraphx::gpu::context: 0.00057782ms, 1%
 reshape: 0.00033842ms, 1%
 hip::hip_allocate_memory: 0.000295ms, 1%
 

--- a/src/include/migraphx/check_context.hpp
+++ b/src/include/migraphx/check_context.hpp
@@ -38,7 +38,7 @@ struct check_context
 {
     struct op : auto_register_op<op>
     {
-        std::string name() const
+        static std::string name()
         {
             const auto& op_type_name                      = get_type_name<T>();
             const auto& split_name                        = split_string(op_type_name, ':');
@@ -52,7 +52,8 @@ struct check_context
                     name_without_version.push_back(i);
                 }
             });
-            return join_strings(name_without_version, "");
+            static std::string op_name = join_strings(name_without_version, "");
+            return op_name;
         }
 
         shape compute_shape(const std::vector<shape>&) const { return {}; }

--- a/src/include/migraphx/check_context.hpp
+++ b/src/include/migraphx/check_context.hpp
@@ -45,14 +45,12 @@ struct check_context
             std::vector<std::string> name_without_version = {"check_context"};
             // op_type_name would contain internal namespace name with version_x_y_z
             // remove version and construct op_name such as check_context::migraphx::gpu::context
-            std::for_each(split_name.begin(), split_name.end(), [&](const auto& i) {
-                if(not i.empty() and not contains(i, "version"))
-                {
-                    name_without_version.push_back("::");
-                    name_without_version.push_back(i);
-                }
-            });
-            static std::string op_name = join_strings(name_without_version, "");
+            std::copy_if(
+                split_name.begin(),
+                split_name.end(),
+                std::back_inserter(name_without_version),
+                [&](const auto& i) { return not i.empty() and not contains(i, "version"); });
+            static std::string op_name = join_strings(name_without_version, "::");
             return op_name;
         }
 

--- a/src/include/migraphx/check_context.hpp
+++ b/src/include/migraphx/check_context.hpp
@@ -39,8 +39,8 @@ struct check_context
     {
         std::string name() const
         {
-            const auto op_type_name = get_type_name<T>();
-            const auto& split_name  = split_string(op_type_name, ':');
+            const auto& op_type_name = get_type_name<T>();
+            const auto& split_name   = split_string(op_type_name, ':');
             // construct name as check_context::gpu::context or check_context::cpu::context or
             // likewise.
             return "check_context::" + split_name[split_name.size() - 3] +

--- a/src/include/migraphx/check_context.hpp
+++ b/src/include/migraphx/check_context.hpp
@@ -38,7 +38,7 @@ struct check_context
 {
     struct op : auto_register_op<op>
     {
-        static std::string name()
+        static std::string compute_op_name()
         {
             const auto& op_type_name                      = get_type_name<T>();
             const auto& split_name                        = split_string(op_type_name, ':');
@@ -50,7 +50,12 @@ struct check_context
                 split_name.end(),
                 std::back_inserter(name_without_version),
                 [&](const auto& i) { return not i.empty() and not contains(i, "version"); });
-            static std::string op_name = join_strings(name_without_version, "::");
+            return join_strings(name_without_version, "::");
+        }
+
+        std::string name() const
+        {
+            static auto op_name = compute_op_name();
             return op_name;
         }
 

--- a/src/include/migraphx/check_context.hpp
+++ b/src/include/migraphx/check_context.hpp
@@ -27,6 +27,7 @@
 #include <migraphx/program.hpp>
 #include <migraphx/config.hpp>
 #include <migraphx/register_op.hpp>
+#include <migraphx/stringutils.hpp>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -36,7 +37,15 @@ struct check_context
 {
     struct op : auto_register_op<op>
     {
-        std::string name() const { return "check_context::" + get_type_name<T>(); }
+        std::string name() const
+        {
+            const auto op_type_name = get_type_name<T>();
+            const auto& split_name  = split_string(op_type_name, ':');
+            // construct name as check_context::gpu::context or check_context::cpu::context or
+            // likewise.
+            return "check_context::" + split_name[split_name.size() - 3] +
+                   "::" + split_name[split_name.size() - 1];
+        }
         shape compute_shape(const std::vector<shape>&) const { return {}; }
         argument compute(context& ctx, const shape&, const std::vector<argument>&) const
         {

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -491,7 +491,7 @@ std::vector<argument> program::eval(parameter_map params, execution_environment 
     return ret;
 }
 
-const int program_file_version = 5;
+const int program_file_version = 6;
 
 value program::to_value() const
 {
@@ -625,7 +625,7 @@ void program::from_value(const value& v)
     auto version = v.at("version").to<int>();
     if(version != program_file_version)
     {
-        MIGRAPHX_THROW("Warning: Program version mismatch");
+        MIGRAPHX_THROW("Warning: Program version mismatch, try using older version of MIGraphX.");
     }
 
     this->impl->target_name = v.at("target").to<std::string>();

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -491,7 +491,7 @@ std::vector<argument> program::eval(parameter_map params, execution_environment 
     return ret;
 }
 
-const int program_file_version = 6;
+const int program_file_version = 5;
 
 value program::to_value() const
 {
@@ -625,7 +625,7 @@ void program::from_value(const value& v)
     auto version = v.at("version").to<int>();
     if(version != program_file_version)
     {
-        MIGRAPHX_THROW("Warning: Program version mismatch, try using older version of MIGraphX.");
+        MIGRAPHX_THROW("Warning: Program version mismatch");
     }
 
     this->impl->target_name = v.at("target").to<std::string>();

--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -35,7 +35,6 @@
 #include <migraphx/stringutils.hpp>
 #include <migraphx/tf.hpp>
 #include <migraphx/onnx.hpp>
-#include <migraphx/type_name.hpp>
 #include <migraphx/load_save.hpp>
 #include <migraphx/register_target.hpp>
 #include <migraphx/json.hpp>

--- a/src/targets/gpu/include/migraphx/gpu/oper.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/oper.hpp
@@ -31,7 +31,6 @@
 #include <migraphx/argument.hpp>
 #include <migraphx/config.hpp>
 #include <migraphx/reduce_dims.hpp>
-#include <migraphx/type_name.hpp>
 #include <utility>
 #include <iostream>
 

--- a/src/targets/gpu/include/migraphx/gpu/prefix_scan_sum.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/prefix_scan_sum.hpp
@@ -33,7 +33,6 @@
 #include <migraphx/shape.hpp>
 #include <migraphx/argument.hpp>
 #include <migraphx/config.hpp>
-#include <migraphx/type_name.hpp>
 #include <utility>
 #include <iostream>
 

--- a/src/targets/gpu/include/migraphx/gpu/reduce_op.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/reduce_op.hpp
@@ -31,7 +31,6 @@
 #include <migraphx/shape.hpp>
 #include <migraphx/argument.hpp>
 #include <migraphx/config.hpp>
-#include <migraphx/type_name.hpp>
 #include <utility>
 #include <iostream>
 


### PR DESCRIPTION
https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/pull/1633 Introduced versioning of symbols.
`check_context` op relied on the namespace symbol to construct its name. 

All the previously generated MXR files would become incompatible with #1633. 

Example: DLRM which used an MXR file failed on performance tests with the following error:

terminate called after throwing an instance of 'migraphx::version_2_6_0::exception'
what(): /src/AMDMIGraphX/src/include/migraphx/ranges.hpp:112: at: Operator not found: check_context::migraphx::version_1::gpu::context