### PR TITLE
Convert Fp16 instance-norm to FP32 temporarily

### DIFF
--- a/src/onnx/parse_instancenorm.cpp
+++ b/src/onnx/parse_instancenorm.cpp
@@ -55,6 +55,7 @@ struct parse_instancenorm : op_parser<parse_instancenorm>
         auto dtype         = oargs[0]->get_shape().type();
         auto literal_dtype = dtype;
         std::vector<instruction_ref> args;
+        // cppcheck-suppress knownConditionTrueFalse
         if(dtype == shape::half_type and convert_fp16)
         {
             std::transform(oargs.begin(), oargs.end(), std::back_inserter(args), [&](const auto i) {

--- a/src/onnx/parse_instancenorm.cpp
+++ b/src/onnx/parse_instancenorm.cpp
@@ -87,7 +87,8 @@ struct parse_instancenorm : op_parser<parse_instancenorm>
         auto mean_bcast =
             info.add_instruction(make_op("multibroadcast", {{"out_lens", dims}}), mean);
         auto l1 = info.add_instruction(make_op("sub"), x, mean_bcast);
-        // for the FP16, if not converting to fp32 then use reduce_sum
+        // for the fp16, if not converting to fp32 then divide `x` and `mean` by `sqrt(n)` and take
+        // reduce_sum
         std::string reduce_op_name =
             (dtype == shape::half_type and not convert_fp16) ? "reduce_sum" : "reduce_mean";
         if(dtype == shape::half_type and not convert_fp16)

--- a/src/onnx/parse_instancenorm.cpp
+++ b/src/onnx/parse_instancenorm.cpp
@@ -26,6 +26,9 @@
 #include <migraphx/ranges.hpp>
 #include <migraphx/instruction.hpp>
 #include <migraphx/make_op.hpp>
+#include <migraphx/env.hpp>
+
+MIGRAPHX_DECLARE_ENV_VAR(MIGRAPHX_DISABLE_FP16_INSTANCENORM_CONVERT);
 
 namespace migraphx {
 inline namespace MIGRAPHX_INLINE_NS {
@@ -47,7 +50,11 @@ struct parse_instancenorm : op_parser<parse_instancenorm>
         // variance = reduce_mean({D1, D2, ... Dk}, (x - mean)^2)
         // Convert fp16 to fp32 to workaround for FP16 accuracy issues with reduce_mean/variance.
         bool convert_fp16 = true;
-        float epsilon     = 1e-5f;
+        if(enabled(MIGRAPHX_DISABLE_FP16_INSTANCENORM_CONVERT{}))
+        {
+            convert_fp16 = false;
+        }
+        float epsilon = 1e-5f;
         if(contains(info.attributes, "epsilon"))
         {
             epsilon = parser.parse_value(info.attributes.at("epsilon")).at<float>();

--- a/src/onnx/parse_instancenorm.cpp
+++ b/src/onnx/parse_instancenorm.cpp
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <iterator>
 #include <migraphx/onnx/op_parser.hpp>
 #include <migraphx/ranges.hpp>
 #include <migraphx/instruction.hpp>
@@ -56,12 +57,10 @@ struct parse_instancenorm : op_parser<parse_instancenorm>
         std::vector<instruction_ref> args;
         if(dtype == shape::half_type and convert_fp16)
         {
-            args.push_back(info.add_instruction(
-                make_op("convert", {{"target_type", shape::float_type}}), oargs[0]));
-            args.push_back(info.add_instruction(
-                make_op("convert", {{"target_type", shape::float_type}}), oargs[1]));
-            args.push_back(info.add_instruction(
-                make_op("convert", {{"target_type", shape::float_type}}), oargs[2]));
+            std::transform(oargs.begin(), oargs.end(), std::back_inserter(args), [&](const auto i) {
+                return info.add_instruction(
+                    make_op("convert", {{"target_type", shape::float_type}}), i);
+            });
             literal_dtype = shape::float_type;
         }
         else

--- a/src/onnx/parse_instancenorm.cpp
+++ b/src/onnx/parse_instancenorm.cpp
@@ -87,7 +87,8 @@ struct parse_instancenorm : op_parser<parse_instancenorm>
             info.add_instruction(make_op("multibroadcast", {{"out_lens", dims}}), mean);
         auto l1 = info.add_instruction(make_op("sub"), x, mean_bcast);
         // for the fp16, if not converting to fp32 then divide `x` and `mean` by `sqrt(n)` and take
-        // reduce_sum
+        // reduce_sum to calculate variance i.e.
+        // var =  reduce_sum((x/s_n - mean/s_n)^2) where s_n = sqrt(n)
         std::string reduce_op_name =
             (dtype == shape::half_type and not convert_fp16) ? "reduce_sum" : "reduce_mean";
         if(dtype == shape::half_type and not convert_fp16)

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -3176,9 +3176,9 @@ TEST_CASE(instance_norm_test)
     auto mean = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2, 3}}}), x);
     auto mean_bcast =
         mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", dims}}), mean);
-    auto l0       = mm->add_instruction(migraphx::make_op("sqdiff"), x, mean_bcast);
-    auto variance = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2, 3}}}), l0);
-    auto l1       = mm->add_instruction(migraphx::make_op("sub"), x, mean_bcast);
+    auto l0       = mm->add_instruction(migraphx::make_op("sub"), x, mean_bcast);
+    auto l1       = mm->add_instruction(migraphx::make_op("sqdiff"), x, mean_bcast);
+    auto variance = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2, 3}}}), l1);
     auto epsilon_literal =
         mm->add_literal(migraphx::literal{migraphx::shape{migraphx::shape::float_type}, {1e-5}});
     auto epsilon_bcast = mm->add_instruction(
@@ -3187,7 +3187,7 @@ TEST_CASE(instance_norm_test)
         mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", dims}}), variance);
     auto l2          = mm->add_instruction(migraphx::make_op("add"), variance_bcast, epsilon_bcast);
     auto l3          = mm->add_instruction(migraphx::make_op("rsqrt"), l2);
-    auto l4          = mm->add_instruction(migraphx::make_op("mul"), l1, l3);
+    auto l4          = mm->add_instruction(migraphx::make_op("mul"), l0, l3);
     auto scale_bcast = mm->add_instruction(
         migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", dims}}), scale);
     auto bias_bcast = mm->add_instruction(
@@ -3207,33 +3207,41 @@ TEST_CASE(instance_norm_half_test)
     migraphx::shape s2{migraphx::shape::half_type, {2}};
 
     migraphx::program p;
-    auto* mm   = p.get_main_module();
-    auto x     = mm->add_parameter("0", s1);
-    auto scale = mm->add_parameter("1", s2);
-    auto bias  = mm->add_parameter("2", s2);
+    auto* mm        = p.get_main_module();
+    auto x_fp16     = mm->add_parameter("0", s1);
+    auto scale_fp16 = mm->add_parameter("1", s2);
+    auto bias_fp16  = mm->add_parameter("2", s2);
+
+    auto x = mm->add_instruction(
+        migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), x_fp16);
+    auto scale = mm->add_instruction(
+        migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), scale_fp16);
+    auto bias = mm->add_instruction(
+        migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), bias_fp16);
 
     auto mean = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2, 3}}}), x);
     auto mean_bcast =
         mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", dims}}), mean);
