### PR TITLE
Ensure CI labels map correctly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,7 @@ def rocmnodename(name) {
     } else if(name == "navi21") {
         node_name = "${rocmtest_name} && navi21";
     } else if(name == "anygpu") {
-        node_name = "${rocmtest_name} && (mi100 || mi200 || vega)";
+        node_name = "${rocmtest_name} && (gfx908 || gfx90a || vega)";
     } else if(name == "nogpu") {
         node_name = "${rocmtest_name} && nogpu";
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,8 @@ def rocmnodename(name) {
         node_name = "${rocmtest_name} && vega";
     } else if(name == "navi21") {
         node_name = "${rocmtest_name} && navi21";
+    } else if(name == "anygpu") {
+        node_name = "${rocmtest_name} && (mi100 || mi200 || vega)";
     } else if(name == "nogpu") {
         node_name = "${rocmtest_name} && nogpu";
     }
@@ -144,7 +146,7 @@ def onnxnode(name, body) {
     }
 }
 
-rocmtest onnx: onnxnode('rocmtest') { cmake_build ->
+rocmtest onnx: onnxnode('anygpu') { cmake_build ->
     stage("Onnx runtime") {
         sh '''
             apt install half

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,7 @@ def rocmnodename(name) {
     } else if(name == "navi21") {
         node_name = "${rocmtest_name} && navi21";
     } else if(name == "nogpu") {
-        return rocmtest_name;
+        node_name = "${rocmtest_name} && nogpu";
     }
     return node_name
 }


### PR DESCRIPTION
The ONNX Runtime test suite was running on an unsupported GPU due to labeling logic.  This PR is to ally the ORT tests to run on any supported GPU and also ensures that nogpu doesn't run on GPU based servers