### PR TITLE
Use `optimize_module` pass for the quantization to fp16

### DIFF
--- a/src/onnx/parse_batchnorm.cpp
+++ b/src/onnx/parse_batchnorm.cpp
@@ -57,12 +57,11 @@ struct parse_batchnorm : op_parser<parse_batchnorm>
         auto x_rank = x_lens.size();
         if(x_rank == 1 or x_rank == 2)
         {
-            auto rt      = info.add_literal(migraphx::literal{migraphx::shape{x_type}, {0.5}});
             auto eps     = info.add_literal(migraphx::literal{migraphx::shape{x_type}, {epsilon}});
             auto numer   = info.add_broadcastable_binary_op("sub", args[0], args[3]);
             auto var_eps = info.add_broadcastable_binary_op("add", args[4], eps);
-            auto denom   = info.add_broadcastable_binary_op("pow", var_eps, rt);
-            auto div0    = info.add_broadcastable_binary_op("div", numer, denom);
+            auto rsqrt   = info.add_instruction(make_op("rsqrt"), var_eps);
+            auto div0    = info.add_broadcastable_binary_op("mul", numer, rsqrt);
             auto r0      = info.add_broadcastable_binary_op("mul", div0, args[1]);
             return info.add_broadcastable_binary_op("add", r0, args[2]);
         }
@@ -71,7 +70,6 @@ struct parse_batchnorm : op_parser<parse_batchnorm>
             // unsqueeze tensors of shape (C) to broadcast correctly
             std::vector<int64_t> unsqueeze_axes(x_lens.size() - 2);
             std::iota(unsqueeze_axes.begin(), unsqueeze_axes.end(), 1);
-            auto rt  = info.add_literal(migraphx::literal{migraphx::shape{x_type}, {0.5}});
             auto eps = info.add_literal(migraphx::literal{migraphx::shape{x_type}, {epsilon}});
             auto scale_unsqueeze = info.add_instruction(
                 migraphx::make_op("unsqueeze", {{"axes", unsqueeze_axes}}), args[1]);
@@ -81,11 +79,11 @@ struct parse_batchnorm : op_parser<parse_batchnorm>
                 migraphx::make_op("unsqueeze", {{"axes", unsqueeze_axes}}), args[3]);
             auto var_unsqueeze = info.add_instruction(
                 migraphx::make_op("unsqueeze", {{"axes", unsqueeze_axes}}), args[4]);
-            auto numer   = info.add_broadcastable_binary_op("sub", args[0], mean_unsqueeze);
-            auto var_eps = info.add_broadcastable_binary_op("add", var_unsqueeze, eps);
-            auto denom   = info.add_broadcastable_binary_op("pow", var_eps, rt);
-            auto div0    = info.add_broadcastable_binary_op("div", numer, denom);
-            auto r0      = info.add_broadcastable_binary_op("mul", div0, scale_unsqueeze);
+            auto x_sub_mean = info.add_broadcastable_binary_op("sub", args[0], mean_unsqueeze);
+            auto var_eps    = info.add_broadcastable_binary_op("add", var_unsqueeze, eps);
+            auto rsqrt      = info.add_instruction(make_op("rsqrt"), var_eps);
+            auto div0       = info.add_broadcastable_binary_op("mul", x_sub_mean, rsqrt);
+            auto r0         = info.add_broadcastable_binary_op("mul", div0, scale_unsqueeze);
             return info.add_broadcastable_binary_op("add", r0, bias_unsqueeze);
         }
         else

