### PR TITLE
Use hash key for docker layer computed from Dockerfile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: Docker layer cache
       uses: jpribyl/action-docker-layer-caching@v0.1.1
       with:
-        key: docker-layer-caching-migraphx-${{hashFiles('hip-clang.docker')}}
+        key: docker-layer-caching-migraphx-${{hashFiles('hip-clang.docker', '**/*requirements.txt', '**/install_prereqs.sh', 'rbuild.ini')}}
         restore-keys:
           docker-layer-caching-migraphx-
       # Ignore the failure of a step and avoid terminating the job.
@@ -99,7 +99,7 @@ jobs:
     - name: Docker layer cache
       uses: jpribyl/action-docker-layer-caching@v0.1.1
       with:
-        key: docker-layer-caching-migraphx-${{hashFiles('hip-clang.docker')}}
+        key: docker-layer-caching-migraphx-${{hashFiles('hip-clang.docker', '**/*requirements.txt', '**/install_prereqs.sh', 'rbuild.ini')}}
         restore-keys:
           docker-layer-caching-migraphx-
       # Ignore the failure of a step and avoid terminating the job.
@@ -161,7 +161,7 @@ jobs:
     - name: Docker layer cache
       uses: jpribyl/action-docker-layer-caching@v0.1.1
       with:
-        key: docker-layer-caching-migraphx-${{hashFiles('hip-clang.docker')}}
+        key: docker-layer-caching-migraphx-${{hashFiles('hip-clang.docker', '**/*requirements.txt', '**/install_prereqs.sh', 'rbuild.ini')}}
         restore-keys:
           docker-layer-caching-migraphx-
       # Ignore the failure of a step and avoid terminating the job.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,12 @@ jobs:
     # In this step, this action saves a list of existing images,
     # the cache is created without them in the post run.
     # It also restores the cache if it exists.
-    - uses: jpribyl/action-docker-layer-caching@v0.1.1
+    - name: Docker layer cache
+      uses: jpribyl/action-docker-layer-caching@v0.1.1
+      with:
+        key: layer-docker-layer-caching-migraphx-${{hashFiles('hip-clang.docker')}}
+        restore-keys:
+          layer-docker-layer-caching-migraphx-
       # Ignore the failure of a step and avoid terminating the job.
       continue-on-error: true
 
@@ -91,7 +96,12 @@ jobs:
     # In this step, this action saves a list of existing images,
     # the cache is created without them in the post run.
     # It also restores the cache if it exists.
-    - uses: jpribyl/action-docker-layer-caching@v0.1.1
+    - name: Docker layer cache
+      uses: jpribyl/action-docker-layer-caching@v0.1.1
+      with:
+        key: layer-docker-layer-caching-migraphx-${{hashFiles('hip-clang.docker')}}
+        restore-keys:
+          layer-docker-layer-caching-migraphx-
       # Ignore the failure of a step and avoid terminating the job.
       continue-on-error: true
 
@@ -148,7 +158,12 @@ jobs:
     # In this step, this action saves a list of existing images,
     # the cache is created without them in the post run.
     # It also restores the cache if it exists.
-    - uses: jpribyl/action-docker-layer-caching@v0.1.1
+    - name: Docker layer cache
+      uses: jpribyl/action-docker-layer-caching@v0.1.1
+      with:
+        key: layer-docker-layer-caching-migraphx-${{hashFiles('hip-clang.docker')}}
+        restore-keys:
+          layer-docker-layer-caching-migraphx-
       # Ignore the failure of a step and avoid terminating the job.
       continue-on-error: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,9 +33,9 @@ jobs:
     - name: Docker layer cache
       uses: jpribyl/action-docker-layer-caching@v0.1.1
       with:
-        key: layer-docker-layer-caching-migraphx-${{hashFiles('hip-clang.docker')}}
+        key: docker-layer-caching-migraphx-${{hashFiles('hip-clang.docker')}}
         restore-keys:
-          layer-docker-layer-caching-migraphx-
+          docker-layer-caching-migraphx-
       # Ignore the failure of a step and avoid terminating the job.
       continue-on-error: true
 
@@ -99,9 +99,9 @@ jobs:
     - name: Docker layer cache
       uses: jpribyl/action-docker-layer-caching@v0.1.1
       with:
-        key: layer-docker-layer-caching-migraphx-${{hashFiles('hip-clang.docker')}}
+        key: docker-layer-caching-migraphx-${{hashFiles('hip-clang.docker')}}
         restore-keys:
-          layer-docker-layer-caching-migraphx-
+          docker-layer-caching-migraphx-
       # Ignore the failure of a step and avoid terminating the job.
       continue-on-error: true
 
@@ -161,9 +161,9 @@ jobs:
     - name: Docker layer cache
       uses: jpribyl/action-docker-layer-caching@v0.1.1
       with:
-        key: layer-docker-layer-caching-migraphx-${{hashFiles('hip-clang.docker')}}
+        key: docker-layer-caching-migraphx-${{hashFiles('hip-clang.docker')}}
         restore-keys:
-          layer-docker-layer-caching-migraphx-
+          docker-layer-caching-migraphx-
       # Ignore the failure of a step and avoid terminating the job.
       continue-on-error: true
 

--- a/.github/workflows/clean-closed-pr-caches.yaml
+++ b/.github/workflows/clean-closed-pr-caches.yaml
@@ -19,7 +19,7 @@ jobs:
           BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
 
           echo "Fetching list of cache key"
-          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 | tail -n +3)
 
           ## Setting this to not fail the workflow while deleting cache keys. 
           set +e


### PR DESCRIPTION
Use hash key computed from `hip-clang.docker` for docker layer cache. 

Cut first two lines from output  of `gh actions-cache list` command.  First two lines shows count of caches found. e.g. `showing 6 of 6 caches found in AMDMIGraphX`.  For example, see cleanup stage here : https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/actions/runs/4726769832/jobs/8386680164 
