### PR TITLE
Driver dynamic batch update

### DIFF
--- a/src/driver/argument_parser.hpp
+++ b/src/driver/argument_parser.hpp
@@ -151,11 +151,20 @@ struct value_parser
         T result;
         std::stringstream ss;
         ss.str(x);
-        ss >> result;
+        // handle whitespace in string
+        if constexpr ( std::is_same<T, std::string>::value )
+        {
+            result = ss.str();
+        }
+        else
+        {
+            ss >> result;
+        }
         if(ss.fail())
             throw std::runtime_error("Failed to parse '" + x + "' as " + type_name<T>::apply());
         return result;
     }
+    
 
     template <MIGRAPHX_REQUIRES(std::is_enum<T>{} and not is_multi_value<T>{})>
     static T apply(const std::string& x)

--- a/src/driver/argument_parser.hpp
+++ b/src/driver/argument_parser.hpp
@@ -152,7 +152,7 @@ struct value_parser
         std::stringstream ss;
         ss.str(x);
         // handle whitespace in string
-        if constexpr ( std::is_same<T, std::string>::value )
+        if constexpr(std::is_same<T, std::string>::value)
         {
             result = ss.str();
         }
@@ -164,7 +164,6 @@ struct value_parser
             throw std::runtime_error("Failed to parse '" + x + "' as " + type_name<T>::apply());
         return result;
     }
-    
 
     template <MIGRAPHX_REQUIRES(std::is_enum<T>{} and not is_multi_value<T>{})>
     static T apply(const std::string& x)

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -146,6 +146,33 @@ struct loader
         return map_input_dims;
     }
 
