### PR TITLE
Backout fp16 max/min HIP API change

### DIFF
--- a/src/targets/gpu/kernels/include/migraphx/kernels/math.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/math.hpp
@@ -188,8 +188,10 @@ MIGRAPHX_DEVICE_MATH_BINARY_FOR(float, max, ::max)
 MIGRAPHX_DEVICE_MATH_BINARY_FOR(float, min, ::min)
 MIGRAPHX_DEVICE_MATH_BINARY_FOR(double, max, ::max)
 MIGRAPHX_DEVICE_MATH_BINARY_FOR(double, min, ::min)
-MIGRAPHX_DEVICE_MATH_BINARY_FOR(migraphx::half, max, ::__hmax)
-MIGRAPHX_DEVICE_MATH_BINARY_FOR(migraphx::half, min, ::__hmin)
+// Add overloads for half that calls the float version, this should use "hmax" and "hmin" once 
+// perf CI docker is upgraded to rocm-5.5
+MIGRAPHX_DEVICE_MATH_BINARY_FOR(migraphx::half, max, ::fmaxf)
+MIGRAPHX_DEVICE_MATH_BINARY_FOR(migraphx::half, min, ::fminf)
 
 template <class T, MIGRAPHX_REQUIRES(not is_any_vec<T>())>
 constexpr auto max(const T& a, const T& b)

--- a/src/targets/gpu/kernels/include/migraphx/kernels/math.hpp
+++ b/src/targets/gpu/kernels/include/migraphx/kernels/math.hpp
@@ -188,7 +188,7 @@ MIGRAPHX_DEVICE_MATH_BINARY_FOR(float, max, ::max)
 MIGRAPHX_DEVICE_MATH_BINARY_FOR(float, min, ::min)
 MIGRAPHX_DEVICE_MATH_BINARY_FOR(double, max, ::max)
 MIGRAPHX_DEVICE_MATH_BINARY_FOR(double, min, ::min)
-// Add overloads for half that calls the float version, this should use "hmax" and "hmin" once 
+// Add overloads for half that calls the float version, this should use "hmax" and "hmin" once
 // perf CI docker is upgraded to rocm-5.5
 MIGRAPHX_DEVICE_MATH_BINARY_FOR(migraphx::half, max, ::fmaxf)
 MIGRAPHX_DEVICE_MATH_BINARY_FOR(migraphx::half, min, ::fminf)


### PR DESCRIPTION
#1764  broke perf/accuracy CI tests because it used rocm-5.4.2 inside the docker.  
rocm-5.4.2 doesn't have `hmax` and `hmin` APIs. it only exists in rocm-5.5+.  Backing out those changes temporarily untill we have rocm-5.5 in perf/accuracy CI tests. 