### PR TITLE
Using chunking for msgpack to get around the 4GB limit

### DIFF
--- a/src/include/migraphx/functional.hpp
+++ b/src/include/migraphx/functional.hpp
@@ -98,6 +98,9 @@ constexpr auto sequence_c_impl(F&& f, seq<Ns...>)
     return f(std::integral_constant<std::size_t, Ns>{}...);
 }
 
+template<class... Ts>
+struct overloaded : Ts... { using Ts::operator()...; };
+
 } // namespace detail
 
 template <std::size_t N, class F>
@@ -133,6 +136,12 @@ template <class F, class T>
 auto unpack(F f, T&& x)
 {
     return sequence(tuple_size(x), [&](auto... is) { f(std::get<is>(static_cast<T&&>(x))...); });
+}
+
+template<class... Ts>
+detail::overloaded<Ts...> overload(Ts... xs)
+{
+    return {xs...};
 }
 
 /// Implements a fix-point combinator

--- a/src/include/migraphx/functional.hpp
+++ b/src/include/migraphx/functional.hpp
@@ -98,8 +98,11 @@ constexpr auto sequence_c_impl(F&& f, seq<Ns...>)
     return f(std::integral_constant<std::size_t, Ns>{}...);
 }
 
-template<class... Ts>
-struct overloaded : Ts... { using Ts::operator()...; };
+template <class... Ts>
+struct overloaded : Ts...
+{
+    using Ts::operator()...;
+};
 
 } // namespace detail
 
@@ -138,7 +141,7 @@ auto unpack(F f, T&& x)
     return sequence(tuple_size(x), [&](auto... is) { f(std::get<is>(static_cast<T&&>(x))...); });
 }
 
-template<class... Ts>
+template <class... Ts>
 detail::overloaded<Ts...> overload(Ts... xs)
 {
     return {xs...};

--- a/src/msgpack.cpp
+++ b/src/msgpack.cpp
@@ -157,15 +157,12 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
                 break;
             }
         case msgpack::type::MAP:
-        case msgpack::type::BIN: {
+        case msgpack::type::BIN:
             MIGRAPHX_THROW("Unexpected msgpack type");
-            break;
-        }
-            case msgpack::type::EXT: {
+            case msgpack::type::EXT:
                 MIGRAPHX_THROW("msgpack EXT type not supported.");
             }
-                return o;
-        }
+            return o;
         }
     };
 

--- a/src/msgpack.cpp
+++ b/src/msgpack.cpp
@@ -24,6 +24,43 @@
 #include <migraphx/msgpack.hpp>
 #include <migraphx/serialize.hpp>
 #include <msgpack.hpp>
+#include <variant>
+
+namespace migraphx {
+inline namespace MIGRAPHX_INLINE_NS {
+
+struct msgpack_chunk
+{
+    std::vector<value> chunks;
+
+    value as_value() const
+    {
+        if(chunks.empty())
+            return {};
+        const value& v = chunks.front();
+        if(v.is_array() or v.is_object())
+        {
+            std::vector<value> values = v.is_array() ? v.get_array() : v.get_object();
+            std::for_each(chunks.begin()+1, chunks.end(), [&](const auto& chunk) {
+                values.insert(values.end(), chunk.begin(), chunk.end());
+            });
+            return values;
+        }
+        else if(v.is_binary())
+        {
+            value::binary data = v.get_binary();
+            std::for_each(chunks.begin()+1, chunks.end(), [&](const auto& chunk) {
+                const value::binary& b = chunk.get_binary();
+                data.insert(data.end(), b.begin(), b.end());
+            });
+            return data;
+        }
+        MIGRAPHX_THROW("Incorrect chunking");
+    }
+};
+
+} // namespace MIGRAPHX_INLINE_NS
+} // namespace migraphx
 
 namespace msgpack {
 MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
@@ -62,27 +99,55 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
                 v = o.as<std::string>();
                 break;
             }
