### PR TITLE
Enable parallel compilation with hiprtc

### DIFF
--- a/src/compile_src.cpp
+++ b/src/compile_src.cpp
@@ -75,30 +75,5 @@ std::vector<char> src_compiler::compile(const std::vector<src_file>& srcs) const
     return read_buffer(out_path.string());
 }
 
-template <class T>
-std::pair<std::intptr_t, std::intptr_t> to_intptr(const std::pair<T*, T*>& p)
-{
-    return std::make_pair(reinterpret_cast<std::intptr_t>(p.first),
-                          reinterpret_cast<std::intptr_t>(p.second));
-}
-
-template <class T>
-std::pair<T*, T*> to_pointer(const std::pair<std::intptr_t, std::intptr_t>& p)
-{
-    return std::make_pair(reinterpret_cast<T*>(p.first), reinterpret_cast<T*>(p.second));
-}
-
-void migraphx_to_value(value& v, const src_file& s)
-{
-    v["path"]    = s.path.string();
-    v["content"] = to_value(to_intptr(s.content));
-}
-void migraphx_from_value(const value& v, src_file& s)
-{
-    s.path    = v.at("path").to<std::string>();
-    s.content = to_pointer<const char>(
-        from_value<std::pair<std::intptr_t, std::intptr_t>>(v.at("content")));
-}
-
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace migraphx

--- a/src/compile_src.cpp
+++ b/src/compile_src.cpp
@@ -26,6 +26,8 @@
 #include <migraphx/tmp_dir.hpp>
 #include <migraphx/stringutils.hpp>
 #include <migraphx/errors.hpp>
+#include <migraphx/value.hpp>
+#include <migraphx/serialize.hpp>
 #include <cassert>
 
 namespace migraphx {
@@ -71,6 +73,29 @@ std::vector<char> src_compiler::compile(const std::vector<src_file>& srcs) const
         MIGRAPHX_THROW("Output file missing: " + out);
 
     return read_buffer(out_path.string());
+}
+
+template<class T>
+std::pair<std::intptr_t, std::intptr_t> to_intptr(const std::pair<T*, T*>& p)
+{
+    return std::make_pair(reinterpret_cast<std::intptr_t>(p.first), reinterpret_cast<std::intptr_t>(p.second));
+}
+
+template<class T>
+std::pair<T*, T*> to_pointer(const std::pair<std::intptr_t, std::intptr_t>& p)
+{
+    return std::make_pair(reinterpret_cast<T*>(p.first), reinterpret_cast<T*>(p.second));
+}
+
+void migraphx_to_value(value& v, const src_file& s)
+{
+    v["path"] = s.path.string();
+    v["content"] = to_value(to_intptr(s.content));
+}
+void migraphx_from_value(const value& v, src_file& s)
+{
+    s.path = v.at("path").to<std::string>();
+    s.content = to_pointer<const char>(from_value<std::pair<std::intptr_t, std::intptr_t>>(v.at("content")));
 }
 
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/compile_src.cpp
+++ b/src/compile_src.cpp
@@ -75,13 +75,14 @@ std::vector<char> src_compiler::compile(const std::vector<src_file>& srcs) const
     return read_buffer(out_path.string());
 }
 
-template<class T>
+template <class T>
 std::pair<std::intptr_t, std::intptr_t> to_intptr(const std::pair<T*, T*>& p)
 {
-    return std::make_pair(reinterpret_cast<std::intptr_t>(p.first), reinterpret_cast<std::intptr_t>(p.second));
+    return std::make_pair(reinterpret_cast<std::intptr_t>(p.first),
+                          reinterpret_cast<std::intptr_t>(p.second));
 }
 
