### PR TITLE
Fix TRACE_EVAL > 1

### DIFF
--- a/src/targets/gpu/hip.cpp
+++ b/src/targets/gpu/hip.cpp
@@ -146,7 +146,11 @@ std::vector<T> read_from_gpu(const void* x, std::size_t sz)
     gpu_sync();
     std::vector<T> result(sz);
     assert(not is_device_ptr(result.data()));
-    assert(is_device_ptr(x));
+    if(not is_device_ptr(x))
+    {
+        MIGRAPHX_THROW(
+            "Reading from GPU requires Src buffer to be on the GPU, Copy from gpu failed\n");
+    }
     auto status = hipMemcpy(result.data(), x, sz * sizeof(T), hipMemcpyDeviceToHost);
     if(status != hipSuccess)
         MIGRAPHX_THROW("Copy from gpu failed: " + hip_error(status)); // NOLINT

--- a/src/targets/gpu/hip.cpp
+++ b/src/targets/gpu/hip.cpp
@@ -149,7 +149,7 @@ std::vector<T> read_from_gpu(const void* x, std::size_t sz)
     if(not is_device_ptr(x))
     {
         MIGRAPHX_THROW(
-            "Reading from GPU requires Src buffer to be on the GPU, Copy from gpu failed\n");
+            "read_from_gpu() requires Src buffer to be on the GPU, Copy from gpu failed\n");
     }
     auto status = hipMemcpy(result.data(), x, sz * sizeof(T), hipMemcpyDeviceToHost);
     if(status != hipSuccess)


### PR DESCRIPTION
TRACE_EVAL assumes all instructions always produce results on Target. 
It tries to copy results from the target explicitly. 

Some instructions like `NMS` , ROIAlign are run on the host in which case the following would break. 

https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/c900e382a1344ae286166708a5f77e5fe709370c/src/program.cpp#L558

For example  when trying to run `test_nms` with `MIGRAPHX_TRACE_EVAL=2`, it fails on `copy_from()`. 


