### PR TITLE
cmake: make cppcheck optional if the tool is not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,7 @@ rocm_enable_clang_tidy(
         -analyzer-config cfg-lifetime=true
         -analyzer-config cfg-scopes=true
 )
-include(ROCMCppCheck)
+include(CppCheck)
 rocm_enable_cppcheck(
     CHECKS
         warning

--- a/cmake/CppCheck.cmake
+++ b/cmake/CppCheck.cmake
@@ -1,0 +1,38 @@
+#####################################################################################
+# The MIT License (MIT)
+#
+# Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#####################################################################################
+
+if(COMMAND rocm_enable_cppcheck)
+    return()
+endif()
+
+include(ROCMCppCheck)
+
+include(CMakeDependentOption)
+cmake_dependent_option(MIGRAPHX_ENABLE_CPPCHECK "Enable CppCheck" ON CPPCHECK_EXE OFF)
+
+macro(rocm_enable_cppcheck)
+    if(MIGRAPHX_ENABLE_CPPCHECK)
+        _rocm_enable_cppcheck(${ARGN})
+    endif()
+endmacro()


### PR DESCRIPTION
The PR from the series to enable MIGraphX on Windows.