-template<class T>
+template <class T>
 std::pair<T*, T*> to_pointer(const std::pair<std::intptr_t, std::intptr_t>& p)
 {
     return std::make_pair(reinterpret_cast<T*>(p.first), reinterpret_cast<T*>(p.second));
@@ -89,13 +90,14 @@ std::pair<T*, T*> to_pointer(const std::pair<std::intptr_t, std::intptr_t>& p)
 
 void migraphx_to_value(value& v, const src_file& s)
 {
-    v["path"] = s.path.string();
+    v["path"]    = s.path.string();
     v["content"] = to_value(to_intptr(s.content));
 }
 void migraphx_from_value(const value& v, src_file& s)
 {
-    s.path = v.at("path").to<std::string>();
-    s.content = to_pointer<const char>(from_value<std::pair<std::intptr_t, std::intptr_t>>(v.at("content")));
+    s.path    = v.at("path").to<std::string>();
+    s.content = to_pointer<const char>(
+        from_value<std::pair<std::intptr_t, std::intptr_t>>(v.at("content")));
 }
 
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/dynamic_loader.cpp
+++ b/src/dynamic_loader.cpp
@@ -71,6 +71,16 @@ struct dynamic_loader_impl
     std::shared_ptr<tmp_dir> temp = nullptr;
 };
 
+fs::path dynamic_loader::path(void* address)
+{
+    fs::path p;
+    Dl_info info;
+    // Find the location of .so
+    if(dladdr(address, &info))
+        p = info.dli_fname;
+    return p;
+}
+
 dynamic_loader::dynamic_loader(const fs::path& p) : impl(std::make_shared<dynamic_loader_impl>(p))
 {
 }

--- a/src/dynamic_loader.cpp
+++ b/src/dynamic_loader.cpp
@@ -76,7 +76,7 @@ fs::path dynamic_loader::path(void* address)
     fs::path p;
     Dl_info info;
     // Find the location of .so
-    if(dladdr(address, &info))
+    if(dladdr(address, &info) != 0)
         p = info.dli_fname;
     return p;
 }

--- a/src/include/migraphx/compile_src.hpp
+++ b/src/include/migraphx/compile_src.hpp
@@ -43,9 +43,6 @@ struct src_file
     std::size_t len() const { return content.second - content.first; }
 };
 
