### PR TITLE
Fix scatter operator for nonstandard shapes

### DIFF
--- a/src/include/migraphx/op/scatter.hpp
+++ b/src/include/migraphx/op/scatter.hpp
@@ -66,7 +66,7 @@ struct scatter : op_name<Derived>
 
     shape normalize_compute_shape(std::vector<shape> inputs) const
     {
-        check_shapes{inputs, *this}.has(3).standard();
+        check_shapes{inputs, *this}.has(3);
         // If non-packed, this converts to a packed output while preserving permutation of tensor
         return inputs.front().with_lens(inputs.front().lens());
     }


### PR DESCRIPTION
remove standard() shape check for scatter inputs. Fixes error seen for non standard inputs