### PR TITLE
stop docker when failing to install from continuing 

### DIFF
--- a/tools/download_models.sh
+++ b/tools/download_models.sh
@@ -24,6 +24,8 @@
 # THE SOFTWARE.
 #####################################################################################
 
+set -e
+
 if [ -z "$ONNX_HOME" ]
 then
    # The onnx library uses ONNX_HOME, by default if it doesn't exist


### PR DESCRIPTION
During a CI run I noticed a download of a model fail.  The script continued and then hours later the problem resulted in a failed onnx test because the model didn't exist.  This change should stop the building of the docker image when the model did not download correctly.