### PR TITLE
Fix assertion error during verify and make DCE work with tuples

### DIFF
--- a/src/dead_code_elimination.cpp
+++ b/src/dead_code_elimination.cpp
@@ -50,7 +50,9 @@ void dead_code_elimination::apply(module& m) const
             break;
         // Skip instruction with empty shape as output unless its [dynamic, builtin, undefined,
         // identity, allocate]
-        if((not i->get_shape().dynamic() and i->get_shape().elements() == 0) and
+        if((not i->get_shape().dynamic() and
+            (i->get_shape().elements() == 0 and
+             i->get_shape().type() != migraphx::shape::tuple_type)) and
            not(i->name().front() == '@') and not contains({"identity", "allocate"}, i->name()) and
            not i->is_undefined())
             continue;

--- a/src/dead_code_elimination.cpp
+++ b/src/dead_code_elimination.cpp
@@ -49,7 +49,7 @@ void dead_code_elimination::apply(module& m) const
         if(i == last)
             break;
         // Skip instruction with empty shape as output unless its [dynamic, builtin, undefined,
-        // identity, allocate]
+        // identity, allocate or tuple_type]
         if((not i->get_shape().dynamic() and
             (i->get_shape().elements() == 0 and
              i->get_shape().type() != migraphx::shape::tuple_type)) and

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -326,6 +326,8 @@ instruction_ref module::replace_instruction(instruction_ref ins, instruction_ref
 
     if(ins == std::prev(this->end()))
     {
+        // "rep" instruction could be used earlier in the program and moving it at the end
+        // may cause invalid program, therefore make an identity operation in this case.
         return replace_instruction(ins, make_op("identity"), rep);
     }
 

--- a/test/dead_code_elimination_test.cpp
+++ b/test/dead_code_elimination_test.cpp
@@ -273,59 +273,17 @@ TEST_CASE(param_not_eliminated)
     EXPECT(p == create_program());
 }
 
-TEST_CASE(eliminate_tuple_ins)
+TEST_CASE(tuple_test)
 {
-    auto create_program = [](bool add_dead_ins) {
-        migraphx::program p;
-        auto* mm = p.get_main_module();
-        migraphx::shape sd{migraphx::shape::float_type, {1}};
-        auto l1 = mm->add_literal(migraphx::literal(sd, {1}));
-        auto l2 = mm->add_literal(migraphx::literal(sd, {2}));
-        auto l3 = mm->add_literal(migraphx::literal(sd, {3}));
-        migraphx::shape sx{migraphx::shape::float_type, {1, 4}};
-        migraphx::shape sy{migraphx::shape::float_type, {3, 4}};
-        migraphx::shape sc{migraphx::shape::bool_type};
-        auto cond = mm->add_parameter("cond", sc);
-        auto x    = mm->add_parameter("x", sx);
-        auto y    = mm->add_parameter("y", sy);
-
-        auto* then_mod = p.create_module("If_6_if");
-        auto m1        = then_mod->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {1, 4}}}), l1);
-        auto add0 = then_mod->add_instruction(migraphx::make_op("add"), x, m1);
-        auto m2   = then_mod->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {3, 4}}}), l2);
-        auto mul0  = then_mod->add_instruction(migraphx::make_op("mul"), y, m2);
-        auto mfp16 = then_mod->add_instruction(
-            migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}), mul0);
-        then_mod->add_return({add0, mul0, mfp16});
-
-        auto* else_mod = p.create_module("If_6_else");
-        auto me1       = else_mod->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {1, 4}}}), l3);
-        auto mul1 = else_mod->add_instruction(migraphx::make_op("mul"), x, me1);
-        auto me2  = else_mod->add_instruction(
-            migraphx::make_op("multibroadcast", {{"out_lens", {3, 4}}}), l3);
-        auto add1  = else_mod->add_instruction(migraphx::make_op("add"), y, me2);
-        auto afp16 = else_mod->add_instruction(
-            migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}), add1);
-        else_mod->add_return({mul1, add1, afp16});
-        if(add_dead_ins)
-        {
-            auto neg_cond = mm->add_instruction(migraphx::make_op("neg"), {cond});
-            mm->add_instruction(migraphx::make_op("if"), {neg_cond}, {then_mod, else_mod});
-        }
-        auto ret = mm->add_instruction(migraphx::make_op("if"), {cond}, {then_mod, else_mod});
-        auto r0  = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), ret);
-        auto r1  = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 1}}), ret);
-        auto r16 = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 2}}), ret);
-        mm->add_return({r0, r1, r16});
-
-        return p;
-    };
-    auto p = create_program(true);
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    auto one = mm->add_literal(1);
+    auto two = mm->add_literal(2);
+    mm->add_instruction(tuple_op{}, one, two);
+    mm->add_return({one, two});
+    auto count = std::distance(mm->begin(), mm->end());
     run_pass(p);
