### PR TITLE
Use free regular_file function for SLES which uses experimental files…

### DIFF
--- a/src/py/py_loader.cpp
+++ b/src/py/py_loader.cpp
@@ -35,9 +35,9 @@ static std::vector<fs::path> find_available_python_versions()
     auto path = dynamic_loader::path(&load_py).parent_path();
     for(const auto& entry : fs::directory_iterator{path})
     {
-        if(not entry.is_regular_file())
-            continue;
         auto p = entry.path();
+        if(not is_regular_file(p))
+            continue;
         if(not contains(p.stem().string(), "migraphx_py_"))
             continue;
         result.push_back(p);

--- a/src/py/py_loader.cpp
+++ b/src/py/py_loader.cpp
@@ -36,7 +36,7 @@ static std::vector<fs::path> find_available_python_versions()
     for(const auto& entry : fs::directory_iterator{path})
     {
         auto p = entry.path();
-        if(not is_regular_file(p))
+        if(not fs::is_regular_file(p))
             continue;
         if(not contains(p.stem().string(), "migraphx_py_"))
             continue;


### PR DESCRIPTION
…ystem and it doesn't have member function is_regular_file


experimental directory_entry doesn't have is_regular_file member function.


https://en.cppreference.com/w/cpp/experimental/fs/directory_entry
https://en.cppreference.com/w/cpp/filesystem/directory_entry