-    auto l0       = mm->add_instruction(migraphx::make_op("sqdiff"), x, mean_bcast);
-    auto variance = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2, 3}}}), l0);
-    auto l1       = mm->add_instruction(migraphx::make_op("sub"), x, mean_bcast);
+    auto l0       = mm->add_instruction(migraphx::make_op("sub"), x, mean_bcast);
+    auto l1       = mm->add_instruction(migraphx::make_op("sqdiff"), x, mean_bcast);
+    auto variance = mm->add_instruction(migraphx::make_op("reduce_mean", {{"axes", {2, 3}}}), l1);
     auto epsilon_literal =
-        mm->add_literal(migraphx::literal{migraphx::shape{migraphx::shape::half_type}, {1e-5}});
+        mm->add_literal(migraphx::literal{migraphx::shape{migraphx::shape::float_type}, {1e-5}});
     auto epsilon_bcast = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"out_lens", dims}}), epsilon_literal);
     auto variance_bcast =
         mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", dims}}), variance);
     auto l2          = mm->add_instruction(migraphx::make_op("add"), variance_bcast, epsilon_bcast);
     auto l3          = mm->add_instruction(migraphx::make_op("rsqrt"), l2);
-    auto l4          = mm->add_instruction(migraphx::make_op("mul"), l1, l3);
+    auto l4          = mm->add_instruction(migraphx::make_op("mul"), l0, l3);
     auto scale_bcast = mm->add_instruction(
         migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", dims}}), scale);
     auto bias_bcast = mm->add_instruction(
         migraphx::make_op("broadcast", {{"axis", 1}, {"out_lens", dims}}), bias);
-    auto l5 = mm->add_instruction(migraphx::make_op("mul"), l4, scale_bcast);
-    mm->add_instruction(migraphx::make_op("add"), l5, bias_bcast);
-
+    auto l5                 = mm->add_instruction(migraphx::make_op("mul"), l4, scale_bcast);
+    auto instance_norm_fp32 = mm->add_instruction(migraphx::make_op("add"), l5, bias_bcast);
+    mm->add_instruction(migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}),
+                        instance_norm_fp32);
     auto prog = optimize_onnx("instance_norm_half_test.onnx");
 
     EXPECT(p == prog);

