### PR TITLE
Update cpp generator to handle inf from  float

### DIFF
--- a/src/cpp_generator.cpp
+++ b/src/cpp_generator.cpp
@@ -207,19 +207,20 @@ cpp_generator::function cpp_generator::generate_module(const module& m,
     });
     f.set_name(name).set_types(m).set_body(
         m, [&](instruction_ref ins, const auto& names) -> std::string {
-            if(ins->name() == "@literal") {
+            if(ins->name() == "@literal")
+            {
                 std::string string_literal;
                 ins->get_literal().visit([&](auto v) {
                     assert(v.size() == 1);
                     auto x = v.front();
-                    if(x > __builtin_huge_valf or x < - __builtin_huge_valf) 
+                    if(std::isinf(x))
                     {
-                        string_literal = "__builtin_huge_valf";
+                        string_literal = "__builtin_huge_valf()";
                         if(x < 0)
-                            string_literal = "- __builtin_huge_valf";
+                            string_literal = "-__builtin_huge_valf()";
                     }
                     else if(std::isnan(x))
-                        string_literal = "__builtin_nanf";
+                        string_literal = "__builtin_nanf()";
                     else
                         string_literal = std::to_string(x);
                 });

--- a/src/cpp_generator.cpp
+++ b/src/cpp_generator.cpp
@@ -222,7 +222,7 @@ cpp_generator::function cpp_generator::generate_module(const module& m,
                     else if(std::isnan(x))
                         string_literal = "__builtin_nanf()";
                     else
-                        string_literal = std::to_string(x);
+                        string_literal = ins->get_literal().to_string();
                 });
                 return shape::cpp_type(ins->get_shape().type()) + "(" + string_literal + ")";
             }

--- a/src/cpp_generator.cpp
+++ b/src/cpp_generator.cpp
@@ -31,7 +31,6 @@
 #include <migraphx/iterator_for.hpp>
 #include <map>
 #include <sstream>
-#include <limits>
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -212,11 +211,11 @@ cpp_generator::function cpp_generator::generate_module(const module& m,
                 auto string_literal = ins->get_literal().to_string();
 
                 if (string_literal == "inf") {
-                    string_literal =  std::numeric_limits<decltype(shape::cpp_type(ins->get_shape().type()))>::max() + "+ 1";
+                    string_literal = "1.0 / 0.0";
                 }
 
                 if(string_literal == "-inf") {
-                    string_literal =  std::numeric_limits<decltype(shape::cpp_type(ins->get_shape().type()))>::min() + "- 1";
+                    string_literal = "- 1.0 / 0.0";
                 }
 
                 auto s = shape::cpp_type(ins->get_shape().type()) + "(" +

--- a/src/cpp_generator.cpp
+++ b/src/cpp_generator.cpp
@@ -224,9 +224,7 @@ cpp_generator::function cpp_generator::generate_module(const module& m,
                     else
                         string_literal = std::to_string(x);
                 });
-                auto s = shape::cpp_type(ins->get_shape().type()) + "(" + string_literal + ")";
-
-                return s;
+                return shape::cpp_type(ins->get_shape().type()) + "(" + string_literal + ")";
             }
             auto s = g(ins, names);
             if(impl->fresult)

--- a/src/cpp_generator.cpp
+++ b/src/cpp_generator.cpp
@@ -215,12 +215,12 @@ cpp_generator::function cpp_generator::generate_module(const module& m,
                     auto x = v.front();
                     if(std::isinf(x))
                     {
-                        string_literal = "__builtin_huge_valf()";
+                        string_literal = "__builtin_huge_val()";
                         if(x < 0)
-                            string_literal = "-__builtin_huge_valf()";
+                            string_literal = "-__builtin_huge_val()";
                     }
                     else if(std::isnan(x))
-                        string_literal = "__builtin_nanf()";
+                        string_literal = "__builtin_nan()";
                     else
                         string_literal = ins->get_literal().to_string();
                 });

