### PR TITLE
Fixed printing to stdout when `MIGRAPHX_TRACE_MLIR` is enabled

### DIFF
--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -647,8 +647,8 @@ struct mlir_program
     void set_gpu_properties(const context& migraphx_ctx)
     {
         const auto& device = migraphx_ctx.get_current_device();
-        target_arch  = device.get_device_name();
-        num_cu       = device.get_cu_count();
+        target_arch        = device.get_device_name();
+        num_cu             = device.get_cu_count();
     }
 
     std::pair<std::size_t, std::size_t> get_launch_params() const
@@ -869,15 +869,22 @@ code_object_op compile_mlir(const context& migraphx_ctx,
     adjust_param_shapes(m, to_shapes(inputs));
     const bool trace = enabled(MIGRAPHX_TRACE_MLIR{});
 
+    static std::mutex mutex;
     if(trace)
+    {
+        const std::lock_guard<std::mutex> lock(mutex);
         std::cout << m << std::endl;
+    }
 
     mlir_program mp;
     mp.set_gpu_properties(migraphx_ctx);
     mp.parse(m);
     auto mod_op = mlirModuleGetOperation(mp.mmodule.get());
     if(trace)
+    {
+        const std::lock_guard<std::mutex> lock(mutex);
         std::cout << mlir_print(&mlirOperationPrint, mod_op) << std::endl;
+    }
     auto co            = mp.compile(solution);
     co.expected_inputs = to_shapes(inputs);
     co.output          = m.get_output_shapes().front();


### PR DESCRIPTION
While working with migraphx + rocmlir, I noticed some `gibberish` in stdout which is set to `on`. For example,

```bash
$ head -n 20 before.out
Compiling ...
Reading: /MIGraphXDeps/resnet50-v1-7.onnx
mlir_main:pointwise4:x1.0 = @param:x1.0 -> float_type, {1, 64, 1, 1}, {64, 1, 1, 1}, target_id=0
mlir_main:pointwise4:@1 = multibroadcast[out_lens={1, mlir_main:pointwise2:x1.0mlir_4:y1 = mlir_main:pointwise6:x3.0 = @param = :@param64@param:, x1.056 -> , float_type56:x3.0 -> float_type, {},out_dyn_dims={}](mlir_main:pointwise4:x1.0) -> float_type, {1, 64, 56, 56}, {, 64, 1, 0, 0}, target_id=0
mlir_main:pointwise4:y1 = @param:y1 -> float_type, {64, 64, 3, 3}, {576, 9, 3, 1}, target_id=0
y1mlir_main:pointwise0:x1.0mlir_main:pointwise4:y0{ =  -> float_type, {@param:y0 -> float_type, {1, 64, 56, 56}, {1, 256, 1, 1}, {200704, 3136, 56, 1256, 1, 1, 1}}1, 64, 1, 1, target_id=}, , target_id={00
64, 1, 1, 1mlir_main:pointwise4:@4 = 256, 64, 1, 1convolution
}, mlir_main:pointwise6:x1.0 = @param:x1.0 -> float_type, {1, 256, 1, 1}, {256, 1, 1, 1}, target_id=0
mlir_main:pointwise10:x1.0 = @param:x1.0 -> mlir_main:pointwise6:@2 = float_typemultibroadcast{[out_lens=, {{1, 256, 56, 56},out_dyn_dims={}64, 1, 1, 1]} = (mlir_main:pointwise6:x3.0) -> float_type, {@param:1, 256, 56, 56}, {x1.0256, 1, 0, 0[, target_id=}0mlir_main:pointwise26:x1.0padding = 1, 64, 1, 1@param, target_id=
}, {mlir_4:y0 = @param:y0 -> float_type, {01, 64, 56, 56
mlir_main:pointwise6:x2 = @param:x2 -> float_type, {64, 1, 1, 11, 256, 56, 56}, {802816, 3136, 56, 1}, target_id=0
 -> float_typemlir_main:pointwise6:@4 = multibroadcast[out_lens={1, 256, 56, }, , {{56},out_dyn_dims={}]}(mlir_main:pointwise6:x1.0200704, 3136, 56, 11, 64, 1, 1}}, =) -> float_typemlir_main:pointwise32:x1.0, target_id=, target_id={1, 1, 1,  = @param:x1.0 -> {0
64, 1, 1, 1}, target_id=0
mlir_main:pointwise0:@1 = multibroadcast[out_lens={1, 64, 112, 112},out_dyn_dims={}](mlir_main:pointwise0:x1.0) -> float_type, {1, 64, 112, 112}, {64, 1, 0, 0}, target_id=0
mlir_main:pointwise0:y1 = @param:y1 -> float_type, {64, 3, 7, 7}, {147, 49, 7, 1}, target_id=0
mlir_main:pointwise0:y0 = @param:y0 -> float_type, {1, 3, 224, 224}, {150528, 50176, 224, 1}, target_id=0
mlir_main:pointwise0:@4 = convolution[padding={3, 3, 3, 3},stride={2, 2},dilation={1, 1},group=1,padding_mode=0](mlir_main:pointwise0:y0,mlir_main:pointwise0:y1) -> float_type, {1, 64, 112, 112}, {802816, 12544, 112, 1}, target_id=0
mlir_main:pointwise0:@5 = add(mlir_main:pointwise0:@4,mlir_main:pointwise0:@1) -> float_type, {1, 64, 112, 112}, {802816, 12544, 112, 1}, target_id=0
mlir_main:pointwise0:@6 = relu(mlir_main:pointwise0:@5) -> float_type, {1, 64, 112, 112}, {802816, 12544, 112, 1}, target_id=0
mlir_main:pointwise0:@7 = @return(mlir_main:pointwise0:@6), target_id=0
```

The problem is solved by surrounding all `std::cout` with lock guards. Here is the result

```bash
$ head -n 20 after.out
Compiling ...
Reading: /MIGraphXDeps/resnet50-v1-7.onnx
mlir_main:pointwise6:x3.0 = @param:x3.0 -> float_type, {1, 256, 1, 1}, {256, 1, 1, 1}, target_id=0
mlir_main:pointwise6:x1.0 = @param:x1.0 -> float_type, {1, 256, 1, 1}, {256, 1, 1, 1}, target_id=0
mlir_main:pointwise6:@2 = multibroadcast[out_lens={1, 256, 56, 56},out_dyn_dims={}](mlir_main:pointwise6:x3.0) -> float_type, {1, 256, 56, 56}, {256, 1, 0, 0}, target_id=0
mlir_main:pointwise6:x2 = @param:x2 -> float_type, {1, 256, 56, 56}, {802816, 3136, 56, 1}, target_id=0
mlir_main:pointwise6:@4 = multibroadcast[out_lens={1, 256, 56, 56},out_dyn_dims={}](mlir_main:pointwise6:x1.0) -> float_type, {1, 256, 56, 56}, {256, 1, 0, 0}, target_id=0
mlir_main:pointwise6:y1 = @param:y1 -> float_type, {256, 64, 1, 1}, {64, 1, 1, 1}, target_id=0
mlir_main:pointwise6:y0 = @param:y0 -> float_type, {1, 64, 56, 56}, {200704, 3136, 56, 1}, target_id=0
mlir_main:pointwise6:@7 = convolution[padding={0, 0, 0, 0},stride={1, 1},dilation={1, 1},group=1,padding_mode=0](mlir_main:pointwise6:y0,mlir_main:pointwise6:y1) -> float_type, {1, 256, 56, 56}, {802816, 3136, 56, 1}, target_id=0
mlir_main:pointwise6:@8 = add(mlir_main:pointwise6:@7,mlir_main:pointwise6:@4) -> float_type, {1, 256, 56, 56}, {802816, 3136, 56, 1}, target_id=0
mlir_main:pointwise6:@9 = add(mlir_main:pointwise6:@8,mlir_main:pointwise6:x2) -> float_type, {1, 256, 56, 56}, {802816, 3136, 56, 1}, target_id=0
mlir_main:pointwise6:@10 = add(mlir_main:pointwise6:@9,mlir_main:pointwise6:@2) -> float_type, {1, 256, 56, 56}, {802816, 3136, 56, 1}, target_id=0
mlir_main:pointwise6:@11 = relu(mlir_main:pointwise6:@10) -> float_type, {1, 256, 56, 56}, {802816, 3136, 56, 1}, target_id=0
mlir_main:pointwise6:@12 = @return(mlir_main:pointwise6:@11), target_id=0

mlir_main:pointwise17:x1.0 = @param:x1.0 -> float_type, {1, 64, 1, 1}, {64, 1, 1, 1}, target_id=0
mlir_main:pointwise17:@1 = multibroadcast[out_lens={1, 64, 56, 56},out_dyn_dims={}](mlir_main:pointwise17:x1.0) -> float_type, {1, 64, 56, 56}, {64, 1, 0, 0}, target_id=0
mlir_main:pointwise17:y1 = @param:y1 -> float_type, {64, 256, 1, 1}, {256, 1, 1, 1}, target_id=0
mlir_main:pointwise17:y0 = @param:y0 -> float_type, {1, 256, 56, 56}, {802816, 3136, 56, 1}, target_id=0
``` 

Closes ROCmSoftwarePlatform/rocMLIR#1216