### PR TITLE
Enable hipRTC

### DIFF
--- a/src/targets/gpu/CMakeLists.txt
+++ b/src/targets/gpu/CMakeLists.txt
@@ -35,12 +35,11 @@ endif()
 
 find_package(composable_kernel 1.0.0 COMPONENTS jit_library REQUIRED) 
 
-set(MIGRAPHX_USE_HIPRTC OFF CACHE BOOL "Use hipRTC APIs")
-#if(BUILD_DEV)
-#set(MIGRAPHX_USE_HIPRTC OFF CACHE BOOL "Use hipRTC APIs")
-#else()
-#set(MIGRAPHX_USE_HIPRTC ON CACHE BOOL "Use hipRTC APIs")
-#endif()
+if(BUILD_DEV)
+    set(MIGRAPHX_USE_HIPRTC OFF CACHE BOOL "Use hipRTC APIs")
+else()
+    set(MIGRAPHX_USE_HIPRTC ON CACHE BOOL "Use hipRTC APIs")
+endif()
 
 include(Embed)
 file(GLOB KERNEL_FILES ${CONFIGURE_DEPENDS}


### PR DESCRIPTION
switch from hipClang to hipRTC which allows rocm package installs to be located in different directories