### PR TITLE
add missing <array> header file

### DIFF
--- a/test/include/test.hpp
+++ b/test/include/test.hpp
@@ -24,6 +24,7 @@
 
 #include <atomic>
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>


### PR DESCRIPTION
The recently added tests for fp8 support use `std::array`. The `<array>` header file must be explicitly added on Windows. Otherwise, the compilation will fail, complaining on, for example, `error: constexpr variable cannot have non-literal type 'const std::array<float, 256>'`.
