### PR TITLE
Add back clamping and add tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,9 +88,9 @@ def rocmnodename(name) {
     } else if(name == "navi21") {
         node_name = "${rocmtest_name} && navi21";
     } else if(name == "mi100+") {
-        node_name = "${rocmtest_name} && (gfx908 || gfx90a)";
+        node_name = "${rocmtest_name} && (gfx908 || gfx90a) && !vm";
     } else if(name == "cdna") {
-        node_name = "${rocmtest_name} && (gfx908 || gfx90a || vega)";
+        node_name = "${rocmtest_name} && (gfx908 || gfx90a || vega) && !vm";
     } else if(name == "nogpu") {
         node_name = "${rocmtest_name} && nogpu";
     }

--- a/src/include/migraphx/op/convert.hpp
+++ b/src/include/migraphx/op/convert.hpp
@@ -66,7 +66,19 @@ struct convert : unary<convert>
         auto type = target_type;
         return [type](auto x) {
             auto y = x;
-            shape::visit(type, [&](auto as) { y = as(x); });
+            shape::visit(type, [&](auto as) {
+                // clamping value between target_type's max and min doesn't work for NaNs,
+                if(std::isnan(x))
+                {
+                    y = as.nan();
+                }
+                else
+                {
+                    // clamp overflowing/underflowing values to min()/max() instead of +/-infinity
+                    // during downcasting
+                    y = std::min(std::max(as(x), as.min()), as.max());
+                }
+            });
             return y;
         };
     }

--- a/test/api/test_gpu.cpp
+++ b/test/api/test_gpu.cpp
@@ -34,7 +34,6 @@ TEST_CASE(load_and_run)
     auto shapes_before = p.get_output_shapes();
     migraphx::compile_options options;
     options.set_offload_copy();
-    options.set_exhaustive_tune_flag();
     p.compile(migraphx::target("gpu"), options);
     auto shapes_after = p.get_output_shapes();
     CHECK(shapes_before.size() == 1);

--- a/test/py/test_gpu.py
+++ b/test/py/test_gpu.py
@@ -33,8 +33,8 @@ def test_conv_relu():
     p = migraphx.parse_onnx("conv_relu_maxpool_test.onnx")
     print(p)
     print("Compiling ...")
-    # set offload_copy, fast_match and exhaustive_tune to true
-    p.compile(migraphx.get_target("gpu"), True, True, True)
+    # set offload_copy, fast_match to true    
+    p.compile(migraphx.get_target("gpu"), True, True)
     print(p)
     params = {}
 

--- a/test/py/test_gpu.py
+++ b/test/py/test_gpu.py
@@ -33,7 +33,7 @@ def test_conv_relu():
     p = migraphx.parse_onnx("conv_relu_maxpool_test.onnx")
     print(p)
     print("Compiling ...")
-    # set offload_copy, fast_match to true    
+    # set offload_copy, fast_match to true
     p.compile(migraphx.get_target("gpu"), True, True)
     print(p)
     params = {}

--- a/test/ref_ops_test.cpp
+++ b/test/ref_ops_test.cpp
@@ -1939,7 +1939,7 @@ TEST_CASE(convert_downcast_overflow_test)
     migraphx::program p;
     auto* mm = p.get_main_module();
     migraphx::shape s{migraphx::shape::float_type, {2, 2}};
-    std::vector<float> data(4, std::numeric_limits<migraphx::half>::max() + 1);
+    std::vector<float> data(4, 2 * std::numeric_limits<migraphx::half>::max());
     auto l = mm->add_literal(migraphx::literal{s, data});
     mm->add_instruction(migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}),
                         l);
@@ -1957,7 +1957,7 @@ TEST_CASE(convert_downcast_underflow_test)
     migraphx::program p;
     auto* mm = p.get_main_module();
     migraphx::shape s{migraphx::shape::float_type, {2, 2}};
-    std::vector<float> data(4, std::numeric_limits<migraphx::half>::lowest() - 1);
+    std::vector<float> data(4, 2 * std::numeric_limits<migraphx::half>::lowest());
     auto l = mm->add_literal(migraphx::literal{s, data});
     mm->add_instruction(migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}),
                         l);

--- a/test/ref_ops_test.cpp
+++ b/test/ref_ops_test.cpp
@@ -1934,6 +1934,42 @@ TEST_CASE(cosh_dyn_test)
     EXPECT(migraphx::verify::verify_range(results_vector, gold));
 }
 
+TEST_CASE(convert_downcast_overflow_test)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    migraphx::shape s{migraphx::shape::float_type, {2, 2}};
+    std::vector<float> data(4, std::numeric_limits<migraphx::half>::max() + 1);
+    auto l = mm->add_literal(migraphx::literal{s, data});
+    mm->add_instruction(migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}),
+                        l);
+    p.compile(migraphx::make_target("ref"));
+    auto result = p.eval({}).back();
+    std::vector<migraphx::half> results_vector(4);
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    EXPECT(std::all_of(results_vector.begin(), results_vector.end(), [](const auto& x) {
+        return x == std::numeric_limits<migraphx::half>::max();
+    }));
+}
+
+TEST_CASE(convert_downcast_underflow_test)
+{
+    migraphx::program p;
+    auto* mm = p.get_main_module();
+    migraphx::shape s{migraphx::shape::float_type, {2, 2}};
+    std::vector<float> data(4, std::numeric_limits<migraphx::half>::lowest() - 1);
+    auto l = mm->add_literal(migraphx::literal{s, data});
+    mm->add_instruction(migraphx::make_op("convert", {{"target_type", migraphx::shape::half_type}}),
+                        l);
+    p.compile(migraphx::make_target("ref"));
+    auto result = p.eval({}).back();
+    std::vector<migraphx::half> results_vector(4);
+    result.visit([&](auto output) { results_vector.assign(output.begin(), output.end()); });
+    EXPECT(std::all_of(results_vector.begin(), results_vector.end(), [](const auto& x) {
+        return x == std::numeric_limits<migraphx::half>::lowest();
+    }));
+}
+
 TEST_CASE(convert_nan_upcast_test)
 {
     migraphx::program p;


### PR DESCRIPTION
Fixes #1957 

Clamping was removed in https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/pull/1853. 

Turns out clamping as necessary to handle overflow/underflow cases.  during downcasting, if it overflowed then without clamping it returned infinity.

```
#include "half.hpp"
#include <bitset>
#include <cmath>
#include <iostream>
#include <limits>

int main() {
  float d = 129536;
  half_float::half converted_f =
      std::min(std::numeric_limits<half_float::half>::max(),
               std::max(std::numeric_limits<half_float::half>::min(),
                        half_float::half(d)));
  std::cout << "converted_f: " << converted_f << std::endl;
  std::cout << "casted_f: " << half_float::half(d) << std::endl;
  return 0;
}
```

```
converted_f: 65504
casted_f: inf
```




