### PR TITLE
[mlir] Apply is_mlir_conv predicate in standalone MLIr offloading

### DIFF
--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -365,7 +365,7 @@ bool is_enabled(std::string_view op_name, context* ctx)
         {
             return true;
         }
-        else if(op_name == "convolution" || op_name == "quant_convolution")
+        else if(op_name == "convolution" or op_name == "quant_convolution")
         {
             if(ctx == nullptr)
             {

--- a/src/targets/gpu/fuse_mlir.cpp
+++ b/src/targets/gpu/fuse_mlir.cpp
@@ -327,12 +327,12 @@ struct find_mlir_standalone_op
 
 struct find_mlir_standalone_convolution_op : find_mlir_standalone_op
 {
-    auto matcher() const { return match::name("convolution"); }
+    auto matcher() const { return is_mlir_conv; }
 };
 
 struct find_mlir_standalone_dot_op : find_mlir_standalone_op
 {
-    auto matcher() const { return match::name("dot"); }
+    auto matcher() const { return match::any_of(match::name("dot"), match::name("quant_dot")); }
 };
 
 /**
@@ -365,7 +365,7 @@ bool is_enabled(std::string_view op_name, context* ctx)
         {
             return true;
         }
-        else if(op_name == "convolution")
+        else if(op_name == "convolution" || op_name == "quant_convolution")
         {
             if(ctx == nullptr)
             {


### PR DESCRIPTION
Currently, the is_mlir_conv predicate wasn't being used when offloading standalone convolutions to MLIR on Navi3x, which caused failures relating to being unable to construct the MLIR program when a 3D convlolution was passed in.

Fixes
https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1153

This commit amends the standalone lowering to use said predicate, as well as to include quant_convolution and quant_dot into the set of operations that get a standalone lowering.