--- a/test/verify/main.cpp
+++ b/test/verify/main.cpp
@@ -76,10 +76,10 @@ int main(int argc, const char* argv[])
          "test_select_module_reduce",
          "test_select_module_conv",
          "test_split_single_dyn_dim",
-         "test_instancenorm_large_3d<migraphx::MIGRAPHX_INLINE_NS::shape::half_type>",
+         "test_instancenorm_large_3d<migraphx::version_1::shape::half_type>",
          "test_instancenorm_large_3d<migraphx::shape::float_type>",
          "test_instancenorm_large_3d<migraphx::shape::half_type>",
-         "test_instancenorm_large_3d<migraphx::MIGRAPHX_INLINE_NS::shape::float_type>"});
+         "test_instancenorm_large_3d<migraphx::version_1::shape::float_type>"});
     rv.disable_test_for("gpu", {"test_conv_bn_add"});
     rv.run(argc, argv);
 }

--- a/test/verify/main.cpp
+++ b/test/verify/main.cpp
@@ -75,10 +75,8 @@ int main(int argc, const char* argv[])
                          "test_select_module_reduce",
                          "test_select_module_conv",
                          "test_split_single_dyn_dim",
-                         "test_instancenorm_large_3d<migraphx::version_1::shape::half_type>",
                          "test_instancenorm_large_3d<migraphx::shape::float_type>",
-                         "test_instancenorm_large_3d<migraphx::shape::half_type>",
-                         "test_instancenorm_large_3d<migraphx::version_1::shape::float_type>"});
+                         "test_instancenorm_large_3d<migraphx::shape::half_type>"});
     rv.disable_test_for("gpu", {"test_conv_bn_add"});
     rv.run(argc, argv);
 }

--- a/test/verify/main.cpp
+++ b/test/verify/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, const char* argv[])
          "test_split_single_dyn_dim",
          "test_instancenorm_large_3d<migraphx::MIGRAPHX_INLINE_NS::shape::half_type>",
          "test_instancenorm_large_3d<migraphx::shape::float_type>",
-		 "test_instancenorm_large_3d<migraphx::shape::half_type>",
+         "test_instancenorm_large_3d<migraphx::shape::half_type>",
          "test_instancenorm_large_3d<migraphx::MIGRAPHX_INLINE_NS::shape::float_type>"});
     rv.disable_test_for("gpu", {"test_conv_bn_add"});
     rv.run(argc, argv);