-    EXPECT(p == create_program(false));
+    EXPECT(std::distance(mm->begin(), mm->end()) == (count - 1));
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/dead_code_elimination_test.cpp
+++ b/test/dead_code_elimination_test.cpp
@@ -232,7 +232,6 @@ TEST_CASE(reused_twice)
 
     auto count = std::distance(mm->begin(), mm->end());
     run_pass(p);
-    p.debug_print();
     EXPECT(std::distance(mm->begin(), mm->end()) != count);
     EXPECT(std::distance(mm->begin(), mm->end()) == 4);
 }
@@ -272,6 +271,61 @@ TEST_CASE(param_not_eliminated)
     auto p = create_program();
     run_pass(p);
     EXPECT(p == create_program());
+}
+
+TEST_CASE(eliminate_tuple_ins)
+{
+    auto create_program = [](bool add_dead_ins) {
+        migraphx::program p;
+        auto* mm = p.get_main_module();
+        migraphx::shape sd{migraphx::shape::float_type, {1}};
+        auto l1 = mm->add_literal(migraphx::literal(sd, {1}));
+        auto l2 = mm->add_literal(migraphx::literal(sd, {2}));
+        auto l3 = mm->add_literal(migraphx::literal(sd, {3}));
+        migraphx::shape sx{migraphx::shape::float_type, {1, 4}};
+        migraphx::shape sy{migraphx::shape::float_type, {3, 4}};
+        migraphx::shape sc{migraphx::shape::bool_type};
+        auto cond = mm->add_parameter("cond", sc);
+        auto x    = mm->add_parameter("x", sx);
+        auto y    = mm->add_parameter("y", sy);
+
+        auto* then_mod = p.create_module("If_6_if");
+        auto m1        = then_mod->add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", {1, 4}}}), l1);
+        auto add0 = then_mod->add_instruction(migraphx::make_op("add"), x, m1);
+        auto m2   = then_mod->add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", {3, 4}}}), l2);
+        auto mul0  = then_mod->add_instruction(migraphx::make_op("mul"), y, m2);
+        auto mfp16 = then_mod->add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}), mul0);
+        then_mod->add_return({add0, mul0, mfp16});
+
+        auto* else_mod = p.create_module("If_6_else");
+        auto me1       = else_mod->add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", {1, 4}}}), l3);
+        auto mul1 = else_mod->add_instruction(migraphx::make_op("mul"), x, me1);
+        auto me2  = else_mod->add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", {3, 4}}}), l3);
+        auto add1  = else_mod->add_instruction(migraphx::make_op("add"), y, me2);
+        auto afp16 = else_mod->add_instruction(
+            migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}), add1);
+        else_mod->add_return({mul1, add1, afp16});
+        if(add_dead_ins)
+        {
+            auto neg_cond = mm->add_instruction(migraphx::make_op("neg"), {cond});
+            mm->add_instruction(migraphx::make_op("if"), {neg_cond}, {then_mod, else_mod});
+        }
+        auto ret = mm->add_instruction(migraphx::make_op("if"), {cond}, {then_mod, else_mod});
+        auto r0  = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 0}}), ret);
+        auto r1  = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 1}}), ret);
+        auto r16 = mm->add_instruction(migraphx::make_op("get_tuple_elem", {{"index", 2}}), ret);
+        mm->add_return({r0, r1, r16});
+
+        return p;
+    };
+    auto p = create_program(true);
+    run_pass(p);
+    EXPECT(p == create_program(false));
 }
 
 int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/test/include/basic_ops.hpp