--- a/src/onnx/parse_batchnorm.cpp
+++ b/src/onnx/parse_batchnorm.cpp
@@ -57,12 +57,12 @@ struct parse_batchnorm : op_parser<parse_batchnorm>
         auto x_rank = x_lens.size();
         if(x_rank == 1 or x_rank == 2)
         {
-            auto eps     = info.add_literal(migraphx::literal{migraphx::shape{x_type}, {epsilon}});
-            auto numer   = info.add_broadcastable_binary_op("sub", args[0], args[3]);
-            auto var_eps = info.add_broadcastable_binary_op("add", args[4], eps);
-            auto rsqrt   = info.add_instruction(make_op("rsqrt"), var_eps);
-            auto div0    = info.add_broadcastable_binary_op("mul", numer, rsqrt);
-            auto r0      = info.add_broadcastable_binary_op("mul", div0, args[1]);
+            auto eps = info.add_literal(migraphx::literal{migraphx::shape{x_type}, {epsilon}});
+            auto x_sub_mean = info.add_broadcastable_binary_op("sub", args[0], args[3]);
+            auto var_eps    = info.add_broadcastable_binary_op("add", args[4], eps);
+            auto rsqrt      = info.add_instruction(make_op("rsqrt"), var_eps);
+            auto mul0       = info.add_broadcastable_binary_op("mul", args[1], rsqrt);
+            auto r0         = info.add_broadcastable_binary_op("mul", x_sub_mean, mul0);
             return info.add_broadcastable_binary_op("add", r0, args[2]);
         }
         else if(x_rank > 2)
@@ -82,8 +82,8 @@ struct parse_batchnorm : op_parser<parse_batchnorm>
             auto x_sub_mean = info.add_broadcastable_binary_op("sub", args[0], mean_unsqueeze);
             auto var_eps    = info.add_broadcastable_binary_op("add", var_unsqueeze, eps);
             auto rsqrt      = info.add_instruction(make_op("rsqrt"), var_eps);
-            auto div0       = info.add_broadcastable_binary_op("mul", x_sub_mean, rsqrt);
-            auto r0         = info.add_broadcastable_binary_op("mul", div0, scale_unsqueeze);
+            auto mul0       = info.add_broadcastable_binary_op("mul", scale_unsqueeze, rsqrt);
+            auto r0         = info.add_broadcastable_binary_op("mul", x_sub_mean, mul0);
             return info.add_broadcastable_binary_op("add", r0, bias_unsqueeze);
         }
         else

--- a/src/pass_manager.cpp
+++ b/src/pass_manager.cpp
@@ -178,6 +178,8 @@ void run_passes(module& mod, const std::vector<pass>& passes, tracer trace)
 
 void run_passes(program& prog, const std::vector<pass>& passes, tracer trace)
 {
+    if(enabled(MIGRAPHX_TRACE_PASSES{}))
+        trace = tracer{std::cout};
     run_passes(prog, prog.get_main_module(), passes, trace);
 }
 

--- a/src/pass_manager.cpp
+++ b/src/pass_manager.cpp
@@ -178,8 +178,6 @@ void run_passes(module& mod, const std::vector<pass>& passes, tracer trace)
 
 void run_passes(program& prog, const std::vector<pass>& passes, tracer trace)
 {
-    if(enabled(MIGRAPHX_TRACE_PASSES{}))
-        trace = tracer{std::cout};
     run_passes(prog, prog.get_main_module(), passes, trace);
 }
 

--- a/src/tf/parse_batchnorm.cpp
+++ b/src/tf/parse_batchnorm.cpp
@@ -66,8 +66,8 @@ struct parse_batchnorm : op_parser<parse_batchnorm>
         auto x_sub_mean = info.add_broadcastable_binary_op("sub", args[0], mean_unsqueeze);
         auto var_eps    = info.add_broadcastable_binary_op("add", var_unsqueeze, eps);
         auto rsqrt      = info.add_instruction(make_op("rsqrt"), var_eps);
-        auto div0       = info.add_broadcastable_binary_op("mul", x_sub_mean, rsqrt);
-        auto r0         = info.add_broadcastable_binary_op("mul", div0, scale_unsqueeze);
+        auto mul0       = info.add_broadcastable_binary_op("mul", scale_unsqueeze, rsqrt);
+        auto r0         = info.add_broadcastable_binary_op("mul", x_sub_mean, mul0);
         return info.add_broadcastable_binary_op("add", r0, bias_unsqueeze);
     }
 };