--- a/test/verify/main.cpp
+++ b/test/verify/main.cpp
@@ -67,16 +67,17 @@ int main(int argc, const char* argv[])
 {
     run_verify rv;
     rv.add_validation_for("gpu", &validate_gpu);
-    rv.disable_test_for("cpu",
-                        {"test_if_lp",
-                         "test_if_param",
-                         "test_if_literal",
-                         "test_select_module_add",
-                         "test_select_module_reduce",
-                         "test_select_module_conv",
-                         "test_split_single_dyn_dim",
-                         "test_instancenorm_large_3D<migraphx::shape::half_type>",
-                         "test_instancenorm_large_3D<migraphx::shape::float_type>"});
+    rv.disable_test_for(
+        "cpu",
+        {"test_if_lp",
+         "test_if_param",
+         "test_if_literal",
+         "test_select_module_add",
+         "test_select_module_reduce",
+         "test_select_module_conv",
+         "test_split_single_dyn_dim",
+         "test_instancenorm_large_3d<migraphx::MIGRAPHX_INLINE_NS::shape::half_type>",
+         "test_instancenorm_large_3d<migraphx::MIGRAPHX_INLINE_NS::shape::float_type>"});
     rv.disable_test_for("gpu", {"test_conv_bn_add"});
     rv.run(argc, argv);
 }

--- a/test/verify/main.cpp
+++ b/test/verify/main.cpp
@@ -67,19 +67,18 @@ int main(int argc, const char* argv[])
 {
     run_verify rv;
     rv.add_validation_for("gpu", &validate_gpu);
-    rv.disable_test_for(
-        "cpu",
-        {"test_if_lp",
-         "test_if_param",
-         "test_if_literal",
-         "test_select_module_add",
-         "test_select_module_reduce",
-         "test_select_module_conv",
-         "test_split_single_dyn_dim",
-         "test_instancenorm_large_3d<migraphx::version_1::shape::half_type>",
-         "test_instancenorm_large_3d<migraphx::shape::float_type>",
-         "test_instancenorm_large_3d<migraphx::shape::half_type>",
-         "test_instancenorm_large_3d<migraphx::version_1::shape::float_type>"});
+    rv.disable_test_for("cpu",
+                        {"test_if_lp",
+                         "test_if_param",
+                         "test_if_literal",
+                         "test_select_module_add",
+                         "test_select_module_reduce",
+                         "test_select_module_conv",
+                         "test_split_single_dyn_dim",
+                         "test_instancenorm_large_3d<migraphx::version_1::shape::half_type>",
+                         "test_instancenorm_large_3d<migraphx::shape::float_type>",
+                         "test_instancenorm_large_3d<migraphx::shape::half_type>",
+                         "test_instancenorm_large_3d<migraphx::version_1::shape::float_type>"});
     rv.disable_test_for("gpu", {"test_conv_bn_add"});
     rv.run(argc, argv);
 }

--- a/test/verify/main.cpp
+++ b/test/verify/main.cpp
@@ -74,7 +74,9 @@ int main(int argc, const char* argv[])
                          "test_select_module_add",
                          "test_select_module_reduce",
                          "test_select_module_conv",
-                         "test_split_single_dyn_dim"});
+                         "test_split_single_dyn_dim",
+                         "test_instancenorm_large_3D<migraphx::shape::half_type>",
+                         "test_instancenorm_large_3D<migraphx::shape::float_type>"});
     rv.disable_test_for("gpu", {"test_conv_bn_add"});
     rv.run(argc, argv);
 }

--- a/test/verify/main.cpp
+++ b/test/verify/main.cpp
@@ -77,6 +77,8 @@ int main(int argc, const char* argv[])
          "test_select_module_conv",
          "test_split_single_dyn_dim",
          "test_instancenorm_large_3d<migraphx::MIGRAPHX_INLINE_NS::shape::half_type>",
+         "test_instancenorm_large_3d<migraphx::shape::float_type>",
+		 "test_instancenorm_large_3d<migraphx::shape::half_type>",
          "test_instancenorm_large_3d<migraphx::MIGRAPHX_INLINE_NS::shape::float_type>"});
     rv.disable_test_for("gpu", {"test_conv_bn_add"});
     rv.run(argc, argv);

