### PR TITLE
Print message from driver if offload copy is set for compiled program

### DIFF
--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -459,8 +459,8 @@ struct compiler
         {
             if(ct.target_name == "gpu" && is_offload_copy_set(p))
             {
-                std::cout << "Compiled program likely has offload_copy set, Try passing "
-                             "`--enable-offload-copy` if program fails.";
+                std::cout << "Compiled MIGraphX program likely has offload_copy set, Try passing "
+                             "`--enable-offload-copy` if program run fails.";
             }
             return p;
         }

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -460,14 +460,14 @@ struct compiler
             if(ct.target_name == "gpu" && is_offload_copy_set(p))
             {
                 std::cout << "Compiled MIGraphX program likely has offload_copy set, Try passing "
-                             "`--enable-offload-copy` if program run fails.";
+                             "`--enable-offload-copy` if program run fails.\n";
             }
             else if(ct.target_name == "gpu")
             {
                 std::cout
                     << "Compiled MIGraphX program likely compiled without offload_copy set, Try "
                        "removing "
-                       "`--enable-offload-copy` flag if passed to driver, if program run fails.";
+                       "`--enable-offload-copy` flag if passed to driver, if program run fails.\n";
             }
             return p;
         }

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -455,8 +455,10 @@ struct compiler
     {
         auto p = l.load();
         // Dont compile if its already been compiled
+
         if(p.is_compiled())
         {
+
             if(ct.target_name == "gpu" && is_offload_copy_set(p))
             {
                 std::cout << "Compiled MIGraphX program likely has offload_copy set, Try passing "

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -456,7 +456,11 @@ struct compiler
         auto p = l.load();
         // Dont compile if its already been compiled
         if(p.is_compiled())
+        {
+            if(ct.target_name == "gpu")
+                co.offload_copy = is_offload_copy_set(p);
             return p;
+        }
         auto t = ct.get_target();
         if(to_fp16)
         {

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -457,8 +457,11 @@ struct compiler
         // Dont compile if its already been compiled
         if(p.is_compiled())
         {
-            if(ct.target_name == "gpu")
-                co.offload_copy = is_offload_copy_set(p);
+            if(ct.target_name == "gpu" && is_offload_copy_set(p))
+            {
+                std::cout << "Compiled program likely has offload_copy set, Try passing "
+                             "`--enable-offload-copy` if program fails.";
+            }
             return p;
         }
         auto t = ct.get_target();

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -458,19 +458,24 @@ struct compiler
 
         if(p.is_compiled())
         {
+            if(ct.target_name == "gpu")
+            {
+                if(is_offload_copy_set(p) and not co.offload_copy)
+                {
+                    std::cout << "MIGraphX program was likely compiled with offload_copy set, Try "
+                                 "passing "
+                                 "`--enable-offload-copy` if program run fails.\n";
+                }
+                else if(co.offload_copy)
+                {
+                    std::cout << "MIGraphX program was likely compiled without "
+                                 "offload_copy set, Try "
+                                 "removing "
+                                 "`--enable-offload-copy` flag if passed to driver, if program run "
+                                 "fails.\n";
+                }
+            }
 
-            if(ct.target_name == "gpu" and is_offload_copy_set(p) and not co.offload_copy)
-            {
-                std::cout << "Compiled MIGraphX program likely has offload_copy set, Try passing "
-                             "`--enable-offload-copy` if program run fails.\n";
-            }
-            else if(ct.target_name == "gpu" and co.offload_copy)
-            {
-                std::cout
-                    << "Compiled MIGraphX program likely compiled without offload_copy set, Try "
-                       "removing "
-                       "`--enable-offload-copy` flag if passed to driver, if program run fails.\n";
-            }
             return p;
         }
         auto t = ct.get_target();

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -462,6 +462,13 @@ struct compiler
                 std::cout << "Compiled MIGraphX program likely has offload_copy set, Try passing "
                              "`--enable-offload-copy` if program run fails.";
             }
+            else if(ct.target_name == "gpu")
+            {
+                std::cout
+                    << "Compiled MIGraphX program likely compiled without offload_copy set, Try "
+                       "removing "
+                       "`--enable-offload-copy` flag if passed to driver, if program run fails.";
+            }
             return p;
         }
         auto t = ct.get_target();

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -459,12 +459,12 @@ struct compiler
         if(p.is_compiled())
         {
 
-            if(ct.target_name == "gpu" && is_offload_copy_set(p))
+            if(ct.target_name == "gpu" and is_offload_copy_set(p) and not co.offload_copy)
             {
                 std::cout << "Compiled MIGraphX program likely has offload_copy set, Try passing "
                              "`--enable-offload-copy` if program run fails.\n";
             }
-            else if(ct.target_name == "gpu")
+            else if(ct.target_name == "gpu" and co.offload_copy)
             {
                 std::cout
                     << "Compiled MIGraphX program likely compiled without offload_copy set, Try "

--- a/src/driver/perf.cpp
+++ b/src/driver/perf.cpp
@@ -115,17 +115,10 @@ bool is_offload_copy_set(const program& p)
             for(const auto& j : return_args)
             {
                 auto alias_ins = instruction::get_output_alias(j, true);
-                if(alias_ins->name() == "@param")
-                {
-                    if(not param_ins.erase(alias_ins))
-                    {
-                        return false;
-                    }
-                }
-                else if(alias_ins->name() != "hip::copy_from_gpu")
-                {
+                if(alias_ins->name() == "@param" && param_ins.erase(alias_ins) == 0)
                     return false;
-                }
+                else if(alias_ins->name() != "hip::copy_from_gpu")
+                    return false;
             }
         }
     }

--- a/src/driver/perf.cpp
+++ b/src/driver/perf.cpp
@@ -91,6 +91,14 @@ parameter_map create_param_map(const program& p, bool gpu)
     return m;
 }
 
+target get_target(bool gpu)
+{
+    if(gpu)
+        return make_target("gpu");
+    else
+        return make_target("cpu");
+}
+
 bool is_offload_copy_set(const program& p)
 {
     assert(p.is_compiled());
@@ -121,14 +129,6 @@ bool is_offload_copy_set(const program& p)
         }
     }
     return param_ins.empty();