-            case msgpack::type::BIN: {
-                v = migraphx::value::binary{o.via.bin.ptr, o.via.bin.size};
-                break;
-            }
             case msgpack::type::ARRAY: {
-                migraphx::value r = migraphx::value::array{};
+                if(o.via.array.size == 0)
+                {
+                    v = migraphx::value::array{};
+                    break;
+                }
+                std::variant<migraphx::value::array, migraphx::value::binary, migraphx::value::object> r;
+                switch (o.via.array.ptr->type) {
+                    case msgpack::type::BIN: {
+                        r = migraphx::value::binary{};
+                        break;
+                    }
+                    case msgpack::type::ARRAY: {
+                        r = migraphx::value::array{};
+                        break;
+                    }
+                    case msgpack::type::MAP: {
+                        r = migraphx::value::object{};
+                        break;
+                    }
+                    default:
+                        MIGRAPHX_THROW("Incorrect chunking");
+                    }
+                }
                 std::for_each(
                     o.via.array.ptr,
                     o.via.array.ptr + o.via.array.size,
-                    [&](const msgpack::object& so) { r.push_back(so.as<migraphx::value>()); });
-                v = r;
-                break;
+                    [&](const msgpack::object& sa) { 
+                        std::visit(overload([&](migraphx::value::binary& bin) {
+                            bin.insert(bin.end(), o.via.bin.ptr, o.via.bin.ptr+o.via.bin.size);
+                        }, [&](migraphx::value::array& arr) {
+                            std::for_each(
+                                sa.via.array.ptr,
+                                sa.via.array.ptr + sa.via.array.size,
+                                [&](const msgpack::object& so) { arr.push_back(so.as<migraphx::value>()); });
+                        }, [&](migraphx::value::object& obj) {
+                            std::for_each(sa.via.map.ptr,
+                                          sa.via.map.ptr + sa.via.map.size,
+                                          [&](const msgpack::object_kv& p) {
+                                              obj[p.key.as<std::string>()] = p.val.as<migraphx::value>();
+                                          });
+                        }), r);
+                    });
+                    std::visit([&](const auto& x) { v = x; }, r);
+                    break;
             }
