### PR TITLE
Removed split_single_dyn_dim compile flag

### DIFF
--- a/doc/src/driver/compile.rst
+++ b/doc/src/driver/compile.rst
@@ -32,10 +32,6 @@ Disable fast math optimization
 
 Perform an exhaustive search to find the fastest version of generated kernels for selected backend
 
-.. options:: --split-single-dyn-dim
-
-Enable the split single dynamic dimension pass
-
 .. option::  --fp16
 
 Quantize for fp16

--- a/examples/migraphx/migraphx_driver/README.md
+++ b/examples/migraphx/migraphx_driver/README.md
@@ -53,7 +53,6 @@ See below for a comprehensive list of commands and option arguments, as well as 
 | --enable-offload-copy                    | Enable implicit offload copying                           |
 | --disable-fast-math                      | Disable fast math optimization                            |
 | --exhaustive-tune                        | Enable exhaustive search to find fastest kernel           |
-| --split-single-dyn-dim                   | Enable split_single_dyn_dim compiler pass                 |
 | --fp16                                   | Quantize for fp16                                         |
 | --int8                                   | Quantize for int8                                         |
 | --tolerance                              | Tolerance for errors                                      |

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -436,11 +436,6 @@ struct compiler
            {"--exhaustive-tune"},
            ap.help("Exhastively search for best tuning parameters for kernels"),
            ap.set_value(true));
-        ap(co.split_single_dyn_dim,
-           {"--split-single-dyn-dim"},
-           ap.help("If there is a single non-fixed dynamic dimension in the model, then split to "
-                   "static submodules"),
-           ap.set_value(true));
         ap(quantize, {"--fp16"}, ap.help("Quantize for fp16"), ap.set_value(precision::fp16));
         ap(quantize, {"--int8"}, ap.help("Quantize for int8"), ap.set_value(precision::int8));
     }

--- a/src/include/migraphx/compile_options.hpp
+++ b/src/include/migraphx/compile_options.hpp
@@ -40,9 +40,6 @@ struct compile_options
 
     bool fast_math       = true;
     bool exhaustive_tune = false;
-
-    /// Use the split_single_dyn_dim pass
-    bool split_single_dyn_dim = false;
     tracer trace{};
 };
 

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -101,8 +101,8 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
     // clang-format off
     return
     {
-        enable_pass(options.split_single_dyn_dim, split_single_dyn_dim{}),
-        enable_pass(options.split_single_dyn_dim, dead_code_elimination{}),
+        split_single_dyn_dim{},
+        dead_code_elimination{},
         normalize_ops{},
         dead_code_elimination{},
         simplify_qdq{},

--- a/test/verify/test_split_single_dyn_dim.cpp
+++ b/test/verify/test_split_single_dyn_dim.cpp
@@ -46,11 +46,4 @@ struct test_split_single_dyn_dim : verify_program<test_split_single_dyn_dim>
         mm->add_return({add_ins});
         return p;
     }
-
-    migraphx::compile_options get_compile_options() const
-    {
-        migraphx::compile_options co;
-        co.split_single_dyn_dim = true;
-        return co;
-    };
 };


### PR DESCRIPTION
* Removed the split_single_dyn_dim compiler flag
* Updated spllit_single_dyn_dim compiler pass to skip if dynamic parameter outputs to `select_module` operator
* Updated docs