### PR TITLE
Preserve layout of fused kernel for `layernorm+pointwise`

### DIFF
--- a/src/targets/gpu/prefuse_ops.cpp
+++ b/src/targets/gpu/prefuse_ops.cpp
@@ -62,7 +62,6 @@ struct layernorm_base
         if(inputs.front().elements() == 1 and
            all_of(inputs, [](const auto& ss) { return ss.scalar(); }))
             return inputs.front();
-
         auto l_s = shape::from_permutation(
             t, s.lens(), find_permutation(std::vector<shape>(inputs.begin(), inputs.begin() + N)));
         // just prelayernorm or preadd_layernorm
@@ -70,7 +69,7 @@ struct layernorm_base
             return l_s;
         // else, layernorm + pointwise fusion, preserve layout of fused op
         std::vector<shape> lp_s(inputs.begin() + N, inputs.end());
-        lp_s.insert(lp_s.begin(), lp_s);
+        lp_s.insert(lp_s.begin(), l_s);
         return shape::from_permutation(t, s.lens(), find_permutation(lp_s));
     }
 };

--- a/src/targets/gpu/prefuse_ops.cpp
+++ b/src/targets/gpu/prefuse_ops.cpp
@@ -63,15 +63,15 @@ struct layernorm_base
            all_of(inputs, [](const auto& ss) { return ss.scalar(); }))
             return inputs.front();
 
-        auto lp_s = shape::from_permutation(
+        auto l_s = shape::from_permutation(
             t, s.lens(), find_permutation(std::vector<shape>(inputs.begin(), inputs.begin() + N)));
-        // just prelayernorm, preadd_layernorm or prelayernorm+pointwise fused kernel
-        if(nargs <= 2)
-            return lp_s;
-        // else, preadd_layernorm + pointwise fusion, preserve layout of fused op
-        std::vector<shape> alp_s(inputs.begin() + N, inputs.end());
-        alp_s.insert(alp_s.begin(), lp_s);
-        return shape::from_permutation(t, s.lens(), find_permutation(alp_s));
+        // just prelayernorm or preadd_layernorm
+        if(nargs <= N)
+            return l_s;
+        // else, layernorm + pointwise fusion, preserve layout of fused op
+        std::vector<shape> lp_s(inputs.begin() + N, inputs.end());
+        lp_s.insert(lp_s.begin(), lp_s);
+        return shape::from_permutation(t, s.lens(), find_permutation(lp_s));
     }
 };
 

--- a/test/verify/test_layernorm.cpp
+++ b/test/verify/test_layernorm.cpp
@@ -58,7 +58,7 @@ migraphx::instruction_ref add_layernorm(migraphx::module& m,
     auto div = m.add_instruction(migraphx::make_op("div"), sub, sqrt_mbcast);
     auto scale_mbcast =
         m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", dims}}), scale);
-    auto mul = m.add_instruction(migraphx::make_op("mul"), scale_mbcast, div);
+    auto mul = m.add_instruction(migraphx::make_op("mul"), div, scale_mbcast);
 
     auto bias_mbcast =
         m.add_instruction(migraphx::make_op("multibroadcast", {{"out_lens", dims}}), bias);
@@ -171,7 +171,7 @@ struct test_add_layernorm_add_gemm_nonstd : verify_program<test_add_layernorm_ad
         migraphx::program p;
         auto* mm = p.get_main_module();
         auto s =
-            migraphx::shape::from_permutation(migraphx::shape::float_type, {8, 1, 16}, {2, 0, 1});
+            migraphx::shape::from_permutation(migraphx::shape::float_type, {8, 1, 16}, {1, 2, 0});
         auto x = mm->add_parameter("x", s);
         auto y = mm->add_parameter("y", s);
         auto z = mm->add_parameter("z", migraphx::shape{migraphx::shape::float_type, {8, 16, 64}});


### PR DESCRIPTION
Fixes https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/issues/2137

