### PR TITLE
Use private access specifier to build embed library

### DIFF
--- a/cmake/Embed.cmake
+++ b/cmake/Embed.cmake
@@ -196,7 +196,7 @@ function(add_embed_library EMBED_NAME)
     
     add_library(${EMBED_NAME} INTERFACE)
     if(EMBED_USE_LD)
-        target_sources(${EMBED_NAME} INTERFACE ${OUTPUT_FILES})
+        target_sources(${EMBED_NAME} PRIVATE ${OUTPUT_FILES})
     else()
         target_sources(${INTERNAL_EMBED_LIB} PRIVATE ${OUTPUT_FILES})
     endif()


### PR DESCRIPTION
Fixes the error : 

```
CMake Error at test/CMakeLists.txt:100 (add_executable):
  Cannot find source file:

    /home/umayadav/repo/AMDMIGraphX/build/src/targets/gpu/kernels/include/migraphx/kernels/algorithm.hpp.o

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm .h
  .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90 .f95 .f03 .hip .ispc
Call Stack (most recent call first):
  test/CMakeLists.txt:129 (add_test_executable)


```