### PR TITLE
use find_package() for SQLite3

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -261,9 +261,8 @@ find_package(nlohmann_json 3.8.0 REQUIRED)
 target_link_libraries(migraphx PRIVATE nlohmann_json::nlohmann_json)
 migraphx_generate_export_header(migraphx)
 
-find_package(PkgConfig)
-pkg_check_modules(SQLITE3 REQUIRED IMPORTED_TARGET sqlite3)
-target_link_libraries(migraphx PRIVATE PkgConfig::SQLITE3)
+find_package(SQLite3 REQUIRED)
+target_link_libraries(migraphx PRIVATE SQLite::SQLite3)
 
 find_package(msgpackc-cxx QUIET)
 if(NOT msgpackc-cxx_FOUND)


### PR DESCRIPTION
The PR changes from using `PkgConfig` to the `find_package()` CMake command while searching for SQLite3.