### PR TITLE
Fix gpu::contiguous elimination bug

### DIFF
--- a/src/eliminate_contiguous.cpp
+++ b/src/eliminate_contiguous.cpp
@@ -41,6 +41,14 @@ static bool try_compute_shape(instruction_ref ins,
                               const std::vector<shape>& inputs,
                               const std::vector<module_ref>& mods)
 {
+    // compute_shape of gpu::contiguous always returns a standard shape
+    // this can propagate false `true` values for non standard shapes in recursive try_compute_shape
+    // calls
+    if(ins->name() == "gpu::contiguous" &&
+       std::any_of(inputs.begin(), inputs.end(), [&](auto& shape) { return not shape.standard(); }))
+    {
+        return false;
+    }
     try
     {
         shape new_shape = ins->get_operator().compute_shape(inputs, mods);


### PR DESCRIPTION
When testing `gpu::contiguous` instruction replacability recursive calls to `try_compute_shape` can pick up `gpu::contiguous` instructions as an instruction [output](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/src/eliminate_contiguous.cpp#L75-L85).
These instructions always passes the `try_compute_shape` check [here](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/src/eliminate_contiguous.cpp#L55-L58) because compute_shape of `gpu::contiguous` always returns a standard shape [here](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/src/targets/gpu/include/migraphx/gpu/contiguous.hpp#L44-L46), thus propagating false `true` values upwards.
For these corner cases we must demand the standard shape of the inputs as well, to avoid ellimination of needed `gpu::contiguous` instructions.

This fixes: https://github.com/migraphx-benchmark/AMDMIGraphX/issues/141#issuecomment-1768010476

cc @TedThemistokleous @causten 