### PR TITLE
Set compile options from accuracy checker

### DIFF
--- a/tools/accuracy/accuracy_checker.py
+++ b/tools/accuracy/accuracy_checker.py
@@ -82,6 +82,27 @@ def parse_args():
                         default=False,
                         help='Turn on ort VERBOSE logging via session options')
 
+    parser.add_argument(
+        '--disable-offload-copy',
+        dest="offload_copy",
+        action='store_false',
+        default=True,
+        help=
+        'Disable offload copying (user must handle copy to and from device)')
+
+    parser.add_argument(
+        '--disable-fast-math',
+        dest="fast_math",
+        action='store_false',
+        default=True,
+        help='Disable fast math optimizations (etc: rewrite_gelu)')
+
+    parser.add_argument('--exhaustive_tune',
+                        dest="exhaustive_tune",
+                        action='store_true',
+                        default=False,
+                        help='Enable exhaustive tuning for solutions')
+
     args = parser.parse_args()
 
     return args
@@ -177,7 +198,12 @@ def main():
         print(model)
 
     if not args.ort_run:
-        model.compile(migraphx.get_target(args.target))
+        model.compile(
+            migraphx.get_target(args.target),
+            offload_copy=args.offload_copy,
+            fast_math=args.fast_math,
+            exhaustive_tune=args.exhaustive_tune,
+        )
 
     params = {}
     test_inputs = {}


### PR DESCRIPTION
Importantly allows you to set disable_fast_math from the accuracy checker.