--- a/src/tf/parse_batchnorm.cpp
+++ b/src/tf/parse_batchnorm.cpp
@@ -52,7 +52,6 @@ struct parse_batchnorm : op_parser<parse_batchnorm>
         auto x_type = args[0]->get_shape().type();
 
         // unsqueeze tensors of shape (C) to broadcast correctly
-        auto rt  = info.add_literal(migraphx::literal{migraphx::shape{x_type}, {0.5}});
         auto eps = info.add_literal(migraphx::literal{migraphx::shape{x_type}, {epsilon}});
 
         auto scale_unsqueeze =
@@ -64,11 +63,11 @@ struct parse_batchnorm : op_parser<parse_batchnorm>
         auto var_unsqueeze =
             info.add_instruction(migraphx::make_op("unsqueeze", {{"axes", {1, 2}}}), args[4]);
 
-        auto numer   = info.add_broadcastable_binary_op("sub", args[0], mean_unsqueeze);
-        auto var_eps = info.add_broadcastable_binary_op("add", var_unsqueeze, eps);
-        auto denom   = info.add_broadcastable_binary_op("pow", var_eps, rt);
-        auto div0    = info.add_broadcastable_binary_op("div", numer, denom);
-        auto r0      = info.add_broadcastable_binary_op("mul", div0, scale_unsqueeze);
+        auto x_sub_mean = info.add_broadcastable_binary_op("sub", args[0], mean_unsqueeze);
+        auto var_eps    = info.add_broadcastable_binary_op("add", var_unsqueeze, eps);
+        auto rsqrt      = info.add_instruction(make_op("rsqrt"), var_eps);
+        auto div0       = info.add_broadcastable_binary_op("mul", x_sub_mean, rsqrt);
+        auto r0         = info.add_broadcastable_binary_op("mul", div0, scale_unsqueeze);
         return info.add_broadcastable_binary_op("add", r0, bias_unsqueeze);
     }
 };

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -440,14 +440,13 @@ TEST_CASE(batch_norm_flat_test)
     auto mean  = mm->add_parameter("mean", {migraphx::shape::float_type, {1}});
     auto var   = mm->add_parameter("variance", {migraphx::shape::float_type, {1}});
 
-    auto rt  = mm->add_literal(migraphx::literal{migraphx::shape::float_type, {0.5}});
     auto eps = mm->add_literal(migraphx::literal{migraphx::shape::float_type, {1e-6f}});
 
-    auto numer   = add_common_op(*mm, migraphx::make_op("sub"), {x, mean});
-    auto var_eps = add_common_op(*mm, migraphx::make_op("add"), {var, eps});
-    auto denom   = add_common_op(*mm, migraphx::make_op("pow"), {var_eps, rt});
-    auto div0    = add_common_op(*mm, migraphx::make_op("div"), {numer, denom});
-    auto r0      = add_common_op(*mm, migraphx::make_op("mul"), {div0, scale});
+    auto x_sub_mean = add_common_op(*mm, migraphx::make_op("sub"), {x, mean});
+    auto var_eps    = add_common_op(*mm, migraphx::make_op("add"), {var, eps});
+    auto rsqrt      = mm->add_instruction(migraphx::make_op("rsqrt"), {var_eps});
+    auto div0       = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, rsqrt});
+    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {div0, scale});
     add_common_op(*mm, migraphx::make_op("add"), {r0, bias});
 
     auto prog = optimize_onnx("batch_norm_flat_test.onnx");
@@ -465,14 +464,13 @@ TEST_CASE(batch_norm_rank_2_test)
     auto mean  = mm->add_parameter("mean", {migraphx::shape::float_type, {5}});
     auto var   = mm->add_parameter("variance", {migraphx::shape::float_type, {5}});
 
