### PR TITLE
default to ROCm 5.5

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -12,7 +12,7 @@ on:
       rocm_release:
         description: ROCm Version
         required: true
-        default: '5.4.2'
+        default: '5.5'
       performance_reports_repo:
         description: Repository where performance reports are stored
         required: true
@@ -48,7 +48,7 @@ jobs:
   release:
     uses: ROCmSoftwarePlatform/migraphx-benchmark/.github/workflows/perf-test.yml@main
     with:
-      rocm_release: ${{ github.event.inputs.rocm_release || '5.4.2' }}
+      rocm_release: ${{ github.event.inputs.rocm_release || '5.5' }}
       result_number: ${{ github.event.inputs.result_number || '10' }}
       flags: ${{ github.event.inputs.flags || '-r' }}
       performance_reports_repo: ${{ github.event.inputs.performance_reports_repo || 'ROCmSoftwarePlatform/migraphx-reports' }}


### PR DESCRIPTION
Switching default ROCm version to 5.5