-void migraphx_to_value(value& v, const src_file& s);
-void migraphx_from_value(const value& v, src_file& s);
-
 struct src_compiler
 {
     std::string compiler                      = "c++";

--- a/src/include/migraphx/compile_src.hpp
+++ b/src/include/migraphx/compile_src.hpp
@@ -34,12 +34,17 @@
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
+struct value;
+
 struct src_file
 {
     fs::path path;
     std::pair<const char*, const char*> content;
     std::size_t len() const { return content.second - content.first; }
 };
+
+void migraphx_to_value(value& v, const src_file& s);
+void migraphx_from_value(const value& v, src_file& s);
 
 struct src_compiler
 {

--- a/src/include/migraphx/dynamic_loader.hpp
+++ b/src/include/migraphx/dynamic_loader.hpp
@@ -37,6 +37,11 @@ struct dynamic_loader_impl;
 
 struct dynamic_loader
 {
+    template<class T>
+    static fs::path path(T* address)
+    {
+        return path(reinterpret_cast<void*>(address));
+    }
     static fs::path path(void* address);
     dynamic_loader() = default;
 

--- a/src/include/migraphx/dynamic_loader.hpp
+++ b/src/include/migraphx/dynamic_loader.hpp
@@ -37,7 +37,7 @@ struct dynamic_loader_impl;
 
 struct dynamic_loader
 {
-    template<class T>
+    template <class T>
     static fs::path path(T* address)
     {
         return path(reinterpret_cast<void*>(address));

--- a/src/include/migraphx/dynamic_loader.hpp
+++ b/src/include/migraphx/dynamic_loader.hpp
@@ -37,6 +37,7 @@ struct dynamic_loader_impl;
 
 struct dynamic_loader
 {
+    static fs::path path(void* address);
     dynamic_loader() = default;
 
     dynamic_loader(const fs::path& p);

--- a/src/include/migraphx/msgpack.hpp
+++ b/src/include/migraphx/msgpack.hpp
@@ -30,6 +30,7 @@
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 
+void to_msgpack(const value& v, std::function<void(const char*, std::size_t)> writer);
 std::vector<char> to_msgpack(const value& v);
 value from_msgpack(const std::vector<char>& buffer);
 value from_msgpack(const char* buffer, std::size_t size);

--- a/src/include/migraphx/process.hpp
+++ b/src/include/migraphx/process.hpp
@@ -26,6 +26,7 @@
 
 #include <migraphx/config.hpp>
 #include <migraphx/filesystem.hpp>
+#include <functional>
 #include <string>
 #include <memory>
 
@@ -36,6 +37,7 @@ struct process_impl;
 
 struct process
 {
+    using writer = std::function<void(const char*, std::size_t)>;
     process(const std::string& cmd);
 
     // move constructor
@@ -49,6 +51,7 @@ struct process
     process& cwd(const fs::path& p);
 
     void exec();
+    void write(std::function<void(process::writer)> pipe_in);
 
     private:
     std::unique_ptr<process_impl> impl;

--- a/src/msgpack.cpp
+++ b/src/msgpack.cpp
@@ -184,7 +184,7 @@ struct writer_stream
 
 void to_msgpack(const value& v, std::function<void(const char*, std::size_t)> writer)
 {
-    writer_stream ws{writer};
+    writer_stream ws{std::move(writer)};
     msgpack::pack(ws, v);
 }
 

--- a/src/msgpack.cpp
+++ b/src/msgpack.cpp
@@ -172,6 +172,22 @@ struct vector_stream
     }
 };
 
+struct writer_stream
+{
+    std::function<void(const char*, std::size_t)> writer;
+    writer_stream& write(const char* b, std::size_t n)
+    {
+        writer(b, n);
+        return *this;
+    }
+};
+
+void to_msgpack(const value& v, std::function<void(const char*, std::size_t)> writer)
+{
+    writer_stream ws{writer};
+    msgpack::pack(ws, v);
+}
+
 std::vector<char> to_msgpack(const value& v)
 {
     vector_stream vs;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -38,7 +38,7 @@ std::function<void(const char*)> redirect_to(std::ostream& os)
     return [&](const char* x) { os << x; };
 }
 
-template<class F>
+template <class F>
 int exec(const std::string& cmd, const char* type, F f)
 {
     int ec = 0;
@@ -70,12 +70,9 @@ int exec(const std::string& cmd, const std::function<void(const char*)>& std_out
 int exec(const std::string& cmd, std::function<void(process::writer)> std_in)
 {
     return exec(cmd, "w", [&](FILE* f) {
-        std_in([&](const char* buffer, std::size_t n) {
-            std::fwrite(buffer, 1, n, f);
-        });
+        std_in([&](const char* buffer, std::size_t n) { std::fwrite(buffer, 1, n, f); });
     });
 }
-
 
 struct process_impl
 {
@@ -90,8 +87,8 @@ struct process_impl
         result += command;
         return result;
     }
-    
-    template<class... Ts>
+
+    template <class... Ts>
     void check_exec(Ts&&... xs) const
     {
         int ec = migraphx::exec(std::forward<Ts>(xs)...);
@@ -122,10 +119,7 @@ process& process::cwd(const fs::path& p)
     return *this;
 }
 
-void process::exec()
-{
-    impl->check_exec(impl->get_command(), redirect_to(std::cout));
-}
+void process::exec() { impl->check_exec(impl->get_command(), redirect_to(std::cout)); }
 
 void process::write(std::function<void(process::writer)> pipe_in)
 {

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -38,7 +38,8 @@ std::function<void(const char*)> redirect_to(std::ostream& os)
     return [&](const char* x) { os << x; };
 }
 
-int exec(const std::string& cmd, const std::function<void(const char*)>& std_out)
+template<class F>
+int exec(const std::string& cmd, const char* type, F f)
 {
     int ec = 0;
     if(enabled(MIGRAPHX_TRACE_CMD_EXECUTE{}))
@@ -49,15 +50,32 @@ int exec(const std::string& cmd, const std::function<void(const char*)>& std_out
     };
     {
         // TODO: Use execve instead of popen
-        std::unique_ptr<FILE, decltype(closer)> pipe(popen(cmd.c_str(), "r"), closer); // NOLINT
+        std::unique_ptr<FILE, decltype(closer)> pipe(popen(cmd.c_str(), type), closer); // NOLINT
         if(not pipe)
             MIGRAPHX_THROW("popen() failed: " + cmd);
-        std::array<char, 128> buffer;
-        while(fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr)
-            std_out(buffer.data());
+        f(pipe.get());
     }
     return ec;
 }
+
+int exec(const std::string& cmd, const std::function<void(const char*)>& std_out)
+{
+    return exec(cmd, "r", [&](FILE* f) {
+        std::array<char, 128> buffer;
+        while(fgets(buffer.data(), buffer.size(), f) != nullptr)
+            std_out(buffer.data());
+    });
+}
+
+int exec(const std::string& cmd, std::function<void(process::writer)> std_in)
+{
+    return exec(cmd, "w", [&](FILE* f) {
+        std_in([&](const char* buffer, std::size_t n) {
+            std::fwrite(buffer, 1, n, f);
+        });
+    });
+}
+
 
 struct process_impl
 {
@@ -71,6 +89,15 @@ struct process_impl
             result += "cd " + cwd.string() + "; ";
         result += command;
         return result;
+    }
+    
+    template<class... Ts>
+    void check_exec(Ts&&... xs) const
+    {
+        int ec = migraphx::exec(std::forward<Ts>(xs)...);
+        if(ec != 0)
+            MIGRAPHX_THROW("Command " + get_command() + " exited with status " +
+                           std::to_string(ec));
     }
 };
 
@@ -97,10 +124,12 @@ process& process::cwd(const fs::path& p)
 
 void process::exec()
 {
-    auto ec = migraphx::exec(impl->get_command(), redirect_to(std::cout));
-    if(ec != 0)
-        MIGRAPHX_THROW("Command " + impl->get_command() + " exited with status " +
-                       std::to_string(ec));
+    impl->check_exec(impl->get_command(), redirect_to(std::cout));
+}
+
+void process::write(std::function<void(process::writer)> pipe_in)
+{
+    impl->check_exec(impl->get_command(), std::move(pipe_in));
 }
 
 } // namespace MIGRAPHX_INLINE_NS

--- a/src/targets/gpu/CMakeLists.txt
+++ b/src/targets/gpu/CMakeLists.txt
@@ -240,6 +240,7 @@ target_link_libraries(migraphx_gpu PUBLIC migraphx MIOpen roc::rocblas)
 target_link_libraries(migraphx_gpu PRIVATE migraphx_device migraphx_kernels)
 
 add_subdirectory(driver)
+add_subdirectory(hiprtc)
 
 rocm_install_targets(
     TARGETS migraphx_gpu migraphx_device compile_for_gpu

--- a/src/targets/gpu/compile_hip.cpp
+++ b/src/targets/gpu/compile_hip.cpp
@@ -182,8 +182,9 @@ struct hiprtc_program
     }
 };
 
-std::vector<std::vector<char>>
-compile_hip_src_with_hiprtc(const std::vector<src_file>& srcs, std::string params, const std::string& arch)
+std::vector<std::vector<char>> compile_hip_src_with_hiprtc(const std::vector<src_file>& srcs,
+                                                           std::string params,
+                                                           const std::string& arch)
 {
     hiprtc_program prog(srcs);
     auto options = split_string(params, ' ');
@@ -216,28 +217,29 @@ std::vector<std::vector<char>>
 compile_hip_src(const std::vector<src_file>& srcs, std::string params, const std::string& arch)
 {
     value v;
-    v["srcs"] = to_value(srcs);
+    v["srcs"]   = to_value(srcs);
     v["params"] = to_value(params);
-    v["arch"] = to_value(arch);
+    v["arch"]   = to_value(arch);
 
     tmp_dir td{};
     auto out = td.path / "output";
-    
-    auto p = dynamic_loader::path((void*)&compile_hip_src_with_hiprtc);
+
+    auto p      = dynamic_loader::path((void*)&compile_hip_src_with_hiprtc);
     auto driver = p.parent_path().parent_path() / "bin" / "migraphx-hiprtc-driver";
 
     process(driver.string() + " " + out.string()).write([&](auto writer) {
         to_msgpack(v, writer);
     });
-    if (not fs::exists(out))
+    if(not fs::exists(out))
         return {};
     return {read_buffer(out.string())};
 }
 
 #else // MIGRAPHX_USE_HIPRTC
 
-std::vector<std::vector<char>>
-compile_hip_src_with_hiprtc(const std::vector<src_file>& srcs, std::string params, const std::string& arch)
+std::vector<std::vector<char>> compile_hip_src_with_hiprtc(const std::vector<src_file>& srcs,
+                                                           std::string params,
+                                                           const std::string& arch)
 {
     MIGRAPHX_THROW("Not using hiprtc");
 }

--- a/src/targets/gpu/compile_hip.cpp
+++ b/src/targets/gpu/compile_hip.cpp
@@ -218,7 +218,7 @@ compile_hip_src(const std::vector<src_file>& srcs, std::string params, const std
     auto p      = dynamic_loader::path((void*)&compile_hip_src_with_hiprtc);
     auto driver = p.parent_path().parent_path() / "bin" / "migraphx-hiprtc-driver";
 
-    if (fs::exists(driver))
+    if(fs::exists(driver))
     {
         value v;
         v["srcs"]   = to_value(hsrcs);
@@ -227,7 +227,6 @@ compile_hip_src(const std::vector<src_file>& srcs, std::string params, const std
 
         tmp_dir td{};
         auto out = td.path / "output";
-
 
         process(driver.string() + " " + out.string()).write([&](auto writer) {
             to_msgpack(v, writer);

--- a/src/targets/gpu/compile_hip.cpp
+++ b/src/targets/gpu/compile_hip.cpp
@@ -70,6 +70,7 @@ void hiprtc_check_error(hiprtcResult err, const std::string& msg, const std::str
         throw make_exception(ctx, hiprtc_error(err, msg));
 }
 
+// NOLINTNEXTLINE
 #define MIGRAPHX_HIPRTC(...) \
     hiprtc_check_error(__VA_ARGS__, #__VA_ARGS__, MIGRAPHX_MAKE_SOURCE_CTX())
 
@@ -139,7 +140,7 @@ struct hiprtc_program
                                      include_names.data());
     }
 
-    void compile(const std::vector<std::string>& options)
+    void compile(const std::vector<std::string>& options) const
     {
         if(enabled(MIGRAPHX_TRACE_HIPRTC{}))
             std::cout << "hiprtc " << join_strings(options, " ") << " " << cpp_name << std::endl;

--- a/src/targets/gpu/compile_hip.cpp
+++ b/src/targets/gpu/compile_hip.cpp
@@ -215,7 +215,7 @@ std::vector<std::vector<char>>
 compile_hip_src(const std::vector<src_file>& srcs, std::string params, const std::string& arch)
 {
     std::vector<hiprtc_src_file> hsrcs{srcs.begin(), srcs.end()};
-    auto p      = dynamic_loader::path((void*)&compile_hip_src_with_hiprtc);
+    auto p      = dynamic_loader::path(&compile_hip_src_with_hiprtc);
     auto driver = p.parent_path().parent_path() / "bin" / "migraphx-hiprtc-driver";
 
     if(fs::exists(driver))

--- a/src/targets/gpu/compile_hip.cpp
+++ b/src/targets/gpu/compile_hip.cpp
@@ -117,21 +117,19 @@ struct hiprtc_program
     std::string cpp_src  = "";
     std::string cpp_name = "";
 
-    hiprtc_program(const std::vector<src_file>& srcs)
+    hiprtc_program(std::vector<hiprtc_src_file> srcs)
     {
         for(auto&& src : srcs)
         {
-            std::string content{src.content.first, src.content.second};
-            std::string path = src.path.string();
-            if(src.path.extension().string() == ".cpp")
+            if(ends_with(src.path, ".cpp"))
             {
-                cpp_src  = std::move(content);
-                cpp_name = std::move(path);
+                cpp_src  = std::move(src.content);
+                cpp_name = std::move(src.path);
             }
             else
             {
-                headers.push_back(std::move(content));
-                include_names.push_back(std::move(path));
+                headers.push_back(std::move(src.content));
+                include_names.push_back(std::move(src.path));
             }
         }
         prog = hiprtc_program_create(cpp_src.c_str(),
@@ -182,7 +180,7 @@ struct hiprtc_program
     }
 };
 
-std::vector<std::vector<char>> compile_hip_src_with_hiprtc(const std::vector<src_file>& srcs,
+std::vector<std::vector<char>> compile_hip_src_with_hiprtc(const std::vector<hiprtc_src_file>& srcs,
                                                            std::string params,
                                                            const std::string& arch)
 {
@@ -216,8 +214,9 @@ std::vector<std::vector<char>> compile_hip_src_with_hiprtc(const std::vector<src
 std::vector<std::vector<char>>
 compile_hip_src(const std::vector<src_file>& srcs, std::string params, const std::string& arch)
 {
+    std::vector<hiprtc_src_file> hsrcs{srcs.begin(), srcs.end()};
     value v;
-    v["srcs"]   = to_value(srcs);
+    v["srcs"]   = to_value(hsrcs);
     v["params"] = to_value(params);
     v["arch"]   = to_value(arch);
 
@@ -237,7 +236,7 @@ compile_hip_src(const std::vector<src_file>& srcs, std::string params, const std
 
 #else // MIGRAPHX_USE_HIPRTC
 
-std::vector<std::vector<char>> compile_hip_src_with_hiprtc(const std::vector<src_file>& srcs,
+std::vector<std::vector<char>> compile_hip_src_with_hiprtc(const std::vector<hiprtc_src_file>& srcs,
                                                            std::string params,
                                                            const std::string& arch)
 {

--- a/src/targets/gpu/hiprtc/CMakeLists.txt
+++ b/src/targets/gpu/hiprtc/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(migraphx-hiprtc-driver
 )
 rocm_clang_tidy_check(migraphx-hiprtc-driver)
 target_link_libraries(migraphx-hiprtc-driver PRIVATE migraphx_gpu)
+add_dependencies(migraphx_all_targets migraphx-hiprtc-driver)
 rocm_install_targets(
     TARGETS migraphx-hiprtc-driver
 )

--- a/src/targets/gpu/hiprtc/CMakeLists.txt
+++ b/src/targets/gpu/hiprtc/CMakeLists.txt
@@ -27,3 +27,6 @@ add_executable(migraphx-hiprtc-driver
 )
 rocm_clang_tidy_check(migraphx-hiprtc-driver)
 target_link_libraries(migraphx-hiprtc-driver PRIVATE migraphx_gpu)
+rocm_install_targets(
+    TARGETS migraphx-hiprtc-driver
+)

--- a/src/targets/gpu/hiprtc/CMakeLists.txt
+++ b/src/targets/gpu/hiprtc/CMakeLists.txt
@@ -1,0 +1,28 @@
+#####################################################################################
+# The MIT License (MIT)
+#
+# Copyright (c) 2015-2022 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#####################################################################################
+
+add_executable(migraphx-hiprtc-driver
+    main.cpp
+)
+target_link_libraries(migraphx-hiprtc-driver PRIVATE migraphx_gpu)

--- a/src/targets/gpu/hiprtc/CMakeLists.txt
+++ b/src/targets/gpu/hiprtc/CMakeLists.txt
@@ -25,4 +25,5 @@
 add_executable(migraphx-hiprtc-driver
     main.cpp
 )
+rocm_clang_tidy_check(migraphx-hiprtc-driver)
 target_link_libraries(migraphx-hiprtc-driver PRIVATE migraphx_gpu)

--- a/src/targets/gpu/hiprtc/main.cpp
+++ b/src/targets/gpu/hiprtc/main.cpp
@@ -24,15 +24,15 @@ std::vector<char> read_stdin()
 
 int main(int argc, char const* argv[])
 {
-    if (argc < 2)
+    if(argc < 2)
         std::abort();
     std::string output_name = argv[1];
 
     auto v = migraphx::from_msgpack(read_stdin());
     std::vector<migraphx::src_file> srcs;
     migraphx::from_value(v.at("srcs"), srcs);
-auto out = migraphx::gpu::compile_hip_src_with_hiprtc(srcs, v.at("params").to<std::string>(), v.at("arch").to<std::string>());
-    if (not out.empty())
+    auto out = migraphx::gpu::compile_hip_src_with_hiprtc(
+        srcs, v.at("params").to<std::string>(), v.at("arch").to<std::string>());
+    if(not out.empty())
         migraphx::write_buffer(output_name, out.front());
 }
-

--- a/src/targets/gpu/hiprtc/main.cpp
+++ b/src/targets/gpu/hiprtc/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char const* argv[])
     std::string output_name = argv[1];
 
     auto v = migraphx::from_msgpack(read_stdin());
-    std::vector<migraphx::src_file> srcs;
+    std::vector<migraphx::gpu::hiprtc_src_file> srcs;
     migraphx::from_value(v.at("srcs"), srcs);
     auto out = migraphx::gpu::compile_hip_src_with_hiprtc(
         srcs, v.at("params").to<std::string>(), v.at("arch").to<std::string>());

--- a/src/targets/gpu/hiprtc/main.cpp
+++ b/src/targets/gpu/hiprtc/main.cpp
@@ -32,7 +32,7 @@ int main(int argc, char const* argv[])
     std::vector<migraphx::gpu::hiprtc_src_file> srcs;
     migraphx::from_value(v.at("srcs"), srcs);
     auto out = migraphx::gpu::compile_hip_src_with_hiprtc(
-        srcs, v.at("params").to<std::string>(), v.at("arch").to<std::string>());
+        std::move(srcs), v.at("params").to<std::string>(), v.at("arch").to<std::string>());
     if(not out.empty())
         migraphx::write_buffer(output_name, out.front());
 }

--- a/src/targets/gpu/hiprtc/main.cpp
+++ b/src/targets/gpu/hiprtc/main.cpp
@@ -1,0 +1,38 @@
+#include <migraphx/gpu/compile_hip.hpp>
+#include <migraphx/serialize.hpp>
+#include <migraphx/value.hpp>
+#include <migraphx/msgpack.hpp>
+#include <migraphx/file_buffer.hpp>
+#include <iostream>
+#include <cstring>
+
+std::vector<char> read_stdin()
+{
+    std::vector<char> result;
+
+    std::array<char, 1024> buffer;
+    std::size_t len = 0;
+    while((len = std::fread(buffer.data(), 1, buffer.size(), stdin)) > 0)
+    {
+        if(std::ferror(stdin) && !std::feof(stdin))
+            throw std::runtime_error(std::strerror(errno));
+
+        result.insert(result.end(), buffer.data(), buffer.data() + len);
+    }
+    return result;
+}
+
+int main(int argc, char const* argv[])
+{
+    if (argc < 2)
+        std::abort();
+    std::string output_name = argv[1];
+
+    auto v = migraphx::from_msgpack(read_stdin());
+    std::vector<migraphx::src_file> srcs;
+    migraphx::from_value(v.at("srcs"), srcs);
+auto out = migraphx::gpu::compile_hip_src_with_hiprtc(srcs, v.at("params").to<std::string>(), v.at("arch").to<std::string>());
+    if (not out.empty())
+        migraphx::write_buffer(output_name, out.front());
+}
+

--- a/src/targets/gpu/hiprtc/main.cpp
+++ b/src/targets/gpu/hiprtc/main.cpp
@@ -14,8 +14,8 @@ std::vector<char> read_stdin()
     std::size_t len = 0;
     while((len = std::fread(buffer.data(), 1, buffer.size(), stdin)) > 0)
     {
-        if(std::ferror(stdin) && !std::feof(stdin))
-            throw std::runtime_error(std::strerror(errno));
+        if(std::ferror(stdin) != 0 and std::feof(stdin) == 0)
+            MIGRAPHX_THROW(std::strerror(errno));
 
         result.insert(result.end(), buffer.data(), buffer.data() + len);
     }

--- a/src/targets/gpu/include/migraphx/gpu/compile_hip.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/compile_hip.hpp
@@ -35,8 +35,9 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
-std::vector<std::vector<char>>
-compile_hip_src_with_hiprtc(const std::vector<src_file>& srcs, std::string params, const std::string& arch);
+std::vector<std::vector<char>> compile_hip_src_with_hiprtc(const std::vector<src_file>& srcs,
+                                                           std::string params,
+                                                           const std::string& arch);
 
 std::vector<std::vector<char>>
 compile_hip_src(const std::vector<src_file>& srcs, std::string params, const std::string& arch);

--- a/src/targets/gpu/include/migraphx/gpu/compile_hip.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/compile_hip.hpp
@@ -56,7 +56,7 @@ struct hiprtc_src_file
     }
 };
 
-std::vector<std::vector<char>> compile_hip_src_with_hiprtc(const std::vector<hiprtc_src_file>& srcs,
+std::vector<std::vector<char>> compile_hip_src_with_hiprtc(std::vector<hiprtc_src_file> srcs,
                                                            std::string params,
                                                            const std::string& arch);
 

--- a/src/targets/gpu/include/migraphx/gpu/compile_hip.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/compile_hip.hpp
@@ -40,13 +40,14 @@ struct hiprtc_src_file
 {
     hiprtc_src_file() = default;
     hiprtc_src_file(const src_file& s)
-    : path(s.path.string()), content(s.content.first, s.content.second)
-    {}
+        : path(s.path.string()), content(s.content.first, s.content.second)
+    {
+    }
     std::string path;
     std::string content;
     operator src_file() const
     {
-        return src_file{path, {content.data(), content.data()+content.size()}};
+        return src_file{path, {content.data(), content.data() + content.size()}};
     }
     template <class Self, class F>
     static auto reflect(Self& self, F f)

--- a/src/targets/gpu/include/migraphx/gpu/compile_hip.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/compile_hip.hpp
@@ -27,6 +27,7 @@
 #include <migraphx/config.hpp>
 #include <migraphx/filesystem.hpp>
 #include <migraphx/compile_src.hpp>
+#include <migraphx/functional.hpp>
 #include <string>
 #include <utility>
 #include <vector>
@@ -35,7 +36,26 @@ namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
-std::vector<std::vector<char>> compile_hip_src_with_hiprtc(const std::vector<src_file>& srcs,
+struct hiprtc_src_file
+{
+    hiprtc_src_file() = default;
+    hiprtc_src_file(const src_file& s)
+    : path(s.path.string()), content(s.content.first, s.content.second)
+    {}
+    std::string path;
+    std::string content;
+    operator src_file() const
+    {
+        return src_file{path, {content.data(), content.data()+content.size()}};
+    }
+    template <class Self, class F>
+    static auto reflect(Self& self, F f)
+    {
+        return pack(f(self.path, "path"), f(self.content, "content"));
+    }
+};
+
+std::vector<std::vector<char>> compile_hip_src_with_hiprtc(const std::vector<hiprtc_src_file>& srcs,
                                                            std::string params,
                                                            const std::string& arch);
 

--- a/src/targets/gpu/include/migraphx/gpu/compile_hip.hpp
+++ b/src/targets/gpu/include/migraphx/gpu/compile_hip.hpp
@@ -36,6 +36,9 @@ inline namespace MIGRAPHX_INLINE_NS {
 namespace gpu {
 
 std::vector<std::vector<char>>
+compile_hip_src_with_hiprtc(const std::vector<src_file>& srcs, std::string params, const std::string& arch);
+
+std::vector<std::vector<char>>
 compile_hip_src(const std::vector<src_file>& srcs, std::string params, const std::string& arch);
 
 std::string enum_params(std::size_t count, std::string param);


### PR DESCRIPTION
This will do parallel compilation with hiprtc by calling it through a driver. It looks for the driver using a relative path to the .so. If the driver doesnt exist(ie static library, the user just bundled the .so files, or files were moved to a non-standard location) then it will gracefully fallback to calling hiprtc directly. 

It will pipe the sources to stdin and then write the binary out to a temp file becasue `popen` doesnt support bidirectional pipes. We could look into fixing that in the future using a process library.