### PR TITLE
cmake: remove linking to migraphx_all_targets from migraphx_cpu scope

### DIFF
--- a/src/targets/cpu/CMakeLists.txt
+++ b/src/targets/cpu/CMakeLists.txt
@@ -88,8 +88,6 @@ foreach(LIBRARY ${OpenMP_CXX_LIBRARIES})
     endif()
 endforeach()
 
-target_link_libraries(migraphx_all_targets INTERFACE migraphx_cpu)
-
 rocm_install_targets(
   TARGETS migraphx_cpu
   INCLUDE


### PR DESCRIPTION
Warning message from CMake:
> Target `migraphx_all_targets` is not created in this directory.  For compatibility with older versions of CMake, the link library `migraphx_cpu` will be looked up in the directory in which the target was created rather than in this calling directory.

However, the `migraphx_cpu` is already linked to `migraphx_all_targets` in `src/CMakeLists.txt` at line 290. So, I am removing the command from `src/targets/cpu/CMakeLists.txt` to suppress the warning message.