+    static auto parse_dyn_dim_map(const std::vector<std::string>& param_dyn_dims)
+    {
+        std::unordered_map<std::string, std::vector<shape::dynamic_dimension>> map_dyn_input_dims;
+        std::string name = "";
+        for(auto&& x : param_dyn_dims)
+        {
+            if(x[0] == '@')
+            {
+                name = x.substr(1);
+            }
+            else
+            {
+                map_dyn_input_dims[name]
+            }
+        }
+    }
+
+    static auto parse_dyn_dim_str(std::string dd_str)
+    {
+        // expecting string formatted as "{min, max, {opts}}" or "{min, max}"
+        if(dd_str.empty())
+        {
+            return migraphx::shape::dynamic_dimension{1, 1};
+        }
+        auto t_str = migraphx::trim(dd_str, [](auto c) { return contains("{}", c); });
+    }
+
     static auto parse_output_names(const std::vector<std::string>& output_names_info)
     {
         std::vector<std::string> output_node_names;
@@ -180,9 +207,11 @@ struct loader
             {
                 onnx_options options;
                 options.default_dim_value      = batch;
+                options.default_dyn_dim_value  = default_dyn_dim;
                 options.skip_unknown_operators = skip_unknown_operators;
                 options.print_program_on_error = true;
                 options.map_input_dims         = map_input_dims;
+                options.map_dyn_input_dims     = map_dyn_inputs_dims;
                 p                              = parse_onnx(file, options);
             }
             else if(file_type == "tf")

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -84,7 +84,10 @@ struct loader
         ap(file_type, {"--tf"}, ap.help("Load as tensorflow"), ap.set_value("tf"));
         ap(file_type, {"--migraphx"}, ap.help("Load as MIGraphX"), ap.set_value("migraphx"));
         ap(file_type, {"--migraphx-json"}, ap.help("Load as MIGraphX JSON"), ap.set_value("json"));
-        ap(batch, {"--batch"}, ap.help("For a static model, set batch size. For a dynamic batch model, sets the batch size at runtime."));
+        ap(batch,
+           {"--batch"},
+           ap.help("For a static model, set batch size. For a dynamic batch model, sets the batch "
+                   "size at runtime."));
         ap(is_nhwc, {"--nhwc"}, ap.help("Treat tensorflow format as nhwc"), ap.set_value(true));
         ap(skip_unknown_operators,
            {"--skip-unknown-operators"},
@@ -99,12 +102,13 @@ struct loader
            ap.nargs(2));
         ap(dyn_param_dims,
            {"--dyn-input-dim"},
-           ap.help("Dynamic dimensions of a parameter (format: \"@name {min1, max1, [opt1_1, opt1_2, ...]} {min2, max2}, etc.\")"),
+           ap.help("Dynamic dimensions of a parameter (format: \"@name {min1, max1, [opt1_1, "
+                   "opt1_2, ...]} {min2, max2}, etc.\")"),
            ap.append(),
            ap.nargs(2));
         ap(default_dyn_dim,
-            {"--default-dyn-dim"},
-            ap.help("Default dynamic dimension (format: \"{min, max, [opts]}\")."));
+           {"--default-dyn-dim"},
+           ap.help("Default dynamic dimension (format: \"{min, max, [opts]}\")."));
         ap(output_names,
            {"--output-names"},
            ap.help("Names of node output (format: \"name_1 name_2 name_n\")"),
@@ -158,16 +162,16 @@ struct loader
     static std::set<std::size_t> parse_opts_str(std::string opts_str)
     {
         // expecting string formatted as "{opt_0, opt_1, ...}" or with "[]"
-        auto trimmed_str = migraphx::trim(opts_str,
-            [](auto c){ return contains(std::string("{["), c); },
-            [](auto c){ return contains(std::string("}]"), c); }
-        );
+        auto trimmed_str = migraphx::trim(
+            opts_str,
+            [](auto c) { return contains(std::string("{["), c); },
+            [](auto c) { return contains(std::string("}]"), c); });
         auto splits = migraphx::split_string(trimmed_str, ',');
         std::set<std::size_t> ret;
-        std::transform(splits.begin(),
-                       splits.end(),
-                       std::inserter(ret, ret.begin()),
-                       [](const auto& opt_str) { return value_parser<std::size_t>::apply(opt_str); });
+        std::transform(
+            splits.begin(), splits.end(), std::inserter(ret, ret.begin()), [](const auto& opt_str) {
+                return value_parser<std::size_t>::apply(opt_str);
+            });
         return ret;
     }
 
@@ -178,22 +182,21 @@ struct loader
         {
             return migraphx::shape::dynamic_dimension{1, 1};
         }
-        auto trimmed_str = migraphx::trim(dd_str,
-            [](auto c){ return contains(std::string("{["), c); },
-            [](auto c){ return contains(std::string("}]"), c); }
-        );
+        auto trimmed_str = migraphx::trim(
+            dd_str,
+            [](auto c) { return contains(std::string("{["), c); },
+            [](auto c) { return contains(std::string("}]"), c); });
         auto splits = migraphx::split_string(trimmed_str, ',');
         switch(splits.size())
         {
-            case 2:
-                return {value_parser<std::size_t>::apply(splits[0]), value_parser<std::size_t>::apply(splits[1])};
-            case 3:
-                return {value_parser<std::size_t>::apply(splits[0]),
+        case 2:
+            return {value_parser<std::size_t>::apply(splits[0]),
+                    value_parser<std::size_t>::apply(splits[1])};
+        case 3:
+            return {value_parser<std::size_t>::apply(splits[0]),
                     value_parser<std::size_t>::apply(splits[1]),
-                    parse_opts_str(splits[2])
-                };
-            default:
-                MIGRAPHX_THROW("Failed to parse dynamic dimension: " + dd_str);
+                    parse_opts_str(splits[2])};
+        default: MIGRAPHX_THROW("Failed to parse dynamic dimension: " + dd_str);
         }
     }
 
@@ -217,7 +220,6 @@ struct loader
         return map_dyn_input_dims;
     }
 
