### PR TITLE
Expose instruction shape and operator through python api

### DIFF
--- a/src/py/migraphx_py.cpp
+++ b/src/py/migraphx_py.cpp
@@ -287,7 +287,9 @@ MIGRAPHX_PYBIND11_MODULE(migraphx, m)
 
     py::class_<migraphx::target>(m, "target");
 
-    py::class_<migraphx::instruction_ref>(m, "instruction_ref");
+    py::class_<migraphx::instruction_ref>(m, "instruction_ref")
+        .def("shape", [](migraphx::instruction_ref i) { return i->get_shape(); })
+        .def("op", [](migraphx::instruction_ref i) { return i->get_operator(); });
 
     py::class_<migraphx::module, std::unique_ptr<migraphx::module, py::nodelete>>(m, "module")
         .def("print", [](const migraphx::module& mm) { std::cout << mm << std::endl; })

--- a/test/py/test_instruction.py
+++ b/test/py/test_instruction.py
@@ -1,0 +1,52 @@
+#####################################################################################
+# The MIT License (MIT)
+#
+# Copyright (c) 2015-2022 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#####################################################################################
+import migraphx
+
+
+def test_instruction_shape():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    input_shape = migraphx.shape(lens=[4,4,64], type="half_type")
+    i = mm.add_parameter("x", input_shape)
+    i2 = mm.add_instruction(migraphx.op("reshape", dims=[16, 64]), [i])
+    out_shape = i2.shape()
+
+    assert out_shape.lens() == [16, 64]
+    assert out_shape.strides() == [64, 1]
+    assert out_shape.type_string() == "half_type"
+
+
+def test_instruction_op():
+    p = migraphx.program()
+    mm = p.get_main_module()
+    input_shape = migraphx.shape(lens=[2, 24])
+    i = mm.add_parameter("x", input_shape)
+    i2 = mm.add_instruction(migraphx.op("relu"), [i])
+    out_op = i2.op()
+
+    assert out_op.name() == "relu"
+
+
+test_instruction_shape()
+test_instruction_op()

--- a/test/py/test_instruction.py
+++ b/test/py/test_instruction.py
@@ -27,7 +27,7 @@ import migraphx
 def test_instruction_shape():
     p = migraphx.program()
     mm = p.get_main_module()
-    input_shape = migraphx.shape(lens=[4,4,64], type="half_type")
+    input_shape = migraphx.shape(lens=[4, 4, 64], type="half_type")
     i = mm.add_parameter("x", input_shape)
     i2 = mm.add_instruction(migraphx.op("reshape", dims=[16, 64]), [i])
     out_shape = i2.shape()
@@ -48,5 +48,6 @@ def test_instruction_op():
     assert out_op.name() == "relu"
 
 
-test_instruction_shape()
-test_instruction_op()
+if __name__ == "__main__":
+    test_instruction_shape()
+    test_instruction_op()


### PR DESCRIPTION
Simply exposing `get_shape` and `get_operator` methods for instruction_ref object in the python API.

Motivation: Having these methods accessible will help clean up torch_migraphx converters and also allow us to not rely on an additional torch shape prop pass to infer input shapes when required.