-    auto rt  = mm->add_literal(migraphx::literal{migraphx::shape::float_type, {0.5}});
     auto eps = mm->add_literal(migraphx::literal{migraphx::shape::float_type, {1e-6f}});
 
-    auto numer   = add_common_op(*mm, migraphx::make_op("sub"), {x, mean});
-    auto var_eps = add_common_op(*mm, migraphx::make_op("add"), {var, eps});
-    auto denom   = add_common_op(*mm, migraphx::make_op("pow"), {var_eps, rt});
-    auto div0    = add_common_op(*mm, migraphx::make_op("div"), {numer, denom});
-    auto r0      = add_common_op(*mm, migraphx::make_op("mul"), {div0, scale});
+    auto x_sub_mean = add_common_op(*mm, migraphx::make_op("sub"), {x, mean});
+    auto var_eps    = add_common_op(*mm, migraphx::make_op("add"), {var, eps});
+    auto rsqrt      = mm->add_instruction(migraphx::make_op("rsqrt"), var_eps);
+    auto div0       = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, rsqrt});
+    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {div0, scale});
     add_common_op(*mm, migraphx::make_op("add"), {r0, bias});
 
     auto prog = optimize_onnx("batch_norm_rank_2_test.onnx");
@@ -490,7 +488,6 @@ TEST_CASE(batch_norm_1d_test)
     auto mean  = mm->add_parameter("mean", {migraphx::shape::float_type, {3}});
     auto var   = mm->add_parameter("variance", {migraphx::shape::float_type, {3}});
 
-    auto rt  = mm->add_literal(migraphx::literal{migraphx::shape::half_type, {0.5}});
     auto eps = mm->add_literal(migraphx::literal{migraphx::shape::half_type, {1e-5f}});
 
     auto usq_scale = mm->add_instruction(migraphx::make_op("unsqueeze", {{"axes", {1}}}), scale);
@@ -498,11 +495,11 @@ TEST_CASE(batch_norm_1d_test)
     auto usq_mean  = mm->add_instruction(migraphx::make_op("unsqueeze", {{"axes", {1}}}), mean);
     auto usq_var   = mm->add_instruction(migraphx::make_op("unsqueeze", {{"axes", {1}}}), var);
 
-    auto numer   = add_common_op(*mm, migraphx::make_op("sub"), {x, usq_mean});
-    auto var_eps = add_common_op(*mm, migraphx::make_op("add"), {usq_var, eps});
-    auto denom   = add_common_op(*mm, migraphx::make_op("pow"), {var_eps, rt});
-    auto div0    = add_common_op(*mm, migraphx::make_op("div"), {numer, denom});
-    auto r0      = add_common_op(*mm, migraphx::make_op("mul"), {div0, usq_scale});
+    auto x_sub_mean = add_common_op(*mm, migraphx::make_op("sub"), {x, usq_mean});
+    auto var_eps    = add_common_op(*mm, migraphx::make_op("add"), {usq_var, eps});
+    auto rsqrt      = mm->add_instruction(migraphx::make_op("rsqrt"), var_eps);
+    auto div0       = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, rsqrt});
+    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {div0, usq_scale});
     add_common_op(*mm, migraphx::make_op("add"), {r0, usq_bias});
 
     auto prog = optimize_onnx("batch_norm_1d_test.onnx");
@@ -520,7 +517,6 @@ TEST_CASE(batch_norm_2d_test)
     auto mean  = mm->add_parameter("mean", {migraphx::shape::float_type, {3}});
     auto var   = mm->add_parameter("variance", {migraphx::shape::float_type, {3}});
 
-    auto rt  = mm->add_literal(migraphx::literal{migraphx::shape::float_type, {0.5}});
     auto eps = mm->add_literal(migraphx::literal{migraphx::shape::float_type, {1e-5f}});
 
     auto usq_scale = mm->add_instruction(migraphx::make_op("unsqueeze", {{"axes", {1, 2}}}), scale);
