### PR TITLE
Fix allocate 0 arg version

### DIFF
--- a/src/include/migraphx/op/allocate.hpp
+++ b/src/include/migraphx/op/allocate.hpp
@@ -37,6 +37,8 @@ namespace op {
  * Static allocate:
  * No inputs: `allocate()`
  * `this.s` attribute set to the static output shape of the buffer.
+ * `this.s` attribute can be set to a dynamic output shape; however this will allocate the maximum
+ * buffer size for that case
  *
  * Dynamic allocate:
  * One input: `allocate(output_dims)`
@@ -74,10 +76,6 @@ struct allocate
             }
             else
             {
-                if(s->dynamic())
-                {
-                    MIGRAPHX_THROW("ALLOCATE: dynamic shape attribute and no input");
-                }
                 migraphx::check_shapes{inputs, *this, false}.has(0);
             }
             return s.value();

--- a/test/op_shape_test.cpp
+++ b/test/op_shape_test.cpp
@@ -116,11 +116,12 @@ TEST_CASE(allocate_dyn_with_shape_attr)
                  input);
 }
 
-TEST_CASE(allocate_dyn_no_input_error)
+TEST_CASE(allocate_dyn_no_input)
 {
     migraphx::shape shape_attr{migraphx::shape::float_type,
                                {{1, 4}, {3, 3}, {4, 8, {4, 6}}, {4, 8}, {4, 6}}};
-    throws_shape(migraphx::make_op("allocate", {{"shape", migraphx::to_value(shape_attr)}}));
+    expect_shape(shape_attr,
+                 migraphx::make_op("allocate", {{"shape", migraphx::to_value(shape_attr)}}));
 }
 
 TEST_CASE(allocate_shape_and_buf_type_error)


### PR DESCRIPTION
Adds back the option for 0 arg `allocate` with a dynamic shape attribute.
I forgot that we used this version specifically to allocate the maximum buffer size.
Will need to create a compiler pass to optimize to a static shape in the future when actually running dynamic shapes on GPU.