### PR TITLE
Fixed `split_string` from stringutils

### DIFF
--- a/src/include/migraphx/stringutils.hpp
+++ b/src/include/migraphx/stringutils.hpp
@@ -86,7 +86,7 @@ inline std::string join_strings(Strings strings, const std::string& delim)
 inline std::vector<std::string> split_string(const std::string& s, char delim)
 {
     std::vector<std::string> elems;
-    std::stringstream ss(s + ' ');
+    std::stringstream ss(s + delim);
     std::string item;
     while(std::getline(ss, item, delim))
     {

--- a/test/stringutils.cpp
+++ b/test/stringutils.cpp
@@ -99,4 +99,29 @@ TEST_CASE(interpolate_string_custom3)
     EXPECT(s == "****b****");
 }
 
+TEST_CASE(slit_string_simple1)
+{
+    std::string input = "one,two,three";
+    auto resuts       = migraphx::split_string(input, ',');
+    EXPECT(resuts.size() == 3);
+    EXPECT(resuts.front() == "one");
+    EXPECT(resuts.back() == "three");
+}
+
+TEST_CASE(slit_string_simple2)
+{
+    std::string input = "one";
+    auto resuts       = migraphx::split_string(input, ',');
+    EXPECT(resuts.size() == 1);
+    EXPECT(resuts.front() == "one");
+}
+
+TEST_CASE(slit_string_simple3)
+{
+    std::string input = "one two three";
+    auto resuts       = migraphx::split_string(input, ',');
+    EXPECT(resuts.size() == 1);
+    EXPECT(resuts.front() == "one two three");
+}
+
 int main(int argc, const char* argv[]) { test::run(argc, argv); }


### PR DESCRIPTION
Replaced the whitespace trailing delimiter with the user-specified one 