@@ -530,8 +526,8 @@ TEST_CASE(batch_norm_2d_test)
 
     auto numer   = add_common_op(*mm, migraphx::make_op("sub"), {x, usq_mean});
     auto var_eps = add_common_op(*mm, migraphx::make_op("add"), {usq_var, eps});
-    auto denom   = add_common_op(*mm, migraphx::make_op("pow"), {var_eps, rt});
-    auto div0    = add_common_op(*mm, migraphx::make_op("div"), {numer, denom});
+    auto rsqrt   = mm->add_instruction(migraphx::make_op("rsqrt"), var_eps);
+    auto div0    = add_common_op(*mm, migraphx::make_op("mul"), {numer, rsqrt});
     auto r0      = add_common_op(*mm, migraphx::make_op("mul"), {div0, usq_scale});
     add_common_op(*mm, migraphx::make_op("add"), {r0, usq_bias});
 
@@ -550,7 +546,6 @@ TEST_CASE(batch_norm_3d_test)
     auto mean  = mm->add_parameter("mean", {migraphx::shape::half_type, {2}});
     auto var   = mm->add_parameter("variance", {migraphx::shape::half_type, {2}});
 
-    auto rt  = mm->add_literal(migraphx::literal{migraphx::shape::half_type, {0.5}});
     auto eps = mm->add_literal(migraphx::literal{migraphx::shape::half_type, {1e-6f}});
 
     auto usq_scale =
@@ -561,11 +556,11 @@ TEST_CASE(batch_norm_3d_test)
         mm->add_instruction(migraphx::make_op("unsqueeze", {{"axes", {1, 2, 3}}}), mean);
     auto usq_var = mm->add_instruction(migraphx::make_op("unsqueeze", {{"axes", {1, 2, 3}}}), var);
 
-    auto numer   = add_common_op(*mm, migraphx::make_op("sub"), {x, usq_mean});
-    auto var_eps = add_common_op(*mm, migraphx::make_op("add"), {usq_var, eps});
-    auto denom   = add_common_op(*mm, migraphx::make_op("pow"), {var_eps, rt});
-    auto div0    = add_common_op(*mm, migraphx::make_op("div"), {numer, denom});
-    auto r0      = add_common_op(*mm, migraphx::make_op("mul"), {div0, usq_scale});
+    auto x_sub_mean = add_common_op(*mm, migraphx::make_op("sub"), {x, usq_mean});
+    auto var_eps    = add_common_op(*mm, migraphx::make_op("add"), {usq_var, eps});
+    auto rsqrt      = mm->add_instruction(migraphx::make_op("rsqrt"), var_eps);
+    auto div0       = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, rsqrt});
+    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {div0, usq_scale});
     add_common_op(*mm, migraphx::make_op("add"), {r0, usq_bias});
     auto prog = optimize_onnx("batch_norm_3d_test.onnx");
 
@@ -908,7 +903,6 @@ TEST_CASE(constant_test)
 
 TEST_CASE(constant_fill_test)
 {
-
     migraphx::program p;
     auto* mm = p.get_main_module();
     migraphx::shape s{migraphx::shape::float_type, {2, 3}};
@@ -1105,7 +1099,6 @@ TEST_CASE(conv_bn_relu_maxpool_test)
     auto p5 = mm->add_parameter("5", {migraphx::shape::float_type, {1}});
     auto p6 = mm->add_parameter("6", {migraphx::shape::float_type, {1}});
 
-    auto rt  = mm->add_literal(migraphx::literal{migraphx::shape::float_type, {0.5}});
     auto eps = mm->add_literal(migraphx::literal{migraphx::shape::float_type, {1e-5f}});
 
     uint64_t axis = 1;
@@ -1122,19 +1115,17 @@ TEST_CASE(conv_bn_relu_maxpool_test)
 
     auto mb_mean = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"out_lens", {1, 1, 28, 28}}}), usq_mean);