-}
-
-target get_target(bool gpu)
-{
-    if(gpu)
-        return make_target("gpu");
-    else
-        return make_target("cpu");
 }
 
 } // namespace  MIGRAPHX_INLINE_NS

--- a/src/driver/perf.cpp
+++ b/src/driver/perf.cpp
@@ -117,7 +117,8 @@ bool is_offload_copy_set(const program& p)
                 auto alias_ins = instruction::get_output_alias(j, true);
                 if(alias_ins->name() == "@param")
                 {
-                    if(!param_ins.erase(alias_ins)) {
+                    if(!param_ins.erase(alias_ins))
+                    {
                         return false;
                     }
                 }

--- a/src/driver/perf.cpp
+++ b/src/driver/perf.cpp
@@ -107,8 +107,7 @@ bool is_offload_copy_set(const program& p)
         if(i.name() == "hip::copy_to_gpu")
         {
             auto copy_arg = instruction::get_output_alias(i.inputs().front(), true);
-            if(param_ins.find(copy_arg) != param_ins.end())
-                param_ins.erase(copy_arg);
+            param_ins.erase(copy_arg);
         }
         else if(i.name() == "@return")
         {
@@ -118,12 +117,7 @@ bool is_offload_copy_set(const program& p)
                 auto alias_ins = instruction::get_output_alias(j, true);
                 if(alias_ins->name() == "@param")
                 {
-                    if(param_ins.find(alias_ins) != param_ins.end())
-                    {
-                        param_ins.erase(alias_ins);
-                    }
-                    else
-                    {
+                    if(!param_ins.erase(alias_ins)) {
                         return false;
                     }
                 }

--- a/src/driver/perf.cpp
+++ b/src/driver/perf.cpp
@@ -107,7 +107,7 @@ bool is_offload_copy_set(const program& p)
         if(i.name() == "hip::copy_to_gpu")
         {
             auto copy_arg = instruction::get_output_alias(i.inputs().front(), true);
-            if(param_ins.count(copy_arg))
+            if(param_ins.find(copy_arg) != param_ins.end())
                 param_ins.erase(copy_arg);
         }
         else if(i.name() == "@return")
@@ -118,7 +118,14 @@ bool is_offload_copy_set(const program& p)
                 auto alias_ins = instruction::get_output_alias(j, true);
                 if(alias_ins->name() == "@param")
                 {
-                    return param_ins.erase(alias_ins);
+                    if(param_ins.find(alias_ins) != param_ins.end())
+                    {
+                        param_ins.erase(alias_ins);
+                    }
+                    else
+                    {
+                        return false;
+                    }
                 }
                 else if(alias_ins->name() != "hip::copy_from_gpu")
                 {

--- a/src/driver/perf.cpp
+++ b/src/driver/perf.cpp
@@ -115,9 +115,8 @@ bool is_offload_copy_set(const program& p)
             for(const auto& j : return_args)
             {
                 auto alias_ins = instruction::get_output_alias(j, true);
-                if(alias_ins->name() == "@param" && param_ins.erase(alias_ins) == 0)
-                    return false;
-                else if(alias_ins->name() != "hip::copy_from_gpu")
+                if((alias_ins->name() == "@param" && param_ins.erase(alias_ins) == 0) or
+                   (alias_ins->name() != "hip::copy_from_gpu"))
                     return false;
             }
         }

--- a/src/driver/perf.cpp
+++ b/src/driver/perf.cpp
@@ -117,7 +117,7 @@ bool is_offload_copy_set(const program& p)
                 auto alias_ins = instruction::get_output_alias(j, true);
                 if(alias_ins->name() == "@param")
                 {
-                    if(!param_ins.erase(alias_ins))
+                    if(not param_ins.erase(alias_ins))
                     {
                         return false;
                     }

--- a/src/driver/perf.cpp
+++ b/src/driver/perf.cpp
@@ -23,10 +23,9 @@
  */
 #include "perf.hpp"
 
-#include <unordered_map>
-#include <iterator>
 #include <migraphx/generate.hpp>
 #include <migraphx/instruction.hpp>
+#include <migraphx/instruction_ref.hpp>
 #include <migraphx/register_target.hpp>
 #ifdef HAVE_GPU
 #include <migraphx/gpu/hip.hpp>
@@ -95,14 +94,14 @@ parameter_map create_param_map(const program& p, bool gpu)
 bool is_offload_copy_set(const program& p)
 {
     assert(p.is_compiled());
-    std::vector<std::string> param_names = p.get_parameter_names();
+    const module* mm                     = p.get_main_module();
+    std::vector<std::string> param_names = mm->get_parameter_names();
     std::unordered_set<instruction_ref> param_ins;
     std::transform(param_names.begin(),
                    param_names.end(),
                    std::inserter(param_ins, param_ins.begin()),
-                   [&](const auto& i) { return p.get_parameter(i); });
-    const module mm = *p.get_main_module();
-    for(const auto& i : mm)
+                   [&](const auto& i) { return mm->get_parameter(i); });
+    for(const auto& i : *mm)
     {
         if(i.name() == "hip::copy_to_gpu")
         {

--- a/src/driver/perf.hpp
+++ b/src/driver/perf.hpp
@@ -37,6 +37,7 @@ parameter_map fill_param_map(parameter_map& m,
 parameter_map create_param_map(const program& p, const target& t, bool offload = false);
 
 parameter_map fill_param_map(parameter_map& m, const program& p, bool gpu);
+bool is_offload_copy_set(const program& p);
 parameter_map create_param_map(const program& p, bool gpu = true);
 target get_target(bool gpu);
 

--- a/src/driver/perf.hpp
+++ b/src/driver/perf.hpp
@@ -37,9 +37,17 @@ parameter_map fill_param_map(parameter_map& m,
 parameter_map create_param_map(const program& p, const target& t, bool offload = false);
 
 parameter_map fill_param_map(parameter_map& m, const program& p, bool gpu);
-bool is_offload_copy_set(const program& p);
 parameter_map create_param_map(const program& p, bool gpu = true);
 target get_target(bool gpu);
+/**
+ * @brief Checks if MIGraphX program compiled for "GPU" has offload_copy set of not. This is
+ intended to print a HINT for the users and would not always correctly classify compiled program as
+ with or without offload_copy in all cases.
+
+ * @param p Compiled MIGraphX program for GPU backend
+ * @return true if program is classified as compiled with "offload_copy" set
+ */
+bool is_offload_copy_set(const program& p);
 
 } // namespace MIGRAPHX_INLINE_NS
 } // namespace driver


### PR DESCRIPTION
MXR files can be produced with/without offload copy. 

By default offload-copy is false for the driver. 

When MXR file compiled with offload-copy is run with driver  without `--enable-offload-copy` flag, it would generate parameters and Copy them to GPU before it starts executing the model. 

https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/49b341d3c1e5accb3b13e245615d2f03f663d4fa/src/driver/perf.cpp#L55

During the copy, it first registers the CPU memory.  https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/49b341d3c1e5accb3b13e245615d2f03f663d4fa/src/targets/gpu/include/migraphx/gpu/hip.hpp#L121

But later since the model would have another duplicate `hip::copy_to_gpu`, at that time registration would fail. 

By doing an automatic deduction of `offload_copy` on the compiled model, this issue can be avoided. 