--- a/test/verify/test_instancenorm.cpp
+++ b/test/verify/test_instancenorm.cpp
@@ -31,7 +31,7 @@
 
 migraphx::instruction_ref add_instancenorm(migraphx::module& m,
                                            migraphx::instruction_ref x,
-                                           std::vector<size_t> dims,
+                                           const std::vector<size_t>& dims,
                                            float eps = 1e-5f)
 {
     auto mgx_type = x->get_shape().type();
@@ -80,7 +80,7 @@ template struct test_instancenorm<migraphx::shape::float_type>;
 template struct test_instancenorm<migraphx::shape::half_type>;
 
 template <migraphx::shape::type_t TYPE>
-struct test_instancenorm_large_3D : verify_program<test_instancenorm_large_3D<TYPE>>
+struct test_instancenorm_large_3d : verify_program<test_instancenorm_large_3d<TYPE>>
 {
     migraphx::program create_program() const
     {
@@ -93,5 +93,5 @@ struct test_instancenorm_large_3D : verify_program<test_instancenorm_large_3D<TY
     }
 };
 
-template struct test_instancenorm_large_3D<migraphx::shape::float_type>;
-template struct test_instancenorm_large_3D<migraphx::shape::half_type>;
+template struct test_instancenorm_large_3d<migraphx::shape::float_type>;
+template struct test_instancenorm_large_3d<migraphx::shape::half_type>;

--- a/test/verify/test_instancenorm.cpp
+++ b/test/verify/test_instancenorm.cpp
@@ -1,0 +1,113 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2022 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "verify_program.hpp"
+#include <migraphx/program.hpp>
+#include <migraphx/instruction.hpp>
+#include <migraphx/generate.hpp>
+#include <migraphx/common.hpp>
+#include <migraphx/make_op.hpp>
+
+migraphx::instruction_ref add_instancenorm(migraphx::module& m,
+                                           migraphx::instruction_ref x,
+                                           std::vector<size_t> dims,
+                                           float eps = 1e-5f)
+{
+    auto mgx_type = x->get_shape().type();
+    auto x_lens   = x->get_shape().lens();
+    std::vector<size_t> axes(x_lens.size() - 2);
+    std::iota(axes.begin(), axes.end(), 2);
+    auto scale        = m.add_parameter("scale", migraphx::shape{mgx_type, dims});
+    auto bias         = m.add_parameter("bias", migraphx::shape{mgx_type, dims});
+    auto literal_type = mgx_type;
+    if(mgx_type == migraphx::shape::half_type)
+    {
+        x = m.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), x);
+        scale = m.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), scale);
+        bias = m.add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::float_type}}), bias);
+        literal_type = migraphx::shape::float_type;
+    }
+    auto epsilon = m.add_literal(migraphx::literal{migraphx::shape{literal_type}, {eps}});
+
+    auto mean = m.add_instruction(migraphx::make_op("reduce_mean", {{"axes", axes}}), x);
+    auto mean_mbcast =
+        m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", x_lens}}), mean);
+    auto sub = m.add_instruction(migraphx::make_op("sub"), x, mean_mbcast);
+    auto l0  = m.add_instruction(migraphx::make_op("sqdiff"), {x, mean_mbcast});
+    auto var = m.add_instruction(migraphx::make_op("reduce_mean", {{"axes", axes}}), {l0});
+    auto epsilon_mbcast =
+        m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", x_lens}}), epsilon);
+    auto var_mbcast =
+        m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", x_lens}}), var);
+    auto add_epsilon = m.add_instruction(migraphx::make_op("add"), var_mbcast, epsilon_mbcast);
+    auto rsqrt       = m.add_instruction(migraphx::make_op("rsqrt"), add_epsilon);
+    auto l1          = m.add_instruction(migraphx::make_op("mul"), {sub, rsqrt});
+    auto scale_mbcast =
+        m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", x_lens}}), scale);
+    auto mul = m.add_instruction(migraphx::make_op("mul"), scale_mbcast, l1);
+    auto bias_mbcast =
+        m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", x_lens}}), bias);
+    auto ret = m.add_instruction(migraphx::make_op("add"), mul, bias_mbcast);
+    if(mgx_type == migraphx::shape::half_type)
+    {
+        return m.add_instruction(migraphx::make_op("convert", {{"target_type", mgx_type}}), ret);
+    }
+    return ret;
+}
+
+template <migraphx::shape::type_t TYPE>
+struct test_instancenorm : verify_program<test_instancenorm<TYPE>>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        auto* mm                 = p.get_main_module();
+        std::vector<size_t> dims = {1, 2, 5, 5};
+        auto x                   = mm->add_parameter("x", migraphx::shape{TYPE, dims});
+        add_instancenorm(*mm, x, {1, 2, 1, 1});
+        return p;
+    }
+};
+template struct test_instancenorm<migraphx::shape::float_type>;
+template struct test_instancenorm<migraphx::shape::half_type>;
+
+template <migraphx::shape::type_t TYPE>
+struct test_instancenorm_large_3D : verify_program<test_instancenorm_large_3D<TYPE>>
+{
+    migraphx::program create_program() const
+    {
+        migraphx::program p;
+        auto* mm                 = p.get_main_module();
+        std::vector<size_t> dims = {1, 32, 32, 32, 32};
+        auto x                   = mm->add_parameter("x", migraphx::shape{TYPE, dims});
+        add_instancenorm(*mm, x, {1, 32, 1, 1, 1});
+        return p;
+    }
+};
+
+template struct test_instancenorm_large_3D<migraphx::shape::float_type>;
+template struct test_instancenorm_large_3D<migraphx::shape::half_type>;