--- a/test/verify/test_literal_limits.cpp
+++ b/test/verify/test_literal_limits.cpp
@@ -32,12 +32,16 @@ struct test_literal_limits : verify_program<test_literal_limits>
     migraphx::program create_program() const
     {
         migraphx::program p;
-        auto* mm   = p.get_main_module();
-        auto input_s = migraphx::shape(migraphx::shape::float_type, {3, 1});
+        auto* mm          = p.get_main_module();
+        auto input_s      = migraphx::shape(migraphx::shape::float_type, {3, 1});
         auto infinity_val = std::numeric_limits<float>::infinity();
-        std::vector<float> s_data{infinity_val, -infinity_val, std::numeric_limits<float>::quiet_NaN()};
-        auto input = mm->add_literal(migraphx::literal{input_s, s_data});
-        mm->add_instruction(migraphx::make_op("isnan"), input);
+        std::vector<float> s_data{
+            infinity_val, -infinity_val, std::numeric_limits<float>::quiet_NaN()};
+
+        auto input_param = mm->add_parameter("test_input", input_s);
+        auto input       = mm->add_literal(migraphx::literal{input_s, s_data});
+        auto o1          = mm->add_instruction(migraphx::make_op("mul"), input, input_param);
+        mm->add_instruction(migraphx::make_op("isnan"), o1);
         return p;
     }
 };

--- a/test/verify/test_literal_limits.cpp
+++ b/test/verify/test_literal_limits.cpp
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "verify_program.hpp"
+#include <migraphx/program.hpp>
+#include <migraphx/make_op.hpp>
+#include <limits>
+
+struct test_literal_limits : verify_program<test_literal_limits>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        auto* mm   = p.get_main_module();
+        auto input_s = migraphx::shape(migraphx::shape::float_type, {3, 1});
+        auto infinity_val = std::numeric_limits<float>::infinity();
+        std::vector<float> s_data{infinity_val, -infinity_val, std::numeric_limits<float>::quiet_NaN()};
+        auto input = mm->add_literal(migraphx::literal{input_s, s_data});
+        mm->add_instruction(migraphx::make_op("isnan"), input);
+        return p;
+    }
+};

--- a/test/verify/test_literal_limits.cpp
+++ b/test/verify/test_literal_limits.cpp
@@ -27,16 +27,17 @@
 #include <migraphx/make_op.hpp>
 #include <limits>
 
-struct test_literal_limits : verify_program<test_literal_limits>
+template <migraphx::shape::type_t Q, typename T>
+struct test_literal_limits : verify_program<test_literal_limits<Q, T>>
 {
     migraphx::program create_program() const
     {
         migraphx::program p;
         auto* mm          = p.get_main_module();
-        auto input_s      = migraphx::shape(migraphx::shape::float_type, {3, 1});
-        auto infinity_val = std::numeric_limits<float>::infinity();
-        std::vector<float> s_data{
-            infinity_val, -infinity_val, std::numeric_limits<float>::quiet_NaN()};
+        auto input_s      = migraphx::shape(Q, {3, 1});
+        auto infinity_val = std::numeric_limits<T>::infinity();
+        std::vector<T> s_data{
+            infinity_val, static_cast<T>(-infinity_val), std::numeric_limits<T>::quiet_NaN()};
 
         auto input_param = mm->add_parameter("test_input", input_s);
         auto input       = mm->add_literal(migraphx::literal{input_s, s_data});
@@ -45,3 +46,9 @@ struct test_literal_limits : verify_program<test_literal_limits>
         return p;
     }
 };
+
+template struct test_literal_limits<migraphx::shape::float_type, float>;
+template struct test_literal_limits<migraphx::shape::double_type, double>;
+template struct test_literal_limits<migraphx::shape::half_type, migraphx::half>;
+template struct test_literal_limits<migraphx::shape::int32_type, int32_t>;
+template struct test_literal_limits<migraphx::shape::int8_type, int8_t>;


### PR DESCRIPTION
Use std::numeric_limits<type>::min/max() functions plus the appropriate value to encode -inf/inf so that when code is generated we get the following:

```
auto a = float (( numeric_limits<float>::max() + 1);
auto b = float (numeric_limits<float>::min() - 1);
```

vs

```
auto a = float(inf);
auto b = float(-inf);
```

which can't be assigned. Originally tried to use std::numeric_limits<type>::inifnity() but that still causes a conversion to inf/-inf before again assigning it to the creation of float incorrectly