### PR TITLE
[MLIR] adds support for mul + scalar literals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN git clone --single-branch --branch ${ONNXRUNTIME_BRANCH} --recursive ${ONNXR
 
 ADD tools/build_and_test_onnxrt.sh /onnxruntime/build_and_test_onnxrt.sh
 
-RUN cget -p /usr/local install ROCmSoftwarePlatform/rocMLIR@55c6ee66cc7502db7950693b3e845676cbf400b1 -DBUILD_MIXR_TARGET=On -DLLVM_ENABLE_ZSTD=Off -DLLVM_ENABLE_THREADS=Off
+RUN cget -p /usr/local install ROCmSoftwarePlatform/rocMLIR@a997d5f51314b45d7a4c04f1599966dcf53f9b4d -DBUILD_MIXR_TARGET=On -DLLVM_ENABLE_ZSTD=Off -DLLVM_ENABLE_THREADS=Off
 
 ENV MIOPEN_FIND_DB_PATH=/tmp/miopen/find-db
 ENV MIOPEN_USER_DB_PATH=/tmp/miopen/user-db

--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -544,9 +544,7 @@ struct mlir_program
                 ops.add_results({get_shape(ins)});
             if(ins->name() == "@literal")
             {
-                auto e = ins->eval();
-                literal r{};
-                e.visit_at([&](auto x) { r = literal{x}; });
+                literal r            = ins->get_literal();
                 MlirType tensor_type = make_tensor(ins->get_shape());
                 MlirAttribute mlir_value_attr =
                     mlirDenseElementsAttrRawBufferGet(tensor_type, r.get_shape().bytes(), r.data());


### PR DESCRIPTION
This commit adds support for fusing mul instructions. Along with that, usually contains bound scalar literals. Thus, this commit adds changes to compile bound sclar literals as well.

closes : https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/850