+++ b/test/include/basic_ops.hpp
@@ -189,7 +189,10 @@ struct nop
 struct tuple_op
 {
     std::string name() const { return "tuple_op"; }
-    migraphx::shape compute_shape(std::vector<migraphx::shape> inputs) const { return {inputs}; }
+    migraphx::shape compute_shape(const std::vector<migraphx::shape>& inputs) const
+    {
+        return {inputs};
+    }
     migraphx::argument compute(migraphx::context&,
                                const migraphx::shape&,
                                const std::vector<migraphx::argument>& input_args) const

--- a/test/include/basic_ops.hpp
+++ b/test/include/basic_ops.hpp
@@ -186,6 +186,18 @@ struct nop
     migraphx::shape compute_shape(const std::vector<migraphx::shape>&) const { return {}; }
 };
 
+struct tuple_op
+{
+    std::string name() const { return "tuple_op"; }
+    migraphx::shape compute_shape(std::vector<migraphx::shape> inputs) const { return {inputs}; }
+    migraphx::argument compute(migraphx::context&,
+                               const migraphx::shape&,
+                               const std::vector<migraphx::argument>& input_args) const
+    {
+        return input_args;
+    }
+};
+
 inline migraphx::literal get_2x2(int base = 0)
 {
     return migraphx::literal{{migraphx::shape::float_type, {2, 2}},

--- a/test/quantization.cpp
+++ b/test/quantization.cpp
@@ -92,7 +92,6 @@ TEST_CASE(param_add)
         }
         else
         {
-
             mm->add_instruction(migraphx::make_op("identity"), {fs});
         }
 

--- a/test/quantization.cpp
+++ b/test/quantization.cpp
@@ -263,7 +263,8 @@ TEST_CASE(param_add_sub)
         };
 
         auto p0 = create_program_float();
-        migraphx::quantize_fp16(p0);
+        migraphx::run_passes(
+            p0, {migraphx::quantize_fp16_pass{{"all"}}, migraphx::dead_code_elimination{}});
         EXPECT(p0 == create_program_fp16());
 
         auto p1 = create_program_float();
@@ -439,8 +440,9 @@ TEST_CASE(fp16_subgraph)
     };
 
     auto p1 = create_program();
-    migraphx::run_passes(
-        p1, {migraphx::quantize_fp16_pass{}, migraphx::dead_code_elimination{}}, std::cout);
+    migraphx::quantize_fp16(p1);
+    // migraphx::run_passes(
+    //   p1, {migraphx::quantize_fp16_pass{}, migraphx::dead_code_elimination{}}, std::cout);
 
     auto p2 = create_fp16_program();
 

--- a/test/quantization.cpp
+++ b/test/quantization.cpp
@@ -441,8 +441,6 @@ TEST_CASE(fp16_subgraph)
 
     auto p1 = create_program();
     migraphx::quantize_fp16(p1);
-    // migraphx::run_passes(
-    //   p1, {migraphx::quantize_fp16_pass{}, migraphx::dead_code_elimination{}}, std::cout);
 
     auto p2 = create_fp16_program();
 


### PR DESCRIPTION
Fixes #1856 and additionally makes DCE work for Tuple Types

`verify` was failing with `reduce` in debug builds here : 
https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/a0fa3742f92239fb60c58d4b73f458efb08ef0ed/src/module.cpp#L349

Assertion was failing because of the following pattern:
`ins --> convert(original_type) --> module_end`. 

And then, it was replacing `ins` with `convert(original_type)` here. https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/a0fa3742f92239fb60c58d4b73f458efb08ef0ed/src/quantize_fp16.cpp#L60

`convert(original_type)` would have no outputs while `ins` would have one output and therefore it would fail assertion here : 
https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/a0fa3742f92239fb60c58d4b73f458efb08ef0ed/src/module.cpp#L349