### PR TITLE
Avoid using Template argument deduction for Vector 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -281,6 +281,7 @@ jobs:
           -DBUILD_DEV=On \
           -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/local/bin/ccache \
           -DCMAKE_C_COMPILER_LAUNCHER=/usr/local/bin/ccache \
+          -DCMAKE_CXX_FLAGS="-Werror" \
           -DGPU_TARGETS=gfx908 \
           ..
         make -j$(nproc) tests driver

--- a/src/onnx/parse_resize.cpp
+++ b/src/onnx/parse_resize.cpp
@@ -320,7 +320,8 @@ struct parse_resize : op_parser<parse_resize>
 
             // get the number of dimensions
             std::size_t n_dim = out_lens.size();
-            auto vvv_ind = std::vector(n_dim, std::vector(2, std::vector<size_t>(out_elements)));
+            std::vector<std::vector<std::size_t>> vv_ind(2, std::vector<std::size_t>(out_elements));
+            std::vector<std::vector<std::vector<std::size_t>>> vvv_ind(n_dim, vv_ind);
             std::vector<std::vector<float>> delta(n_dim, std::vector<float>(out_elements));
 
             shape_for_each(out_s, [&](const auto& out_idx_v, size_t out_idx) {


### PR DESCRIPTION
CTAD may not be supported by older C++ runtimes e.g. (gcc-7). 

Seeing this error with `-Werror` on SLES builds : 

```
../../../src/onnx/parse_resize.cpp:323:47: error: 'vector' may not intend to support class template argument deduction [-Werror,-Wctad-maybe-unsupported]
            auto vvv_ind = std::vector(n_dim, std::vector(2, std::vector<size_t>(out_elements)));
                                              ^
/usr/lib64/gcc/x86_64-suse-linux/7/../../../../include/c++/7/bits/stl_vector.h:216:11: note: add a deduction guide to suppress this warning
    class vector : protected _Vector_base<_Tp, _Alloc>
          ^
../../../src/onnx/parse_resize.cpp:323:28: error: 'vector' may not intend to support class template argument deduction [-Werror,-Wctad-maybe-unsupported]
            auto vvv_ind = std::vector(n_dim, std::vector(2, std::vector<size_t>(out_elements)));
                           ^
/usr/lib64/gcc/x86_64-suse-linux/7/../../../../include/c++/7/bits/stl_vector.h:216:11: note: add a deduction guide to suppress this warning
    class vector : protected _Vector_base<_Tp, _Alloc>
          ^

```