### PR TITLE
Add 'skip bot checks' label to Onnxruntime Weekly Sync PR workflow

### DIFF
--- a/.github/workflows/sync-onnxrt-main.yaml
+++ b/.github/workflows/sync-onnxrt-main.yaml
@@ -47,6 +47,7 @@ jobs:
             onnxruntime
             dependancies
             automated 
+            skip bot checks
           assignees: TedThemistokleous
           reviewers: TedThemistokleous causten
           draft: false


### PR DESCRIPTION
This PR modifies the workflow to adds 'skip bot checks' label to Onnxruntime Weekly Sync PR to skip running checks.