-
     static auto parse_output_names(const std::vector<std::string>& output_names_info)
     {
         std::vector<std::string> output_node_names;
@@ -234,9 +236,9 @@ struct loader
         program p;
         if(model.empty())
         {
-            auto map_input_dims    = parse_param_dims(param_dims);
+            auto map_input_dims     = parse_param_dims(param_dims);
             auto map_dyn_input_dims = parse_dyn_dim_map(dyn_param_dims);
-            auto output_node_names = parse_output_names(output_names);
+            auto output_node_names  = parse_output_names(output_names);
             if(file_type.empty())
             {
                 if(ends_with(file, ".onnx"))
@@ -437,7 +439,8 @@ struct compiler
            ap.set_value(true));
         ap(co.split_single_dyn_dim,
            {"--split-single-dyn-dim"},
-           ap.help("If there is a single non-fixed dynamic dimension in the model, then split to static submodules"),
+           ap.help("If there is a single non-fixed dynamic dimension in the model, then split to "
+                   "static submodules"),
            ap.set_value(true));
         ap(quantize, {"--fp16"}, ap.help("Quantize for fp16"), ap.set_value(precision::fp16));
         ap(quantize, {"--int8"}, ap.help("Quantize for int8"), ap.set_value(precision::int8));

--- a/src/driver/perf.cpp
+++ b/src/driver/perf.cpp
@@ -39,7 +39,8 @@ auto get_hash(const T& x)
     return std::hash<T>{}(x);
 }
 
-parameter_map fill_param_map(parameter_map& m, const program& p, const target& t, bool offload, unsigned batch)
+parameter_map
+fill_param_map(parameter_map& m, const program& p, const target& t, bool offload, unsigned batch)
 {
     for(auto&& x : p.get_parameter_shapes())
     {
@@ -47,7 +48,7 @@ parameter_map fill_param_map(parameter_map& m, const program& p, const target& t
         if(arg.empty())
         {
             auto s = x.second.to_static(batch);
-            arg = generate_argument(s, get_hash(x.first));
+            arg    = generate_argument(s, get_hash(x.first));
         }
         if(not offload)
             arg = t.copy_to(arg);

--- a/src/driver/perf.cpp
+++ b/src/driver/perf.cpp
@@ -39,13 +39,16 @@ auto get_hash(const T& x)
     return std::hash<T>{}(x);
 }
 
-parameter_map fill_param_map(parameter_map& m, const program& p, const target& t, bool offload)
+parameter_map fill_param_map(parameter_map& m, const program& p, const target& t, bool offload, unsigned batch)
 {
     for(auto&& x : p.get_parameter_shapes())
     {
         argument& arg = m[x.first];
         if(arg.empty())
-            arg = generate_argument(x.second, get_hash(x.first));
+        {
+            auto s = x.second.to_static(batch);
+            arg = generate_argument(s, get_hash(x.first));
+        }
         if(not offload)
             arg = t.copy_to(arg);
     }

--- a/src/driver/perf.hpp
+++ b/src/driver/perf.hpp
@@ -31,7 +31,7 @@ namespace driver {
 inline namespace MIGRAPHX_INLINE_NS {
 
 parameter_map
-fill_param_map(parameter_map& m, const program& p, const target& t, bool offload = false);
+fill_param_map(parameter_map& m, const program& p, const target& t, bool offload = false, unsigned batch = 1);
 parameter_map create_param_map(const program& p, const target& t, bool offload = false);
 
 parameter_map fill_param_map(parameter_map& m, const program& p, bool gpu);

--- a/src/driver/perf.hpp
+++ b/src/driver/perf.hpp
@@ -30,8 +30,8 @@ namespace migraphx {
 namespace driver {
 inline namespace MIGRAPHX_INLINE_NS {
 
-parameter_map
-fill_param_map(parameter_map& m, const program& p, const target& t, bool offload = false, unsigned batch = 1);
+parameter_map fill_param_map(
+    parameter_map& m, const program& p, const target& t, bool offload = false, unsigned batch = 1);
 parameter_map create_param_map(const program& p, const target& t, bool offload = false);
 
 parameter_map fill_param_map(parameter_map& m, const program& p, bool gpu);

--- a/src/include/migraphx/shape.hpp
+++ b/src/include/migraphx/shape.hpp
@@ -188,19 +188,19 @@ struct shape
 
     /*!
      * Minimum lengths for dynamic shape.
-     * lens() for fixed shape.
+     * lens() for static shape.
      */
     std::vector<std::size_t> min_lens() const;
 
     /*!
      * Maximum lengths for dynamic shape.
-     * lens() for fixed shape.
+     * lens() for static shape.
      */
     std::vector<std::size_t> max_lens() const;
 
     /*!
      * Optimum lengths for dynamic shape.
-     * Empty for fixed shape.
+     * Empty for static shape.
      */
     std::vector<std::set<std::size_t>> opt_lens() const;
 
@@ -260,6 +260,9 @@ struct shape
 
     // convert the shape to an equivalent dynamic shape with empty opts
     shape to_dynamic() const;
+
+    // convert the shape to a static one setting any non-fixed dynamic_dimensions to x
+    shape to_static(std::size_t x) const;
 
     friend bool operator==(const shape& x, const shape& y);
     friend bool operator!=(const shape& x, const shape& y);

--- a/src/include/migraphx/stringutils.hpp
+++ b/src/include/migraphx/stringutils.hpp
@@ -99,7 +99,7 @@ template <class LeftF, class RightF>
 std::string trim(const std::string& s, LeftF lf, RightF rf)
 {
     auto start = std::find_if_not(s.begin(), s.end(), lf);
-    auto last  = std::find_if_not(s.rbegin(), std::string::const_reverse_iterator(start), rf).base();
+    auto last = std::find_if_not(s.rbegin(), std::string::const_reverse_iterator(start), rf).base();
     return {start, last};
 }
 

--- a/src/include/migraphx/stringutils.hpp
+++ b/src/include/migraphx/stringutils.hpp
@@ -95,6 +95,14 @@ inline std::vector<std::string> split_string(const std::string& s, char delim)
     return elems;
 }
 
+template <class LeftF, class RightF>
+std::string trim(const std::string& s, LeftF lf, RightF rf)
+{
+    auto start = std::find_if_not(s.begin(), s.end(), lf);
+    auto last  = std::find_if_not(s.rbegin(), std::string::const_reverse_iterator(start), rf).base();
+    return {start, last};
+}
+
 template <class F>
 std::string trim(const std::string& s, F f)
 {

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -483,12 +483,9 @@ shape shape::to_dynamic() const
     if(not sub_shapes().empty())
     {
         std::vector<shape> subs;
-        std::transform(
-            sub_shapes().cbegin(),
-            sub_shapes().cend(),
-            subs.begin(),
-            [](auto s) { return s.to_dynamic(); }
-        );
+        std::transform(sub_shapes().cbegin(), sub_shapes().cend(), subs.begin(), [](auto s) {
+            return s.to_dynamic();
+        });
         return {subs};
     }
     if(this->dynamic())
@@ -503,12 +500,9 @@ shape shape::to_static(std::size_t x) const
     if(not sub_shapes().empty())
     {
         std::vector<shape> subs;
-        std::transform(
-            sub_shapes().cbegin(),
-            sub_shapes().cend(),
-            subs.begin(),
-            [&](auto s) { return s.to_static(x); }
-        );
+        std::transform(sub_shapes().cbegin(), sub_shapes().cend(), subs.begin(), [&](auto s) {
+            return s.to_static(x);
+        });
         return {subs};
     }
     if(not this->dynamic())
@@ -516,14 +510,11 @@ shape shape::to_static(std::size_t x) const
         return *this;
     }
     auto static_lens = this->max_lens();
-    std::transform(
-            static_lens.begin(),
-            static_lens.end(),
-            this->dyn_dims().cbegin(),
-            static_lens.begin(),
-            [&](auto sl, auto dd){
-                return dd.is_fixed() ? sl : x;
-            });
+    std::transform(static_lens.begin(),
+                   static_lens.end(),
+                   this->dyn_dims().cbegin(),
+                   static_lens.begin(),
+                   [&](auto sl, auto dd) { return dd.is_fixed() ? sl : x; });
     return {type(), static_lens};
 }
 

--- a/test/shape_test.cpp
+++ b/test/shape_test.cpp
@@ -335,7 +335,7 @@ TEST_CASE(test_shape_subshapes_to_dynamic)
     sub_shapes0.push_back(migraphx::shape{migraphx::shape::float_type, {{1, 4}, {4, 4}}});
     sub_shapes0.push_back(migraphx::shape{migraphx::shape::float_type, {3, 4, 5}});
     migraphx::shape s0{sub_shapes0};
-    migraphx::shape s1 = s0.to_dynamic();
+    migraphx::shape s1                       = s0.to_dynamic();
     std::vector<migraphx::shape> sub_shapes1 = {};
     sub_shapes1.push_back(migraphx::shape{migraphx::shape::float_type, {{1, 4}, {4, 4}}});
     sub_shapes1.push_back(migraphx::shape{migraphx::shape::float_type, {{3, 3}, {4, 4}, {5, 5}}});
@@ -364,7 +364,7 @@ TEST_CASE(test_shape_subshapes_to_static)
     sub_shapes0.push_back(migraphx::shape{migraphx::shape::float_type, {{1, 4}, {4, 4}}});
     sub_shapes0.push_back(migraphx::shape{migraphx::shape::float_type, {3, 4, 5}});
     migraphx::shape s0{sub_shapes0};
-    migraphx::shape s1 = s0.to_static(3);
+    migraphx::shape s1                       = s0.to_static(3);
     std::vector<migraphx::shape> sub_shapes1 = {};
     sub_shapes1.push_back(migraphx::shape{migraphx::shape::float_type, {3, 4}});
     sub_shapes1.push_back(migraphx::shape{migraphx::shape::float_type, {3, 4, 5}});

--- a/test/shape_test.cpp
+++ b/test/shape_test.cpp
@@ -329,6 +329,49 @@ TEST_CASE(test_shape_dyn_to_dynamic)
     EXPECT(s0 == s1);
 }
 
+TEST_CASE(test_shape_subshapes_to_dynamic)
+{
+    std::vector<migraphx::shape> sub_shapes0 = {};
+    sub_shapes0.push_back(migraphx::shape{migraphx::shape::float_type, {{1, 4}, {4, 4}}});
+    sub_shapes0.push_back(migraphx::shape{migraphx::shape::float_type, {3, 4, 5}});
+    migraphx::shape s0{sub_shapes0};
+    migraphx::shape s1 = s0.to_dynamic();
+    std::vector<migraphx::shape> sub_shapes1 = {};
+    sub_shapes1.push_back(migraphx::shape{migraphx::shape::float_type, {{1, 4}, {4, 4}}});
+    sub_shapes1.push_back(migraphx::shape{migraphx::shape::float_type, {{3, 3}, {4, 4}, {5, 5}}});
+    migraphx::shape s2{sub_shapes1};
+    EXPECT(s1 == s2);
+}
+
+TEST_CASE(test_shape_dyn_to_static)
+{
+    migraphx::shape s0{migraphx::shape::float_type, {{1, 1}, {2, 2}, {2, 10}, {2, 10}}};
+    migraphx::shape s1 = s0.to_static(4);
+    migraphx::shape s2{migraphx::shape::float_type, {1, 2, 4, 4}};
+    EXPECT(s1 == s2);
+}
+
+TEST_CASE(test_shape_static_to_static)
+{
+    migraphx::shape s0{migraphx::shape::float_type, {1, 2, 4, 4}};
+    migraphx::shape s1 = s0.to_static(8);
+    EXPECT(s0 == s1);
+}
+
+TEST_CASE(test_shape_subshapes_to_static)
+{
+    std::vector<migraphx::shape> sub_shapes0 = {};
+    sub_shapes0.push_back(migraphx::shape{migraphx::shape::float_type, {{1, 4}, {4, 4}}});
+    sub_shapes0.push_back(migraphx::shape{migraphx::shape::float_type, {3, 4, 5}});
+    migraphx::shape s0{sub_shapes0};
+    migraphx::shape s1 = s0.to_static(3);
+    std::vector<migraphx::shape> sub_shapes1 = {};
+    sub_shapes1.push_back(migraphx::shape{migraphx::shape::float_type, {3, 4}});
+    sub_shapes1.push_back(migraphx::shape{migraphx::shape::float_type, {3, 4, 5}});
+    migraphx::shape s2{sub_shapes1};
+    EXPECT(s1 == s2);
+}
+
 TEST_CASE(test_shape_overlap)
 {
     migraphx::shape s{migraphx::shape::float_type, {2, 2, 3}, {6, 3, 2}};


### PR DESCRIPTION
* Added `default_dyn_dim` and `dyn_param_dims` options to the driver to allow for setting dynamic shapes.
* Created associated parsers for the dynamic dimension strings.
* Changed behavior of `batch` option to handle running a specific batch size when running with a dynamic batch model.
* `shape.to_static(size_t)` function to allow for easier conversion.