### PR TITLE
Use matcher name for the `TRACE_MATCHES_FOR` 

### DIFF
--- a/src/include/migraphx/matcher.hpp
+++ b/src/include/migraphx/matcher.hpp
@@ -381,13 +381,14 @@ void find_matches_for(source_location location, Mod& mod, instruction_ref ins, M
     const int trace         = value_of(MIGRAPHX_TRACE_MATCHES{});
     const bool validate     = enabled(MIGRAPHX_VALIDATE_MATCHES{});
     const auto trace_filter = string_value_of(MIGRAPHX_TRACE_MATCHES_FOR{});
-    bool match = false;
+    bool match              = false;
     each_args(
         [&](auto&& m) {
             const auto& matcher_name = get_type_name(m);
-            const bool trace_for = not trace_filter.empty() and
-                           (contains(std::string{location.file_name()}, trace_filter) or
-                            contains(std::string{location.function_name()}, trace_filter) or contains(matcher_name, trace_filter));
+            const bool trace_for     = not trace_filter.empty() and
+                                   (contains(std::string{location.file_name()}, trace_filter) or
+                                    contains(std::string{location.function_name()}, trace_filter) or
+                                    contains(matcher_name, trace_filter));
             if(match)
                 return;
             if(trace > 1 and trace_for)

--- a/src/include/migraphx/matcher.hpp
+++ b/src/include/migraphx/matcher.hpp
@@ -381,22 +381,23 @@ void find_matches_for(source_location location, Mod& mod, instruction_ref ins, M
     const int trace         = value_of(MIGRAPHX_TRACE_MATCHES{});
     const bool validate     = enabled(MIGRAPHX_VALIDATE_MATCHES{});
     const auto trace_filter = string_value_of(MIGRAPHX_TRACE_MATCHES_FOR{});
-    const bool trace_for    = not trace_filter.empty() and
-                           (contains(std::string{location.file_name()}, trace_filter) or
-                            contains(std::string{location.function_name()}, trace_filter));
     bool match = false;
     each_args(
         [&](auto&& m) {
+            const auto& matcher_name = get_type_name(m);
+            const bool trace_for = not trace_filter.empty() and
+                           (contains(std::string{location.file_name()}, trace_filter) or
+                            contains(std::string{location.function_name()}, trace_filter) or contains(matcher_name, trace_filter));
             if(match)
                 return;
-            if(trace > 1 or trace_for)
-                std::cout << "Match: " << get_type_name(m) << std::endl;
+            if(trace > 1 and trace_for)
+                std::cout << "Match: " << matcher_name << std::endl;
             auto r = match_instruction(get_module(mod), ins, m.matcher());
             if(r.result == get_module(mod).end())
                 return;
             if(trace > 0 or trace_for)
             {
-                std::cout << "Matched by " << get_type_name(m) << std::endl;
+                std::cout << "Matched by " << matcher_name << std::endl;
                 get_module(mod).debug_print(ins);
             }
             // If its already invalid dont validate it again
@@ -407,7 +408,7 @@ void find_matches_for(source_location location, Mod& mod, instruction_ref ins, M
                 auto invalid = get_module(mod).validate();
                 if(invalid != get_module(mod).end())
                 {
-                    std::cout << "Invalid program from match: " << get_type_name(m) << std::endl;
+                    std::cout << "Invalid program from match: " << matcher_name << std::endl;
                     std::cout << "Invalid instructions: " << std::endl;
                     get_module(mod).debug_print(invalid->inputs());
                     get_module(mod).debug_print(invalid);


### PR DESCRIPTION
`location.function_name()` was returning `apply()` for all the matchers and wasn't really helpful, since `find_matches()` was called from `apply()` for all the passes. 

It would be better to say `MIGRAPHX_TRACE_MATCHES_FOR="find_split_transpose"` and it should only print matches for that matcher. 

