### PR TITLE
Revert "Run optimize_module for int8 quantization (#2300)"

### DIFF
--- a/src/quantization.cpp
+++ b/src/quantization.cpp
@@ -70,10 +70,6 @@ void quantize_int8(program& prog,
         MIGRAPHX_THROW("QUANTIZE_INT8: only support DOT and CONVOLUTION operation");
     }
 
-    // Run optimize_module() before converting to int8 to const eval and fold in FP32 to
-    // avoid loss of precision.
-    run_passes(prog, {optimize_module{}});
-
     std::shared_ptr<std::vector<std::pair<float, float>>> int8_quant_params =
         std::make_shared<std::vector<std::pair<float, float>>>();
     std::shared_ptr<std::vector<float>> max_abs_vals = std::make_shared<std::vector<float>>();
@@ -147,7 +143,10 @@ void quantize_int8(program& prog,
 
     run_passes(prog,
                {quantize_int8_pass{ins_names, *int8_quant_params},
-                optimize_module{},
+                eliminate_common_subexpression{},
+                dead_code_elimination{},
+                simplify_reshapes{},
+                dead_code_elimination{},
                 simplify_qdq{},
                 dead_code_elimination{}});
 }


### PR DESCRIPTION
This reverts commit 94fcfc02e3eaa7e28db188369c0d1eabb200e01b.

This was breaking Resnet50 for int8 quant and causing other issues before the quantization