### PR TITLE
Update unit as  inference/sec

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -936,7 +936,7 @@ void program::perf_report(std::ostream& os,
     os << std::endl;
 
     os << "Batch size: " << batch << std::endl;
-    os << "Rate: " << rate * batch << "/sec" << std::endl;
+    os << "Rate: " << rate * batch << "inference/sec" << std::endl;
     os << "Total time: " << total_time << "ms" << std::endl;
     os << "Total instructions time: " << total_instruction_time << "ms" << std::endl;
     os << "Overhead time: " << overhead_time << "ms"

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -936,7 +936,7 @@ void program::perf_report(std::ostream& os,
     os << std::endl;
 
     os << "Batch size: " << batch << std::endl;
-    os << "Rate: " << rate * batch << "inference/sec" << std::endl;
+    os << "Rate: " << rate * batch << "inferences/sec" << std::endl;
     os << "Total time: " << total_time << "ms" << std::endl;
     os << "Total instructions time: " << total_instruction_time << "ms" << std::endl;
     os << "Overhead time: " << overhead_time << "ms"


### PR DESCRIPTION
As a user, I am trying to enable the unit self-explanatory.  

Usually, we see unit format as  <some value>  <what the value for>/<time>. Example: X images/sec,  X frames/sec or etc where images or frames helping user to understand , what the value for.

Below Rate unit, until, I read doc or check with owner, I am not sure what it means.  Just for a layman, if we keep like below, they might not get it. Rate: X/sec

But, if we keep, X inference/sec, it will help clearly to know what this value for.  The Rate is  how many inferences of the given inputs can be processed per second so X inference/sec will help user for the same.

For advance user, it /sec might be ok but I am trying to cover all.