### PR TITLE
Fixed MIGraphX+rocMLIR integration regarding fast tuning

### DIFF
--- a/src/targets/gpu/mlir.cpp
+++ b/src/targets/gpu/mlir.cpp
@@ -702,7 +702,8 @@ struct mlir_program
             if(perf_key_bytes > perf_key.size())
                 MIGRAPHX_THROW("Tuning perf key was " + std::to_string(perf_key_bytes) +
                                " bytes and thus too long");
-            tc.solutions.emplace_back(perf_key.begin(), perf_key.begin() + perf_key_bytes);
+            tc.solutions.emplace_back(
+                std::string(perf_key.begin(), perf_key.begin() + perf_key_bytes));
         }
         std::array<char, ROCMLIR_TUNING_KEY_BUFSZ> tuning_key;
         size_t tuning_key_bytes =


### PR DESCRIPTION
This change results in the following on Navi31 for resnet50:

## FP32

```bash
$ MIGRAPHX_ENABLE_MLIR=1 ./bin/migraphx-driver  perf   --onnx /MIGraphXDeps/resnet50-v1-7.onnx

Batch size: 1
Rate: 376.146/sec
Total time: 2.65854ms
Total instructions time: 3.93917ms
Overhead time: 0.0387022ms, -1.28063ms
Overhead: 1%, -48%
```

```bash
$ MIGRAPHX_ENABLE_MLIR=0 ./bin/migraphx-driver  perf   --onnx /MIGraphXDeps/resnet50-v1-7.onnx
Batch size: 1
Rate: 331.604/sec
Total time: 3.01565ms
Total instructions time: 5.6571ms
Overhead time: 0.0618266ms, -2.64145ms
Overhead: 2%, -88%
```


## FP16

```bash
$ MIGRAPHX_ENABLE_MLIR=1 ./bin/migraphx-driver  perf  --fp16  --onnx /MIGraphXDeps/resnet50-v1-7.onnx

Batch size: 1
Rate: 991.816/sec
Total time: 1.00825ms
Total instructions time: 2.14301ms
Overhead time: 0.040039ms, -1.13476ms
Overhead: 4%, -113%
```

```bash
$ MIGRAPHX_ENABLE_MLIR=0 ./bin/migraphx-driver  perf  --fp16  --onnx /MIGraphXDeps/resnet50-v1-7.onnx

Batch size: 1
Rate: 634.355/sec
Total time: 1.5764ms
Total instructions time: 4.17106ms
Overhead time: 0.0631878ms, -2.59465ms
Overhead: 4%, -165%
```

## INT8

```bash
$ MIGRAPHX_ENABLE_MLIR=1 ./bin/migraphx-driver  perf  --int8  --onnx /MIGraphXDeps/resnet50-v1-7.onnx

Batch size: 1
Rate: 916.753/sec
Total time: 1.09081ms
Total instructions time: 2.62071ms
Overhead time: 0.0594211ms, -1.52991ms
Overhead: 5%, -140%
```

```bash
$ MIGRAPHX_ENABLE_MLIR=0 ./bin/migraphx-driver  perf  --int8  --onnx /MIGraphXDeps/resnet50-v1-7.onnx

Batch size: 1
Rate: 178.933/sec
Total time: 5.58869ms
Total instructions time: 9.6085ms
Overhead time: 0.0846503ms, -4.01981ms
Overhead: 2%, -72%
```