### PR TITLE
Specify full path for libamdhip64.so

### DIFF
--- a/test/py/test_gpu_async.py
+++ b/test/py/test_gpu_async.py
@@ -26,6 +26,7 @@ import ctypes
 import os
 import glob
 
+
 def test_conv_relu():
     # Full path of the library is needed to fix an issue on sles
     # where the library is not loaded otherwise.

--- a/test/py/test_gpu_async.py
+++ b/test/py/test_gpu_async.py
@@ -24,14 +24,28 @@
 import migraphx
 import ctypes
 import os
+import glob
 
 def test_conv_relu():
+
     library = "libamdhip64.so"
 
-    # Full path of the library is specified to fix
-    # an issue on sles where the library is not loaded otherwise.
-    if os.path.exists("/opt/rocm/lib/libamdhip64.so"):
-        library = "/opt/rocm/lib/libamdhip64.so"
+    rocm_path_env_var = "rocm_path"
+
+    rocm_path_var = os.getenv(rocm_path_env_var, default="/opt/rocm")
+
+    library_file = os.path.join(rocm_path_var, "lib", library)
+
+    # Check if the library file exists at the specified path
+    if os.path.exists(library_file):
+        library = library_file
+    else:
+        # Pattern match path for rocm paths: /opt/rocm-*
+        rocm_path_pattern = "/opt/rocm-*/lib/libamdhip64.so"
+        matching_libraries = glob.glob(rocm_path_pattern)
+
+        if matching_libraries:
+            library = matching_libraries[0]
 
     hip = ctypes.cdll.LoadLibrary(library)
 

--- a/test/py/test_gpu_async.py
+++ b/test/py/test_gpu_async.py
@@ -1,7 +1,7 @@
 #####################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2015-2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2015-2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,10 +23,17 @@
 #####################################################################################
 import migraphx
 import ctypes
-
+import os
 
 def test_conv_relu():
-    hip = ctypes.cdll.LoadLibrary("libamdhip64.so")
+    library = "libamdhip64.so"
+
+    # Full path of the library is specified to fix
+    # an issue on sles where the library is not loaded otherwise.
+    if os.path.exists("/opt/rocm/lib/libamdhip64.so"):
+        library = "/opt/rocm/lib/libamdhip64.so"
+
+    hip = ctypes.cdll.LoadLibrary(library)
 
     p = migraphx.parse_onnx("conv_relu_maxpool_test.onnx")
     print(p)


### PR DESCRIPTION
test_py_3.6_gpu_async complains about a missing shared library libamdhip64.so
on sles, specifying the full path seems to fix the issue.
This PR makes the change to add the full path to the shared library provided
the shared library exists at that path.