-    auto numer = mm->add_instruction(migraphx::make_op("sub"), l5, mb_mean);
+    auto x_sub_mean = mm->add_instruction(migraphx::make_op("sub"), l5, mb_mean);
     auto mb_eps =
         mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {1, 1, 1}}}), eps);
     auto var_eps = mm->add_instruction(migraphx::make_op("add"), usq_var, mb_eps);
-    auto mb_rt =
-        mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {1, 1, 1}}}), rt);
-    auto denom    = mm->add_instruction(migraphx::make_op("pow"), var_eps, mb_rt);
-    auto mb_denom = mm->add_instruction(
-        migraphx::make_op("multibroadcast", {{"out_lens", {1, 1, 28, 28}}}), denom);
-    auto div0     = mm->add_instruction(migraphx::make_op("div"), numer, mb_denom);
+    auto rsqrt    = mm->add_instruction(migraphx::make_op("rsqrt"), var_eps);
+    auto mb_rsqrt = mm->add_instruction(
+        migraphx::make_op("multibroadcast", {{"out_lens", {1, 1, 28, 28}}}), rsqrt);
+    auto mul0     = mm->add_instruction(migraphx::make_op("mul"), x_sub_mean, mb_rsqrt);
     auto mb_scale = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"out_lens", {1, 1, 28, 28}}}), usq_scale);
-    auto r0      = mm->add_instruction(migraphx::make_op("mul"), div0, mb_scale);
+    auto r0      = mm->add_instruction(migraphx::make_op("mul"), mul0, mb_scale);
     auto mb_bias = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"out_lens", {1, 1, 28, 28}}}), usq_bias);
 
@@ -7150,7 +7141,8 @@ TEST_CASE(variable_batch_user_input_test6)
 
 TEST_CASE(variable_batch_user_input_test7)
 {
-    // if entry in map_dyn_input_dims is all fixed dynamic_dimensions, convert it to a static shape
+    // if entry in map_dyn_input_dims is all fixed dynamic_dimensions, convert it to a static
+    // shape
     migraphx::program p;
     auto* mm = p.get_main_module();
     auto l0  = mm->add_parameter("0", migraphx::shape{migraphx::shape::float_type, {2, 3, 16, 16}});

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -1118,7 +1118,7 @@ TEST_CASE(conv_bn_relu_maxpool_test)
     auto x_sub_mean = mm->add_instruction(migraphx::make_op("sub"), l5, mb_mean);
     auto mb_eps =
         mm->add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", {1, 1, 1}}}), eps);
-    auto var_eps = mm->add_instruction(migraphx::make_op("add"), usq_var, mb_eps);
+    auto var_eps  = mm->add_instruction(migraphx::make_op("add"), usq_var, mb_eps);
     auto rsqrt    = mm->add_instruction(migraphx::make_op("rsqrt"), var_eps);
     auto mb_rsqrt = mm->add_instruction(
         migraphx::make_op("multibroadcast", {{"out_lens", {1, 1, 28, 28}}}), rsqrt);

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -445,8 +445,8 @@ TEST_CASE(batch_norm_flat_test)
     auto x_sub_mean = add_common_op(*mm, migraphx::make_op("sub"), {x, mean});
     auto var_eps    = add_common_op(*mm, migraphx::make_op("add"), {var, eps});
     auto rsqrt      = mm->add_instruction(migraphx::make_op("rsqrt"), {var_eps});
-    auto div0       = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, rsqrt});
-    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {div0, scale});
+    auto mul0       = add_common_op(*mm, migraphx::make_op("mul"), {scale, rsqrt});
+    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, mul0});
     add_common_op(*mm, migraphx::make_op("add"), {r0, bias});
 
     auto prog = optimize_onnx("batch_norm_flat_test.onnx");
