### PR TITLE
Update cmake to use latest and not pinned to 3.24.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,8 @@ RUN /download_models.sh && rm /download_models.sh
 # Install latest ccache version
 RUN cget -p $PREFIX install facebook/zstd@v1.4.5 -X subdir -DCMAKE_DIR=build/cmake
 RUN cget -p $PREFIX install ccache@v4.1 -DENABLE_TESTING=OFF
-RUN cget -p /opt/cmake install kitware/cmake@v3.24.3
+
+RUN pip3 install cmake
 
 COPY ./test/onnx/.onnxrt-commit /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,8 +97,8 @@ RUN /download_models.sh && rm /download_models.sh
 # Install latest ccache version
 RUN cget -p $PREFIX install facebook/zstd@v1.4.5 -X subdir -DCMAKE_DIR=build/cmake
 RUN cget -p $PREFIX install ccache@v4.1 -DENABLE_TESTING=OFF
+RUN cget -p /opt/cmake install kitware/cmake@v3.26.4
 
-RUN pip3 install cmake
 
 COPY ./test/onnx/.onnxrt-commit /
 


### PR DESCRIPTION
Need this since onnxruntime is rolling a version with current versions 3.26.*