--- a/test/verify/test_instancenorm.cpp
+++ b/test/verify/test_instancenorm.cpp
@@ -102,7 +102,7 @@ struct test_instancenorm_large_3D : verify_program<test_instancenorm_large_3D<TY
     {
         migraphx::program p;
         auto* mm                 = p.get_main_module();
-        std::vector<size_t> dims = {1, 32, 32, 32, 32};
+        std::vector<size_t> dims = {1, 32, 64, 64, 64};
         auto x                   = mm->add_parameter("x", migraphx::shape{TYPE, dims});
         add_instancenorm(*mm, x, {1, 32, 1, 1, 1});
         return p;

--- a/test/verify/verify_program.hpp
+++ b/test/verify/verify_program.hpp
@@ -55,10 +55,11 @@ struct register_verify_program_action
         // test_type_name could contain internal namespace name with version_x_y_z i.e.
         // test_instancenorm<migraphx::version_1::shape::float_type> remove version and construct
         // test_name such as test_instancenorm<migraphx::shape::float_type>
-        std::copy_if(split_name.begin(),
-                     split_name.end(),
-                     std::back_inserter(name_without_version),
-                     [&](const auto& i) { return not i.empty() and not contains(i, "version"); });
+        std::copy_if(
+            split_name.begin(),
+            split_name.end(),
+            std::back_inserter(name_without_version),
+            [&](const auto& i) { return not i.empty() and not migraphx::contains(i, "version"); });
         pi.name            = migraphx::join_strings(name_without_version, "::");
         pi.section         = x.section();
         pi.get_program     = [x] { return x.create_program(); };

--- a/test/verify/verify_program.hpp
+++ b/test/verify/verify_program.hpp
@@ -29,6 +29,7 @@
 #include <migraphx/program.hpp>
 #include <migraphx/stringutils.hpp>
 #include <migraphx/compile_options.hpp>
+#include <migraphx/ranges.hpp>
 
 struct program_info
 {

--- a/test/verify/verify_program.hpp
+++ b/test/verify/verify_program.hpp
@@ -27,6 +27,7 @@
 #include <functional>
 #include <migraphx/auto_register.hpp>
 #include <migraphx/program.hpp>
+#include <migraphx/stringutils.hpp>
 #include <migraphx/compile_options.hpp>
 
 struct program_info
@@ -47,7 +48,17 @@ struct register_verify_program_action
     {
         T x;
         program_info pi;
-        pi.name            = migraphx::get_type_name<T>();
+        std::string test_type_name                    = migraphx::get_type_name<T>();
+        const auto& split_name                        = migraphx::split_string(test_type_name, ':');
+        std::vector<std::string> name_without_version = {};
+        // test_type_name could contain internal namespace name with version_x_y_z i.e.
+        // test_instancenorm<migraphx::version_1::shape::float_type> remove version and construct
+        // test_name such as test_instancenorm<migraphx::shape::float_type>
+        std::copy_if(split_name.begin(),
+                     split_name.end(),
+                     std::back_inserter(name_without_version),
+                     [&](const auto& i) { return not i.empty() and not contains(i, "version"); });
+        pi.name            = migraphx::join_strings(name_without_version, "::");
         pi.section         = x.section();
         pi.get_program     = [x] { return x.create_program(); };
         pi.compile_options = x.get_compile_options();

--- a/test/verify/verify_program.hpp
+++ b/test/verify/verify_program.hpp
@@ -60,7 +60,7 @@ struct register_verify_program_action
             split_name.end(),
             std::back_inserter(name_without_version),
             [&](const auto& i) { return not i.empty() and not migraphx::contains(i, "version"); });
-        pi.name            = migraphx::join_strings(name_without_version, "::");
+        pi.name            = migraphx::trim(migraphx::join_strings(name_without_version, "::"));
         pi.section         = x.section();
         pi.get_program     = [x] { return x.create_program(); };
         pi.compile_options = x.get_compile_options();

--- a/test/verify/verify_program.hpp
+++ b/test/verify/verify_program.hpp
@@ -49,7 +49,7 @@ struct register_verify_program_action
     {
         T x;
         program_info pi;
-        std::string test_type_name                    = migraphx::get_type_name<T>();
+        const std::string& test_type_name             = migraphx::get_type_name<T>();
         const auto& split_name                        = migraphx::split_string(test_type_name, ':');
         std::vector<std::string> name_without_version = {};
         // test_type_name could contain internal namespace name with version_x_y_z i.e.

--- a/tools/accuracy/accuracy_checker.py
+++ b/tools/accuracy/accuracy_checker.py
@@ -97,7 +97,7 @@ def parse_args():
         'Save output of ORT as numpy array at path provided by this argument')
     args = parser.parse_args()
     if args.verbose:
-        print("Tolerance is set at {args.tolerance}")
+        print(f"Tolerance is set at {args.tolerance}")
     return args
 
 
@@ -213,7 +213,7 @@ def main():
             in_path = args.np_path[args.numpy.index(name)]
             if args.verbose:
                 print(
-                    "Loading numpy array for input name : {name}, from path : {in_path}"
+                    f"Loading numpy array for input name : {name}, from path : {in_path}"
                 )
             test_input = np.load(in_path).astype(get_np_datatype(in_type))
         elif not args.fill1 and not args.fill0:
@@ -249,7 +249,7 @@ def main():
             if (args.save_ort):
                 if args.verbose:
                     print(
-                        "saving ORT result as numpy array at location : {args.save_ort}"
+                        f"saving ORT result as numpy array at location : {args.save_ort}"
                     )
                 np.save(args.save_ort, pred_fw)
         except Exception as e:

--- a/tools/accuracy/accuracy_checker.py
+++ b/tools/accuracy/accuracy_checker.py
@@ -96,7 +96,8 @@ def parse_args():
         help=
         'Save output of ORT as numpy array at path provided by this argument')
     args = parser.parse_args()
-
+    if args.verbose:
+        print("Tolerance is set at {args.tolerance}")
     return args
 
 
@@ -115,6 +116,15 @@ def check_correctness(gold_outputs,
     ret = True
     for i in range(out_num):
         if not np.allclose(gold_outputs[i], outputs[i], rtol, atol):
+            failed_idx = ~np.isclose(gold_outputs[i], outputs[i], rtol, atol)
+            if verbose:
+                print("Shape of Failed elements{} :\n".format(
+                    gold_outputs[i][failed_idx].shape))
+                print("Expected :\n{}".format(
+                    gold_outputs[i][failed_idx].tolist()[0:400:5]))
+                print('......')
+                print("Actual \n{}".format(
+                    outputs[i][failed_idx].tolist()[0:400:5]))
             ret = False
             if verbose:
                 print('\nOutput {} is incorrect ...'.format(i))

--- a/tools/accuracy/accuracy_checker.py
+++ b/tools/accuracy/accuracy_checker.py
@@ -52,8 +52,14 @@ def parse_args():
     parser.add_argument('--fill0',
                         action='store_true',
                         help='fill all arguments with a value of 0')
-    parser.add_argument('--numpy', action='append', help='fill argument with numpy saved array', type=str)
-    parser.add_argument('--np_path', action='append', help='Path for the saved numpy array', type=str)
+    parser.add_argument('--numpy',
+                        action='append',
+                        help='fill argument with numpy saved array',
+                        type=str)
+    parser.add_argument('--np_path',
+                        action='append',
+                        help='Path for the saved numpy array',
+                        type=str)
     parser.add_argument('--verbose',
                         action='store_true',
                         help='show verbose information (for debugging)')
@@ -83,7 +89,12 @@ def parse_args():
                         action='store_true',
                         default=False,
                         help='Turn on ort VERBOSE logging via session options')
-    parser.add_argument('--save-ort-res', dest="save_ort", type=str, help='Save output of ORT as numpy array at path provided by this argument')
+    parser.add_argument(
+        '--save-ort-res',
+        dest="save_ort",
+        type=str,
+        help=
+        'Save output of ORT as numpy array at path provided by this argument')
     args = parser.parse_args()
 
     return args
@@ -191,7 +202,9 @@ def main():
         if name in args.numpy:
             in_path = args.np_path[args.numpy.index(name)]
             if args.verbose:
-                print("Loading numpy array for input name : {name}, from path : {in_path}")
+                print(
+                    "Loading numpy array for input name : {name}, from path : {in_path}"
+                )
             test_input = np.load(in_path).astype(get_np_datatype(in_type))
         elif not args.fill1 and not args.fill0:
             test_input = np.random.rand(*(in_shape)).astype(
@@ -223,9 +236,11 @@ def main():
 
         try:
             pred_fw = sess.run(None, ort_params)[-1]
-            if(args.save_ort): 
+            if (args.save_ort):
                 if args.verbose:
-                    print("saving ORT result as numpy array at location : {args.save_ort}")
+                    print(
+                        "saving ORT result as numpy array at location : {args.save_ort}"
+                    )
                 np.save(args.save_ort, pred_fw)
         except Exception as e:
             if any(input_dims):

--- a/tools/accuracy/accuracy_checker.py
+++ b/tools/accuracy/accuracy_checker.py
@@ -52,6 +52,8 @@ def parse_args():
     parser.add_argument('--fill0',
                         action='store_true',
                         help='fill all arguments with a value of 0')
+    parser.add_argument('--numpy', action='append', help='fill argument with numpy saved array', type=str)
+    parser.add_argument('--np_path', action='append', help='Path for the saved numpy array', type=str)
     parser.add_argument('--verbose',
                         action='store_true',
                         help='show verbose information (for debugging)')
@@ -81,7 +83,7 @@ def parse_args():
                         action='store_true',
                         default=False,
                         help='Turn on ort VERBOSE logging via session options')
-
+    parser.add_argument('--save-ort-res', dest="save_ort", type=str, help='Save output of ORT as numpy array at path provided by this argument')
     args = parser.parse_args()
 
     return args
@@ -186,7 +188,12 @@ def main():
             print(f'Parameter {name} -> {shape}')
         in_shape = shape.lens()
         in_type = shape.type_string()
-        if not args.fill1 and not args.fill0:
+        if name in args.numpy:
+            in_path = args.np_path[args.numpy.index(name)]
+            if args.verbose:
+                print("Loading numpy array for input name : {name}, from path : {in_path}")
+            test_input = np.load(in_path).astype(get_np_datatype(in_type))
+        elif not args.fill1 and not args.fill0:
             test_input = np.random.rand(*(in_shape)).astype(
                 get_np_datatype(in_type))
         elif not args.fill0:
@@ -216,6 +223,10 @@ def main():
 
         try:
             pred_fw = sess.run(None, ort_params)[-1]
+            if(args.save_ort): 
+                if args.verbose:
+                    print("saving ORT result as numpy array at location : {args.save_ort}")
+                np.save(args.save_ort, pred_fw)
         except Exception as e:
             if any(input_dims):
                 print(


### PR DESCRIPTION
By converting to fp32 : fp16 3d-unet model accuracy comes out the same as FP32 accuracy. 

By using reduce_sum method on Fp16 : accuracy comes out ~0.9% lower compared to fp32  while keeping entire model in fp16.