@@ -468,9 +468,9 @@ TEST_CASE(batch_norm_rank_2_test)
 
     auto x_sub_mean = add_common_op(*mm, migraphx::make_op("sub"), {x, mean});
     auto var_eps    = add_common_op(*mm, migraphx::make_op("add"), {var, eps});
-    auto rsqrt      = mm->add_instruction(migraphx::make_op("rsqrt"), var_eps);
-    auto div0       = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, rsqrt});
-    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {div0, scale});
+    auto rsqrt      = mm->add_instruction(migraphx::make_op("rsqrt"), {var_eps});
+    auto mul0       = add_common_op(*mm, migraphx::make_op("mul"), {scale, rsqrt});
+    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, mul0});
     add_common_op(*mm, migraphx::make_op("add"), {r0, bias});
 
     auto prog = optimize_onnx("batch_norm_rank_2_test.onnx");
@@ -498,8 +498,8 @@ TEST_CASE(batch_norm_1d_test)
     auto x_sub_mean = add_common_op(*mm, migraphx::make_op("sub"), {x, usq_mean});
     auto var_eps    = add_common_op(*mm, migraphx::make_op("add"), {usq_var, eps});
     auto rsqrt      = mm->add_instruction(migraphx::make_op("rsqrt"), var_eps);
-    auto div0       = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, rsqrt});
-    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {div0, usq_scale});
+    auto mul0       = add_common_op(*mm, migraphx::make_op("mul"), {usq_scale, rsqrt});
+    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, mul0});
     add_common_op(*mm, migraphx::make_op("add"), {r0, usq_bias});
 
     auto prog = optimize_onnx("batch_norm_1d_test.onnx");
@@ -524,11 +524,11 @@ TEST_CASE(batch_norm_2d_test)
     auto usq_mean  = mm->add_instruction(migraphx::make_op("unsqueeze", {{"axes", {1, 2}}}), mean);
     auto usq_var   = mm->add_instruction(migraphx::make_op("unsqueeze", {{"axes", {1, 2}}}), var);
 
-    auto numer   = add_common_op(*mm, migraphx::make_op("sub"), {x, usq_mean});
-    auto var_eps = add_common_op(*mm, migraphx::make_op("add"), {usq_var, eps});
-    auto rsqrt   = mm->add_instruction(migraphx::make_op("rsqrt"), var_eps);
-    auto div0    = add_common_op(*mm, migraphx::make_op("mul"), {numer, rsqrt});
-    auto r0      = add_common_op(*mm, migraphx::make_op("mul"), {div0, usq_scale});
+    auto x_sub_mean = add_common_op(*mm, migraphx::make_op("sub"), {x, usq_mean});
+    auto var_eps    = add_common_op(*mm, migraphx::make_op("add"), {usq_var, eps});
+    auto rsqrt      = mm->add_instruction(migraphx::make_op("rsqrt"), var_eps);
+    auto mul0       = add_common_op(*mm, migraphx::make_op("mul"), {usq_scale, rsqrt});
+    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, mul0});
     add_common_op(*mm, migraphx::make_op("add"), {r0, usq_bias});
 
     auto prog = optimize_onnx("batch_norm_2d_test.onnx");
@@ -559,9 +559,10 @@ TEST_CASE(batch_norm_3d_test)
     auto x_sub_mean = add_common_op(*mm, migraphx::make_op("sub"), {x, usq_mean});
     auto var_eps    = add_common_op(*mm, migraphx::make_op("add"), {usq_var, eps});
     auto rsqrt      = mm->add_instruction(migraphx::make_op("rsqrt"), var_eps);
-    auto div0       = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, rsqrt});
-    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {div0, usq_scale});
+    auto mul0       = add_common_op(*mm, migraphx::make_op("mul"), {usq_scale, rsqrt});
+    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, mul0});
     add_common_op(*mm, migraphx::make_op("add"), {r0, usq_bias});
+
     auto prog = optimize_onnx("batch_norm_3d_test.onnx");
 
     EXPECT(p == prog);