```
root@3355683a62d6:~/repo/AMDMIGraphX/build(fix_trace_eval)# ./bin/test_verify "test_nms"
[   RUN    ] test_nms
Run instruction: @0 = @literal{0} -> float_type, {1}, {0}, target_id=0
Time: 0.01743ms, 0.01776ms
Run instruction: @1 = @literal{0.5} -> float_type, {1}, {0}, target_id=0
Time: 0.00055ms, 0.00063ms
Run instruction: @2 = @literal{4} -> int64_type, {1}, {0}, target_id=0
Time: 0.00089ms, 0.00097ms
Run instruction: @3 = @literal{0.9, 0.75, 0.6, 0.95, 0.5, 0.3} -> float_type, {1, 1, 6}, {6, 6, 1}, target_id=0
Time: 0.00067ms, 0.00075ms
Run instruction: boxes = @param:boxes -> float_type, {1, 6, 4}, {24, 4, 1}, target_id=0
Time: 0.01173ms, 0.01186ms
Run instruction: @5 = ref::nonmaxsuppression[center_point_box=1,use_dyn_output=0](boxes,@3,@2,@1,@0) -> int64_type, {6, 3}, {3, 1}, target_id=0
Time: 0.15231ms, 0.15256ms
Output has normal, zero
Output: 0, 0, 3, 0, 0, ..., 0, 0, 0, 0, 0
Run instruction: @0 = check_context::migraphx::gpu::context  -> float_type, {}, {}, target_id=0
Time: 0.01013ms, 0.01098ms
Run instruction: boxes = @param:boxes -> float_type, {1, 6, 4}, {24, 4, 1}, target_id=0
Time: 0.00129ms, 0.00185ms
Run instruction: @2 = hip::copy_from_gpu(boxes) -> float_type, {1, 6, 4}, {24, 4, 1}, target_id=0
Time: 4.32311ms, 4.33639ms
Output has normal
Output: -0.25, 0.75, -0.625, -0.0625, 0.625, ..., -0.75, 0.1875, -0.25, -0.5625, -0.5625
Run instruction: @3 = hip::hip_copy_literal[id=main:@literal:0] -> float_type, {1}, {0}, target_id=0
Time: 0.01117ms, 0.01179ms
Output has zero
Output: 0
Run instruction: @4 = hip::hip_copy_literal[id=main:@literal:1] -> float_type, {1}, {0}, target_id=0
Time: 0.00061ms, 0.00122ms
Output has normal
Output: 0.5
Run instruction: @5 = hip::hip_copy_literal[id=main:@literal:2] -> int64_type, {1}, {0}, target_id=0
Time: 0.00039ms, 0.00076ms
Output has normal
Output: 4
Run instruction: @6 = hip::hip_copy_literal[id=main:@literal:3] -> float_type, {1, 1, 6}, {6, 6, 1}, target_id=0
Time: 0.00034ms, 0.00071ms
Output has normal
Output: 0.9, 0.75, 0.6, 0.95, 0.5, 0.3
Run instruction: @7 = hip::copy_from_gpu(@3) -> float_type, {1}, {0}, target_id=0
Time: 0.03816ms, 0.05154ms
Output has zero
Output: 0
Run instruction: @8 = hip::copy_from_gpu(@4) -> float_type, {1}, {0}, target_id=0
Time: 0.02761ms, 0.04129ms
Output has normal
Output: 0.5
Run instruction: @9 = hip::copy_from_gpu(@5) -> int64_type, {1}, {0}, target_id=0
Time: 0.03735ms, 0.05101ms
Output has normal
Output: 4
Run instruction: @10 = hip::copy_from_gpu(@6) -> float_type, {1, 1, 6}, {6, 6, 1}, target_id=0
Time: 0.02604ms, 0.03947ms
Output has normal
Output: 0.9, 0.75, 0.6, 0.95, 0.5, 0.3
Run instruction: @11 = hip::sync_stream(@2,@10,@9,@8,@7) -> float_type, {1, 6, 4}, {24, 4, 1}, target_id=0
Time: 0.0096ms, 0.00994ms
Output has normal
Output: -0.25, 0.75, -0.625, -0.0625, 0.625, ..., -0.75, 0.1875, -0.25, -0.5625, -0.5625
Run instruction: @12 = nonmaxsuppression[center_point_box=1,use_dyn_output=0](@11,@10,@9,@8,@7) -> int64_type, {6, 3}, {3, 1}, target_id=0
Time: 0.02351ms, 0.02394ms

module: "main"
@0 = check_context::migraphx::gpu::context  -> float_type, {}, {}, target_id=0
boxes = @param:boxes -> float_type, {1, 6, 4}, {24, 4, 1}, target_id=0
@2 = hip::copy_from_gpu(boxes) -> float_type, {1, 6, 4}, {24, 4, 1}, target_id=0
@3 = hip::hip_copy_literal[id=main:@literal:0] -> float_type, {1}, {0}, target_id=0
@4 = hip::hip_copy_literal[id=main:@literal:1] -> float_type, {1}, {0}, target_id=0
@5 = hip::hip_copy_literal[id=main:@literal:2] -> int64_type, {1}, {0}, target_id=0
@6 = hip::hip_copy_literal[id=main:@literal:3] -> float_type, {1, 1, 6}, {6, 6, 1}, target_id=0
@7 = hip::copy_from_gpu(@3) -> float_type, {1}, {0}, target_id=0
@8 = hip::copy_from_gpu(@4) -> float_type, {1}, {0}, target_id=0
@9 = hip::copy_from_gpu(@5) -> int64_type, {1}, {0}, target_id=0
@10 = hip::copy_from_gpu(@6) -> float_type, {1, 1, 6}, {6, 6, 1}, target_id=0
@11 = hip::sync_stream(@2,@10,@9,@8,@7) -> float_type, {1, 6, 4}, {24, 4, 1}, target_id=0
@12 = nonmaxsuppression[center_point_box=1,use_dyn_output=0](@11,@10,@9,@8,@7) -> int64_type, {6, 3}, {3, 1}, target_id=0
main:#output_0 = @param:main:#output_0 -> int64_type, {6, 3}, {3, 1}, target_id=0
@14 = hip::copy_to_gpu(@12,main:#output_0) -> int64_type, {6, 3}, {3, 1}, target_id=0
@15 = @return(@14), target_id=0


FAILED: test_nms
    what(): /home/umayadav/repo/AMDMIGraphX/src/targets/gpu/hip.cpp:152: read_from_gpu: Copy from gpu failed: invalid argument

Aborted (core dumped)

```