-            case msgpack::type::MAP: {
-                migraphx::value r = migraphx::value::object{};
-                std::for_each(o.via.map.ptr,
-                              o.via.map.ptr + o.via.map.size,
-                              [&](const msgpack::object_kv& p) {
-                                  r[p.key.as<std::string>()] = p.val.as<migraphx::value>();
-                              });
-                v = r;
+            case msgpack::type::MAP:
+            case msgpack::type::BIN: {
+                MIGRAPHX_THROW("Unexpected msgpack type");
                 break;
             }
             case msgpack::type::EXT: {

--- a/src/msgpack.cpp
+++ b/src/msgpack.cpp
@@ -124,11 +124,13 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
                         std::visit(
                             migraphx::overload(
                                 [&](migraphx::value::binary& bin) {
+                                    assert(sa.type == msgpack::type::BIN);
                                     bin.insert(bin.end(),
                                                sa.via.bin.ptr,
                                                sa.via.bin.ptr + sa.via.bin.size);
                                 },
                                 [&](migraphx::value::array& arr) {
+                                    assert(sa.type == msgpack::type::ARRAY);
                                     std::for_each(sa.via.array.ptr,
                                                   sa.via.array.ptr + sa.via.array.size,
                                                   [&](const msgpack::object& so) {
@@ -136,6 +138,7 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
                                                   });
                                 },
                                 [&](migraphx::value::object& obj) {
+                                    assert(sa.type == msgpack::type::MAP);
                                     std::for_each(sa.via.map.ptr,
                                                   sa.via.map.ptr + sa.via.map.size,
                                                   [&](const msgpack::object_kv& p) {

--- a/src/msgpack.cpp
+++ b/src/msgpack.cpp
@@ -124,8 +124,9 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
                         std::visit(
                             migraphx::overload(
                                 [&](migraphx::value::binary& bin) {
-                                    bin.insert(
-                                        bin.end(), sa.via.bin.ptr, sa.via.bin.ptr + sa.via.bin.size);
+                                    bin.insert(bin.end(),
+                                               sa.via.bin.ptr,
+                                               sa.via.bin.ptr + sa.via.bin.size);
                                 },
                                 [&](migraphx::value::array& arr) {
                                     std::for_each(sa.via.array.ptr,

--- a/src/msgpack.cpp
+++ b/src/msgpack.cpp
@@ -33,13 +33,13 @@ inline namespace MIGRAPHX_INLINE_NS {
 // Leave an extra byte for error checking
 constexpr std::size_t msgpack_size_limit = std::numeric_limits<uint32_t>::max() - 1;
 
-template<class Range>
+template <class Range>
 std::size_t msgpack_chunk_size(const Range& r)
 {
     return r.size() / msgpack_size_limit;
 }
 
-template<class Iterator, class F>
+template <class Iterator, class F>
 void msgpack_chunk_for_each(Iterator start, Iterator last, F f)
 {
     while(std::distance(start, last) > msgpack_size_limit)
@@ -165,10 +165,11 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
             const auto* data = reinterpret_cast<const char*>(x.data());
             auto size        = x.size();
             o.pack_array(migraphx::msgpack_chunk_size(x));
-            migraphx::msgpack_chunk_for_each(data, data+size, [&](const char* start, const char* last) {
-                o.pack_bin(last-start);
-                o.pack_bin_body(data, last-start);
-            });
+            migraphx::msgpack_chunk_for_each(
+                data, data + size, [&](const char* start, const char* last) {
+                    o.pack_bin(last - start);
+                    o.pack_bin_body(data, last - start);
+                });
             return o;
         }
     };
@@ -199,7 +200,7 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
             if(not v.front().get_key().empty())
             {
                 migraphx::msgpack_chunk_for_each(v.begin(), v.end(), [&](auto start, auto last) {
-                    o.pack_map(last-start);
+                    o.pack_map(last - start);
                     std::for_each(start, last, [&](auto&& x) {
                         o.pack(x.get_key());
                         o.pack(x.without_key());
@@ -209,10 +210,8 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
             else
             {
                 migraphx::msgpack_chunk_for_each(v.begin(), v.end(), [&](auto start, auto last) {
-                    o.pack_array(last-start);
-                    std::for_each(start, last, [&](auto&& x) {
-                        o.pack(x);
-                    });
+                    o.pack_array(last - start);
+                    std::for_each(start, last, [&](auto&& x) { o.pack(x); });
                 });
             }
         }

--- a/src/msgpack.cpp
+++ b/src/msgpack.cpp
@@ -41,7 +41,7 @@ struct msgpack_chunk
         if(v.is_array() or v.is_object())
         {
             std::vector<value> values = v.is_array() ? v.get_array() : v.get_object();
-            std::for_each(chunks.begin()+1, chunks.end(), [&](const auto& chunk) {
+            std::for_each(chunks.begin() + 1, chunks.end(), [&](const auto& chunk) {
                 values.insert(values.end(), chunk.begin(), chunk.end());
             });
             return values;
@@ -49,7 +49,7 @@ struct msgpack_chunk
         else if(v.is_binary())
         {
             value::binary data = v.get_binary();
-            std::for_each(chunks.begin()+1, chunks.end(), [&](const auto& chunk) {
+            std::for_each(chunks.begin() + 1, chunks.end(), [&](const auto& chunk) {
                 const value::binary& b = chunk.get_binary();
                 data.insert(data.end(), b.begin(), b.end());
             });
@@ -105,51 +105,62 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
                     v = migraphx::value::array{};
                     break;
                 }
-                std::variant<migraphx::value::array, migraphx::value::binary, migraphx::value::object> r;
-                switch (o.via.array.ptr->type) {
-                    case msgpack::type::BIN: {
-                        r = migraphx::value::binary{};
-                        break;
-                    }
-                    case msgpack::type::ARRAY: {
-                        r = migraphx::value::array{};
-                        break;
-                    }
-                    case msgpack::type::MAP: {
-                        r = migraphx::value::object{};
-                        break;
-                    }
-                    default:
-                        MIGRAPHX_THROW("Incorrect chunking");
-                    }
+                std::variant<migraphx::value::array,
+                             migraphx::value::binary,
+                             migraphx::value::object>
+                    r;
+                switch(o.via.array.ptr->type)
+                {
+                case msgpack::type::BIN: {
+                    r = migraphx::value::binary{};
+                    break;
                 }
+                case msgpack::type::ARRAY: {
+                    r = migraphx::value::array{};
+                    break;
+                }
+                case msgpack::type::MAP: {
+                    r = migraphx::value::object{};
+                    break;
+                }
+                default: MIGRAPHX_THROW("Incorrect chunking");
+                }
+            }
                 std::for_each(
                     o.via.array.ptr,
                     o.via.array.ptr + o.via.array.size,
-                    [&](const msgpack::object& sa) { 
-                        std::visit(overload([&](migraphx::value::binary& bin) {
-                            bin.insert(bin.end(), o.via.bin.ptr, o.via.bin.ptr+o.via.bin.size);
-                        }, [&](migraphx::value::array& arr) {
-                            std::for_each(
-                                sa.via.array.ptr,
-                                sa.via.array.ptr + sa.via.array.size,
-                                [&](const msgpack::object& so) { arr.push_back(so.as<migraphx::value>()); });
-                        }, [&](migraphx::value::object& obj) {
-                            std::for_each(sa.via.map.ptr,
-                                          sa.via.map.ptr + sa.via.map.size,
-                                          [&](const msgpack::object_kv& p) {
-                                              obj[p.key.as<std::string>()] = p.val.as<migraphx::value>();
-                                          });
-                        }), r);
+                    [&](const msgpack::object& sa) {
+                        std::visit(
+                            overload(
+                                [&](migraphx::value::binary& bin) {
+                                    bin.insert(
+                                        bin.end(), o.via.bin.ptr, o.via.bin.ptr + o.via.bin.size);
+                                },
+                                [&](migraphx::value::array& arr) {
+                                    std::for_each(sa.via.array.ptr,
+                                                  sa.via.array.ptr + sa.via.array.size,
+                                                  [&](const msgpack::object& so) {
+                                                      arr.push_back(so.as<migraphx::value>());
+                                                  });
+                                },
+                                [&](migraphx::value::object& obj) {
+                                    std::for_each(sa.via.map.ptr,
+                                                  sa.via.map.ptr + sa.via.map.size,
+                                                  [&](const msgpack::object_kv& p) {
+                                                      obj[p.key.as<std::string>()] =
+                                                          p.val.as<migraphx::value>();
+                                                  });
+                                }),
+                            r);
                     });
-                    std::visit([&](const auto& x) { v = x; }, r);
-                    break;
-            }
-            case msgpack::type::MAP:
-            case msgpack::type::BIN: {
-                MIGRAPHX_THROW("Unexpected msgpack type");
+                std::visit([&](const auto& x) { v = x; }, r);
                 break;
             }
+        case msgpack::type::MAP:
+        case msgpack::type::BIN: {
+            MIGRAPHX_THROW("Unexpected msgpack type");
+            break;
+        }
             case msgpack::type::EXT: {
                 MIGRAPHX_THROW("msgpack EXT type not supported.");
             }

--- a/src/msgpack.cpp
+++ b/src/msgpack.cpp
@@ -23,44 +23,45 @@
  */
 #include <migraphx/msgpack.hpp>
 #include <migraphx/serialize.hpp>
+#include <migraphx/functional.hpp>
 #include <msgpack.hpp>
 #include <variant>
 
-namespace migraphx {
-inline namespace MIGRAPHX_INLINE_NS {
+// namespace migraphx {
+// inline namespace MIGRAPHX_INLINE_NS {
 
-struct msgpack_chunk
-{
-    std::vector<value> chunks;
+// struct msgpack_chunk
+// {
+//     std::vector<value> chunks;
 
-    value as_value() const
-    {
-        if(chunks.empty())
-            return {};
-        const value& v = chunks.front();
-        if(v.is_array() or v.is_object())
-        {
-            std::vector<value> values = v.is_array() ? v.get_array() : v.get_object();
-            std::for_each(chunks.begin() + 1, chunks.end(), [&](const auto& chunk) {
-                values.insert(values.end(), chunk.begin(), chunk.end());
-            });
-            return values;
-        }
-        else if(v.is_binary())
-        {
-            value::binary data = v.get_binary();
-            std::for_each(chunks.begin() + 1, chunks.end(), [&](const auto& chunk) {
-                const value::binary& b = chunk.get_binary();
-                data.insert(data.end(), b.begin(), b.end());
-            });
-            return data;
-        }
-        MIGRAPHX_THROW("Incorrect chunking");
-    }
-};
+//     value as_value() const
+//     {
+//         if(chunks.empty())
+//             return {};
+//         const value& v = chunks.front();
+//         if(v.is_array() or v.is_object())
+//         {
+//             std::vector<value> values = v.is_array() ? v.get_array() : v.get_object();
+//             std::for_each(chunks.begin() + 1, chunks.end(), [&](const auto& chunk) {
+//                 values.insert(values.end(), chunk.begin(), chunk.end());
+//             });
+//             return values;
+//         }
+//         else if(v.is_binary())
+//         {
+//             value::binary data = v.get_binary();
+//             std::for_each(chunks.begin() + 1, chunks.end(), [&](const auto& chunk) {
+//                 const value::binary& b = chunk.get_binary();
+//                 data.insert(data.end(), b.begin(), b.end());
+//             });
+//             return data;
+//         }
+//         MIGRAPHX_THROW("Incorrect chunking");
+//     }
+// };
 
-} // namespace MIGRAPHX_INLINE_NS
-} // namespace migraphx
+// } // namespace MIGRAPHX_INLINE_NS
+// } // namespace migraphx
 
 namespace msgpack {
 MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
@@ -125,13 +126,12 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
                 }
                 default: MIGRAPHX_THROW("Incorrect chunking");
                 }
-            }
                 std::for_each(
                     o.via.array.ptr,
                     o.via.array.ptr + o.via.array.size,
                     [&](const msgpack::object& sa) {
                         std::visit(
-                            overload(
+                            migraphx::overload(
                                 [&](migraphx::value::binary& bin) {
                                     bin.insert(
                                         bin.end(), o.via.bin.ptr, o.via.bin.ptr + o.via.bin.size);
@@ -164,9 +164,9 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
             case msgpack::type::EXT: {
                 MIGRAPHX_THROW("msgpack EXT type not supported.");
             }
-            }
             return o;
         }
+    }
     };
 
     template <>

--- a/src/msgpack.cpp
+++ b/src/msgpack.cpp
@@ -36,7 +36,7 @@ constexpr std::size_t msgpack_size_limit = std::numeric_limits<uint32_t>::max() 
 template <class Range>
 std::size_t msgpack_chunk_size(const Range& r)
 {
-    return r.size() / msgpack_size_limit;
+    return 1 + r.size() / msgpack_size_limit;
 }
 
 template <class Iterator, class F>
@@ -125,7 +125,7 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
                             migraphx::overload(
                                 [&](migraphx::value::binary& bin) {
                                     bin.insert(
-                                        bin.end(), o.via.bin.ptr, o.via.bin.ptr + o.via.bin.size);
+                                        bin.end(), sa.via.bin.ptr, sa.via.bin.ptr + sa.via.bin.size);
                                 },
                                 [&](migraphx::value::array& arr) {
                                     std::for_each(sa.via.array.ptr,

--- a/src/msgpack.cpp
+++ b/src/msgpack.cpp
@@ -157,10 +157,8 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
                 break;
             }
         case msgpack::type::MAP:
-        case msgpack::type::BIN:
-            MIGRAPHX_THROW("Unexpected msgpack type");
-            case msgpack::type::EXT:
-                MIGRAPHX_THROW("msgpack EXT type not supported.");
+        case msgpack::type::BIN: MIGRAPHX_THROW("Unexpected msgpack type");
+        case msgpack::type::EXT: MIGRAPHX_THROW("msgpack EXT type not supported.");
             }
             return o;
         }

--- a/src/msgpack.cpp
+++ b/src/msgpack.cpp
@@ -164,9 +164,9 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
             case msgpack::type::EXT: {
                 MIGRAPHX_THROW("msgpack EXT type not supported.");
             }
-            return o;
+                return o;
         }
-    }
+        }
     };
 
     template <>

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -624,7 +624,7 @@ std::string get_migraphx_version()
 program file version is for the data structure or format of the MXR file. Version should be bumped
 if any changes occur to the format of the MXR file.
 */
-const int program_file_version = 6;
+const int program_file_version = 7;
 
 value program::to_value() const
 {

--- a/test/msgpack.cpp
+++ b/test/msgpack.cpp
@@ -48,9 +48,9 @@ auto msgpack_type(migraphx::rank<1>, const T& src) -> decltype(src.empty(), std:
 template <class T>
 auto msgpack_type(migraphx::rank<2>, const std::vector<T>& src)
 {
-    using type = decltype(msgpack_type(migraphx::rank<2>{}, src.front()));
+    using type        = decltype(msgpack_type(migraphx::rank<2>{}, src.front()));
     using result_type = std::vector<std::vector<type>>;
-    if (src.empty())
+    if(src.empty())
         return result_type{};
     std::vector<type> result;
     std::transform(src.begin(), src.end(), std::back_inserter(result), [](const auto& x) {

--- a/test/msgpack.cpp
+++ b/test/msgpack.cpp
@@ -27,7 +27,7 @@
 #include <map>
 #include "test.hpp"
 
-template<class T>
+template <class T>
 auto msgpack_type(migraphx::rank<0>, T src)
 {
     if constexpr(std::is_class<T>{})
@@ -36,7 +36,7 @@ auto msgpack_type(migraphx::rank<0>, T src)
         return src;
 }
 
-template<class T>
+template <class T>
 auto msgpack_type(migraphx::rank<1>, const T& src) -> decltype(src.empty(), std::vector<T>{})
 {
     if(src.empty())

--- a/test/msgpack.cpp
+++ b/test/msgpack.cpp
@@ -27,11 +27,28 @@
 #include <map>
 #include "test.hpp"
 
+template<class T>
+auto msgpack_type(migraphx::rank<0>, T src)
+{
+    if constexpr(std::is_class<T>{})
+        return std::vector<T>{src};
+    else
+        return src;
+}
+
+template<class T>
+auto msgpack_type(migraphx::rank<1>, const T& src) -> decltype(src.empty(), std::vector<T>{})
+{
+    if(src.empty())
+        return {};
+    return {src};
+}
+
 template <class T>
 std::vector<char> msgpack_buffer(const T& src)
 {
     std::stringstream buffer;
-    msgpack::pack(buffer, src);
+    msgpack::pack(buffer, msgpack_type(migraphx::rank<2>{}, src));
     buffer.seekg(0);
     std::string str = buffer.str();
     return std::vector<char>(str.data(), str.data() + str.size()); // NOLINT


### PR DESCRIPTION
This will do chunking for arrays, maps, and binary data. This will change our binary format in way that is not backwards-compatible, so it will throw an error about incorrect chunking before it gets to the version check. Perhaps we could improve this error message.