--- a/test/onnx/onnx_test.cpp
+++ b/test/onnx/onnx_test.cpp
@@ -1119,7 +1119,7 @@ TEST_CASE(conv_bn_relu_maxpool_test)
     auto rsqrt      = mm->add_instruction(migraphx::make_op("rsqrt"), var_eps);
     auto mul0       = add_common_op(*mm, migraphx::make_op("mul"), {usq_scale, rsqrt});
     auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, mul0});
-    auto l6 = add_common_op(*mm, migraphx::make_op("add"), {r0, usq_bias});
+    auto l6         = add_common_op(*mm, migraphx::make_op("add"), {r0, usq_bias});
 
     auto l7 = mm->add_instruction(migraphx::make_op("relu"), l6);
     mm->add_instruction(migraphx::make_op("pooling",

--- a/test/tf/tf_test.cpp
+++ b/test/tf/tf_test.cpp
@@ -206,9 +206,8 @@ TEST_CASE(batchnorm_test)
     auto x_sub_mean = add_common_op(*mm, migraphx::make_op("sub"), {x, usq_mean});
     auto var_eps    = add_common_op(*mm, migraphx::make_op("add"), {usq_var, eps});
     auto rsqrt      = mm->add_instruction(migraphx::make_op("rsqrt"), var_eps);
-    auto div0       = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, rsqrt});
-    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {div0, usq_scale});
-
+    auto mul0       = add_common_op(*mm, migraphx::make_op("mul"), {usq_scale, rsqrt});
+    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, mul0});
     add_common_op(*mm, migraphx::make_op("add"), {r0, usq_bias});
 
     auto prog = optimize_tf("batchnorm_test.pb", true);
@@ -237,8 +236,8 @@ TEST_CASE(batchnorm_half_test)
     auto x_sub_mean = add_common_op(*mm, migraphx::make_op("sub"), {x, usq_mean});
     auto var_eps    = add_common_op(*mm, migraphx::make_op("add"), {usq_var, eps});
     auto rsqrt      = mm->add_instruction(migraphx::make_op("rsqrt"), var_eps);
-    auto div0       = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, rsqrt});
-    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {div0, usq_scale});
+    auto mul0       = add_common_op(*mm, migraphx::make_op("mul"), {usq_scale, rsqrt});
+    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, mul0});
     add_common_op(*mm, migraphx::make_op("add"), {r0, usq_bias});
 
     auto prog = optimize_tf("batchnorm_half_test.pb", true);
@@ -267,8 +266,8 @@ TEST_CASE(batchnormv3_test)
     auto x_sub_mean = add_common_op(*mm, migraphx::make_op("sub"), {x, usq_mean});
     auto var_eps    = add_common_op(*mm, migraphx::make_op("add"), {usq_var, eps});
     auto rsqrt      = mm->add_instruction(migraphx::make_op("rsqrt"), var_eps);
-    auto div0       = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, rsqrt});
-    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {div0, usq_scale});
+    auto mul0       = add_common_op(*mm, migraphx::make_op("mul"), {usq_scale, rsqrt});
+    auto r0         = add_common_op(*mm, migraphx::make_op("mul"), {x_sub_mean, mul0});
     add_common_op(*mm, migraphx::make_op("add"), {r0, usq_bias});
 
     auto prog = optimize_tf("batchnormv3_test.pb", true);


### PR DESCRIPTION
Fixes https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/issues/1746

BatchNorm only has `x` as the runtime input parameter for the following equation. All the other parameters are compile-time constants and related operations can be const-folded before quantizing to fp16 to preserve precision. 

`1/sqrt((var+epsilon)) * gamma` can be const folded. 

Adding `optimize_module()` pass before `quantize_fp16()` would do the simplification and const-folding. 

![image](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/assets/29876643/ab41afc3-d82e-4fc1-b533-c2ef16cd1785)



This PR along with #1969 produces FP16 ResNet50 accuracy same as Fp32 model ~76.45%