### PR TITLE
Add missing specialization for the `nullptr` for the hash function

### DIFF
--- a/src/targets/gpu/jit/ck_gemm.cpp
+++ b/src/targets/gpu/jit/ck_gemm.cpp
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  */
 #include <fstream>
-#include <filesystem>
+#include <migraphx/filesystem.hpp>
 #include <migraphx/gpu/compiler.hpp>
 #include <migraphx/make_op.hpp>
 #include <migraphx/gpu/context.hpp>

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -528,9 +528,7 @@ std::size_t value_hash(const std::string& key, const T& x)
     return h;
 }
 
-std::size_t value_hash(const std::string& key, std::nullptr_t) {
-    return hash_value(key);
-}
+std::size_t value_hash(const std::string& key, std::nullptr_t) { return hash_value(key); }
 
 std::size_t value_hash(const std::string& key, const std::vector<value>& x)
 {

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -527,6 +527,11 @@ std::size_t value_hash(const std::string& key, const T& x)
     hash_combine(h, x);
     return h;
 }
+
+std::size_t value_hash(const std::string& key, std::nullptr_t) {
+    return hash_value(key);
+}
+
 std::size_t value_hash(const std::string& key, const std::vector<value>& x)
 {
     std::size_t h = hash_value(key);


### PR DESCRIPTION
#1791  Added hash function for `value` class. It uses the Visit function and has specialization for the bool_type and `<vector>` type but was missing specialization for the nullptr. Nullptr caused compilation issues for RHEL, SLES and CentOS. 