### PR TITLE
Skip "find_split_transpose" if split has more than one outputs

### DIFF
--- a/src/simplify_algebra.cpp
+++ b/src/simplify_algebra.cpp
@@ -1446,10 +1446,13 @@ struct find_split_transpose
         {
             return;
         }
+        if(std::any_of(split_outputs.begin(), split_outputs.end(), [](auto i) {
+               return i->outputs().size() != 1;
+           }))
+            return;
 
         std::vector<instruction_ref> vec_trans(split_outputs.size());
         std::transform(split_outputs.begin(), split_outputs.end(), vec_trans.begin(), [](auto i) {
-            assert(i->outputs().size() == 1);
             return i->outputs().front();
         });
 


### PR DESCRIPTION
The current matcher is doing an assert on the number of outputs but instead, it should skip it if the number of outputs is greater than 1. 

This matcher is doing 
```
input --> slice --> transpose 
    | 
     ---->slice --> transpose 
    | 
    ---->slice --> transpose 
```
to 
```
input --> transpose --> slice
                | 
                 ----> slice 
                | 
                ----> slice 

```
This is only useful if slice in original input graph has one output node (transpose in this case). If it has multiple outputs then doing transpose before the slice would change the layout for the slice's outputs (other than transpose) in original graph. 

Partially solves #2116 
