### PR TITLE
rename 'memoryType' to 'type'

### DIFF
--- a/src/targets/gpu/hip.cpp
+++ b/src/targets/gpu/hip.cpp
@@ -55,7 +55,7 @@ bool is_device_ptr(const void* ptr)
     auto status = hipPointerGetAttributes(&attr, ptr);
     if(status != hipSuccess)
         return false;
-    return attr.memoryType == hipMemoryTypeDevice;
+    return attr.type == hipMemoryTypeDevice;
 }
 
 std::size_t get_available_gpu_memory()


### PR DESCRIPTION
`hipPointerAttribute_t` has a renamed the enum `memoryType` to  `type` starting from ROCm 5.5. There is still backwards compatibility in current releases, but this is to use the new enum name.